### PR TITLE
METRON-937 Pycapa Consume Messages from Begin, End, or Stored Offsets

### DIFF
--- a/metron-sensors/pycapa/README.md
+++ b/metron-sensors/pycapa/README.md
@@ -72,19 +72,22 @@ Pycapa has two primary runtime modes.
 ### Parameters
 
 ```
-$ pycapa -h
+$ pycapa --help
 usage: pycapa [-h] [-p] [-c] [-k KAFKA_BROKERS] [-t KAFKA_TOPIC]
-              [-i NETWORK_IFACE] [-m MAX_PACKETS] [-pp PRETTY_PRINT]
-              [-ll LOG_LEVEL] [-X KAFKA_CONFIGS] [-s SNAPLEN]
+              [-o {begin,end,stored}] [-i NETWORK_IFACE] [-m MAX_PACKETS]
+              [-pp PRETTY_PRINT] [-ll LOG_LEVEL] [-X KAFKA_CONFIGS]
+              [-s SNAPLEN]
 
 optional arguments:
   -h, --help            show this help message and exit
   -p, --producer        sniff packets and send to kafka
   -c, --consumer        read packets from kafka
   -k KAFKA_BROKERS, --kafka-broker KAFKA_BROKERS
-                        kafka broker(s)
+                        kafka broker(s) as host:port
   -t KAFKA_TOPIC, --kafka-topic KAFKA_TOPIC
                         kafka topic
+  -o {begin,end,stored}, --kafka-offset {begin,end,stored}
+                        kafka offset to consume from; default=end
   -i NETWORK_IFACE, --interface NETWORK_IFACE
                         network interface to listen on
   -m MAX_PACKETS, --max-packets MAX_PACKETS
@@ -92,91 +95,81 @@ optional arguments:
   -pp PRETTY_PRINT, --pretty-print PRETTY_PRINT
                         pretty print every X packets
   -ll LOG_LEVEL, --log-level LOG_LEVEL
-                        set the log level
+                        set the log level; DEBUG, INFO, WARN
   -X KAFKA_CONFIGS      define a kafka client parameter; key=value
   -s SNAPLEN, --snaplen SNAPLEN
-                        snapshot length
+                        capture only the first X bytes of each packet;
+                        default=65535
 ```
 
 ### Examples
 
-**Example**: Capture 10 packets from the `eth0` network interface and forward those to a Kafka topic called `pcap` running on `localhost:9092`.
-  ```
-  $ pycapa --producer \
-      --interface eth0 \
-      --kafka-broker localhost:9092 \
-      --kafka-topic pcap \
-      --max-packets 10
-  INFO:root:Connecting to Kafka; {'bootstrap.servers': 'localhost:9092', 'group.id': 'AWBHMIAESAHJ'}
-  INFO:root:Starting packet capture
-  INFO:root:Waiting for '10' message(s) to flush
-  INFO:root:'10' packet(s) in, '10' packet(s) out
-  ```
+#### Example 1
 
-**Example**: Capture packets until SIGINT is received.  A SIGINT is the interrupt signal sent when entering CTRL-D in the console.
-  ```
-  $ pycapa --producer \
-      --interface eth0 \
-      --kafka-broker localhost:9092 \
-      --kafka-topic pcap
-  INFO:root:Connecting to Kafka; {'bootstrap.servers': 'localhost:9092', 'group.id': 'EULLGDOMZDCT'}
+Capture 10 packets from the `eth0` network interface and forward those to a Kafka topic called `pcap` running on `localhost:9092`.  The process will not terminate until all messages have been delivered to Kafka.
+
+```
+$ pycapa --producer \
+    --interface eth0 \
+    --kafka-broker localhost:9092 \
+    --kafka-topic pcap \
+    --max-packets 10
+INFO:root:Connecting to Kafka; {'bootstrap.servers': 'localhost:9092', 'group.id': 'AWBHMIAESAHJ'}
+INFO:root:Starting packet capture
+INFO:root:Waiting for '6' message(s) to flush
+INFO:root:'10' packet(s) in, '10' packet(s) out
+```
+
+#### Example 2
+
+Capture packets until SIGINT is received (the interrupt signal sent when entering CTRL-C in the console.)  In this example, nothing will be reported as packets are captured and delivered to Kafka.  Simply wait a few seconds, then type CTRL-C and the number of packets will be reported.
+
+```
+$ pycapa --producer \
+    --interface en0 \
+    --kafka-broker localhost:9092 \
+    --kafka-topic pcap
+INFO:root:Connecting to Kafka; {'bootstrap.servers': 'localhost:9092', 'group.id': 'EULLGDOMZDCT'}
+INFO:root:Starting packet capture
+^C
+INFO:root:Clean shutdown process started
+INFO:root:Waiting for '2' message(s) to flush
+INFO:root:'21' packet(s) in, '21' packet(s) out
+```
+
+#### Example 3
+
+While capturing packets, output diagnostic information every 5 packets.  Diagnostics will report when packets have been received from the network interface and when they have been successfully delivered to Kafka.
+
+```
+$ pycapa --producer \
+    --interface eth0 \
+    --kafka-broker localhost:9092 \
+    --kafka-topic pcap \
+    --pretty-print 5
+  INFO:root:Connecting to Kafka; {'bootstrap.servers': 'localhost:9092', 'group.id': 'UAWINMBDNQEH'}
   INFO:root:Starting packet capture
+  Packet received[5]
+  Packet delivered[5]: date=2017-05-08 14:48:54.474031 topic=pcap partition=0 offset=29086 len=42
+  Packet received[10]
+  Packet received[15]
+  Packet delivered[10]: date=2017-05-08 14:48:58.879710 topic=pcap partition=0 offset=0 len=187
+  Packet delivered[15]: date=2017-05-08 14:48:59.633127 topic=pcap partition=0 offset=0 len=43
+  Packet received[20]
+  Packet delivered[20]: date=2017-05-08 14:49:01.949628 topic=pcap partition=0 offset=29101 len=134
+  Packet received[25]
   ^C
   INFO:root:Clean shutdown process started
-  INFO:root:Waiting for '0' message(s) to flush
-  INFO:root:'7' packet(s) in, '7' packet(s) out
-  ```
+  Packet delivered[25]: date=2017-05-08 14:49:03.589940 topic=pcap partition=0 offset=0 len=142
+  INFO:root:Waiting for '1' message(s) to flush
+  INFO:root:'27' packet(s) in, '27' packet(s) out
 
-**Example**: While capturing packets, output diagnostic information every 10 packets.
-  ```
-  $ pycapa --producer \
-      --interface en0 \
-      --kafka-broker localhost:9092 \
-      --kafka-topic pcap \
-      --pretty-print 10
-  INFO:root:Connecting to Kafka; {'bootstrap.servers': 'localhost:9092', 'group.id': 'YMDSEEDIHVWD'}
-  INFO:root:Starting packet capture
-  10 packet(s) received
-  ac bc 32 bf 0d 43 b8 3e 59 8b 8a 8a 08 00 45 00
-  00 3c 00 00 40 00 40 06 b9 66 c0 a8 00 02 c0 a8
-  00 03 1f 7c d7 14 5f 8b 82 b4 a8 c5 f6 63 a0 12
-  38 90 59 cc 00 00 02 04 05 b4 04 02 08 0a 00 51
-  44 17 39 43 3e 9b 01 03 03 04
-  20 packet(s) received
-  01 00 5e 00 00 fb ac bc 32 bf 0d 43 08 00 45 00
-  00 44 d2 09 00 00 ff 11 47 f8 c0 a8 00 03 e0 00
-  00 fb 14 e9 14 e9 00 30 69 fc 00 00 00 00 00 01
-  00 00 00 00 00 00 0b 5f 67 6f 6f 67 6c 65 63 61
-  73 74 04 5f 74 63 70 05 6c 6f 63 61 6c 00 00 0c
-  80 01
-  ^C
-  INFO:root:Clean shutdown process started
-  INFO:root:Waiting for '2' message(s) to flush
-  INFO:root:'20' packet(s) in, '20' packet(s) out
-  ```
+```
 
-**Example**: Consume 10 packets from the Kafka topic `pcap` running on `localhost:9092`, then pipe those into Wireshark for DPI.
-  ```
-  $ pycapa --consumer \
-      --kafka-broker localhost:9092 \
-      --kafka-topic pcap \
-      --max-packets 10 \
-      | tshark -i -
-  Capturing on 'Standard input'
-      1   0.000000 ArrisGro_0e:65:df → Apple_bf:0d:43 ARP 56 Who has 192.168.0.3? Tell 192.168.0.1
-      2   0.000044 Apple_bf:0d:43 → ArrisGro_0e:65:df ARP 42 192.168.0.3 is at ac:bc:32:bf:0d:43
-      3   0.203495 fe80::1286:8cff:fe0e:65df → ff02::1      ICMPv6 134 Router Advertisement from 10:86:8c:0e:65:df
-      4   2.031988  192.168.0.3 → 96.27.183.249 TCP 54 55110 → 443 [ACK] Seq=1 Ack=1 Win=4108 Len=0
-      5   2.035816 192.30.253.125 → 192.168.0.3  TLSv1.2 97 Application Data
-      6   2.035892  192.168.0.3 → 192.30.253.125 TCP 66 54671 → 443 [ACK] Seq=1 Ack=32 Win=4095 Len=0 TSval=961120495 TSecr=2658503052
-      7   2.035994  192.168.0.3 → 192.30.253.125 TLSv1.2 101 Application Data
-      8   2.053866 96.27.183.249 → 192.168.0.3  TCP 66 [TCP ACKed unseen segment] 443 → 55110 [ACK] Seq=1 Ack=2 Win=243 Len=0 TSval=728145145 TSecr=961030381
-      9   2.083872 192.30.253.125 → 192.168.0.3  TCP 66 443 → 54671 [ACK] Seq=32 Ack=36 Win=31 Len=0 TSval=2658503087 TSecr=961120495
-     10   3.173189 fe80::1286:8cff:fe0e:65df → ff02::1      ICMPv6 134 Router Advertisement from 10:86:8c:0e:65:df
-  10 packets captured
-  ```
+#### Example 4
 
-**Example**: Consume 10 packets and create a libpcap-compliant pcap file.
+Consume 10 packets and create a libpcap-compliant pcap file.
+
   ```
   $ pycapa --consumer \
       --kafka-broker localhost:9092 \
@@ -195,6 +188,30 @@ optional arguments:
       9   2.253140  192.168.0.3 → 192.175.27.112 TCP 66 55078 → 443 [ACK] Seq=1 Ack=863 Win=4069 Len=0 TSval=961286699 TSecr=967172238
      10   2.494769  192.168.0.3 → 224.0.0.251  MDNS 82 Standard query 0x0000 PTR _googlecast._tcp.local, "QM" question
   ```
+
+#### Example 5
+
+Consume 10 packets from the Kafka topic `pcap` running on `localhost:9092`, then pipe those into Wireshark for DPI.
+
+```
+$ pycapa --consumer \
+    --kafka-broker localhost:9092 \
+    --kafka-topic pcap \
+    --max-packets 10 \
+    | tshark -i -
+Capturing on 'Standard input'
+    1   0.000000 ArrisGro_0e:65:df → Apple_bf:0d:43 ARP 56 Who has 192.168.0.3? Tell 192.168.0.1
+    2   0.000044 Apple_bf:0d:43 → ArrisGro_0e:65:df ARP 42 192.168.0.3 is at ac:bc:32:bf:0d:43
+    3   0.203495 fe80::1286:8cff:fe0e:65df → ff02::1      ICMPv6 134 Router Advertisement from 10:86:8c:0e:65:df
+    4   2.031988  192.168.0.3 → 96.27.183.249 TCP 54 55110 → 443 [ACK] Seq=1 Ack=1 Win=4108 Len=0
+    5   2.035816 192.30.253.125 → 192.168.0.3  TLSv1.2 97 Application Data
+    6   2.035892  192.168.0.3 → 192.30.253.125 TCP 66 54671 → 443 [ACK] Seq=1 Ack=32 Win=4095 Len=0 TSval=961120495 TSecr=2658503052
+    7   2.035994  192.168.0.3 → 192.30.253.125 TLSv1.2 101 Application Data
+    8   2.053866 96.27.183.249 → 192.168.0.3  TCP 66 [TCP ACKed unseen segment] 443 → 55110 [ACK] Seq=1 Ack=2 Win=243 Len=0 TSval=728145145 TSecr=961030381
+    9   2.083872 192.30.253.125 → 192.168.0.3  TCP 66 443 → 54671 [ACK] Seq=32 Ack=36 Win=31 Len=0 TSval=2658503087 TSecr=961120495
+   10   3.173189 fe80::1286:8cff:fe0e:65df → ff02::1      ICMPv6 134 Router Advertisement from 10:86:8c:0e:65:df
+10 packets captured
+```
 
 ### Kerberos
 


### PR DESCRIPTION
## Changes

* I have altered Pycapa so that it can consume messages from either the beginning, end or the previously stored offsets of a topic.  This can be done using the `-o` or `--kafka-offset` flag that can be either `begin`, `end`, or `stored`.  This defaults to `end`.
* Added additional information when using the `--pretty-print` flag.  It will now show the partition and offset for a packet, both on the producer-side (sending packets to Kafka) or the consumer-side (receiving packets from Kafka).

## Testing

1. Install Pycapa by [following these instructions](https://github.com/apache/metron/tree/master/metron-sensors/pycapa#installation).

1. Launch a Kafka Broker on your localhost.  For example, using Kafka installed via Brew on my Mac.

   ```
   export KAFKA_HOME=/usr/local/Cellar/kafka/0.10.1.1/
   export KAFKA_CONF=$KAFKA_HOME/libexec/config
   zookeeper-server-start $KAFKA_CONF/zookeeper.properties
   kafka-server-start $KAFKA_CONF/server.properties
   ```

1. Produce some packets.  Assumes you're actively using `en0` and Kafka is at `localhost:9092`.  Let it run until it completes and captures 50 packets.

    ```
     pycapa --producer \
        --interface en0 \
        --kafka-broker localhost:9092 \
        --kafka-topic pcap \
        --max-packets 50
    ```

1. Run the consumer. The consumer will not consume any packets.  It starts from the end of the topic, by default, and since there are no active producers, there is nothing new to consume.

    ```
    pycapa --consumer \
        --kafka-broker localhost:9092 \
        --kafka-topic pcap
        --pretty-print 1
    ```

1. Run the consumer again, but start from the beginning of the topic.  You should be able to consume all 50 packets.

    ```
    pycapa --consumer \
        --kafka-broker localhost:9092 \
        --kafka-topic pcap
        --pretty-print 1
        --kafka-offset begin
    ```


## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root incubating-metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

