### PR TITLE
METRON-952 Travis CI Link in README Pointing to Old Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/apache/incubator-metron.svg?branch=master)](https://travis-ci.org/apache/incubator-metron)
+[![Build Status](https://travis-ci.org/apache/metron.svg?branch=master)](https://travis-ci.org/apache/metron)
  
 # Apache Metron
 


### PR DESCRIPTION
The Travis CI status link in the README is pointing to the old apache/incubator-metron repository.  I updated this point to apache/metron.

