### PR TITLE
METRON-196 Fix support of ansible 2.1 in metron_elasticsearch_templates - Fix  #153

### DIFF
--- a/metron-deployment/roles/metron_elasticsearch_templates/tasks/load_templates.yml
+++ b/metron-deployment/roles/metron_elasticsearch_templates/tasks/load_templates.yml
@@ -40,6 +40,7 @@
   uri:
     url: "http://{{ inventory_hostname }}:{{ elasticsearch_web_port }}/_template/{{ item | basename | replace('.template','') }}"
     method: PUT
+    body_format: "json"
     body: "{{ lookup('file',item) }}"
     status_code: 200
   with_fileglob: ./files/es_templates/*.template
@@ -48,6 +49,7 @@
   uri:
     url: "http://{{ inventory_hostname }}:{{ elasticsearch_web_port }}/_template/{{ item | basename | replace('.template','') }}"
     method: HEAD
+    body_format: "json"
     body: "{{ lookup('file',item) }}"
     status_code: 200
   with_fileglob: ./files/es_templates/*.template


### PR DESCRIPTION
This pull request add the option `body_format: "json"` to support the upload of json.

Fix the following error during the installation with ansible 2.1.1.0:

```
TASK [metron_elasticsearch_templates : Wait for Index to Become Available] *****
ok: [node1]

TASK [metron_elasticsearch_templates : Add Elasticsearch templates for topologies] ***
failed: [node1] (item=/home/yoyo/incubator-metron/metron-deployment/roles/metron_elasticsearch_templates/files/es_templates/yaf_index.template) => {"content": "", "failed": true, "item": "/home/yoyo/incubator-metron/metron-deployment/roles/metron_elasticsearch_templates/files/es_templates/yaf_index.template", "msg": "Status code was not [200]: An unknown error occurred: sendall() argument 1 must be string or buffer, not dict", "redirected": false, "status": -1, "url": "http://node1:9200/_template/yaf_index"}
failed: [node1] (item=/home/yoyo/incubator-metron/metron-deployment/roles/metron_elasticsearch_templates/files/es_templates/snort_index.template) => {"content": "", "failed": true, "item": "/home/yoyo/incubator-metron/metron-deployment/roles/metron_elasticsearch_templates/files/es_templates/snort_index.template", "msg": "Status code was not [200]: An unknown error occurred: sendall() argument 1 must be string or buffer, not dict", "redirected": false, "status": -1, "url": "http://node1:9200/_template/snort_index"}
failed: [node1] (item=/home/yoyo/incubator-metron/metron-deployment/roles/metron_elasticsearch_templates/files/es_templates/bro_index.template) => {"content": "", "failed": true, "item": "/home/yoyo/incubator-metron/metron-deployment/roles/metron_elasticsearch_templates/files/es_templates/bro_index.template", "msg": "Status code was not [200]: An unknown error occurred: sendall() argument 1 must be string or buffer, not dict", "redirected": false, "status": -1, "url": "http://node1:9200/_template/bro_index"}

NO MORE HOSTS LEFT *************************************************************
    to retry, use: --limit @playbooks/metron_full_install.retry

PLAY RECAP *********************************************************************
node1                      : ok=7    changed=3    unreachable=0    failed=1   

```
- Fix closed issue #153.
- Not tested with vagrant! (should work..)
- Ansible documentation of `body_format`: http://docs.ansible.com/ansible/uri_module.html and ansible/ansible-modules-core#1011.
