### PR TITLE
Metron-979 markdown errors in site-book

### DIFF
--- a/metron-deployment/Kerberos-manual-setup.md
+++ b/metron-deployment/Kerberos-manual-setup.md
@@ -381,7 +381,7 @@ Push Data
 
     ```
     cat sample-bro.txt | ${KAFKA_HOME}/kafka-broker/bin/kafka-console-producer.sh \
-            --broker-list ${BROKERLIST}
+            --broker-list ${BROKERLIST} \
             --security-protocol SASL_PLAINTEXT \
             --topic bro
     ```

--- a/metron-deployment/Kerberos-manual-setup.md
+++ b/metron-deployment/Kerberos-manual-setup.md
@@ -42,75 +42,75 @@ Setup
 
 1. Stop all Metron topologies.  They will be restarted again once Kerberos has been enabled.
 
-  	```
-  	for topology in bro snort enrichment indexing; do
-  		storm kill $topology;
-  	done
-  	```
+    ```
+    for topology in bro snort enrichment indexing; do
+    	storm kill $topology;
+    done
+    ```
 
 1. Create the `metron` user's home directory in HDFS.
 
-  	```
-  	sudo -u hdfs hdfs dfs -mkdir /user/metron
-  	sudo -u hdfs hdfs dfs -chown metron:hdfs /user/metron
-  	sudo -u hdfs hdfs dfs -chmod 770 /user/metron
-  	```
+    ```
+    sudo -u hdfs hdfs dfs -mkdir /user/metron
+    sudo -u hdfs hdfs dfs -chown metron:hdfs /user/metron
+    sudo -u hdfs hdfs dfs -chmod 770 /user/metron
+    ```
 
 Setup a KDC
 -----------
 
 1. Install dependencies.
 
-  	```
-  	yum -y install krb5-server krb5-libs krb5-workstation
-  	```
+    ```
+    yum -y install krb5-server krb5-libs krb5-workstation
+    ```
 
 1. Define the host, `node1`, as the KDC.
 
-  	```
-  	sed -i 's/kerberos.example.com/node1/g' /etc/krb5.conf
-  	cp -f /etc/krb5.conf /var/lib/ambari-server/resources/scripts
-  	```
+    ```
+    sed -i 's/kerberos.example.com/node1/g' /etc/krb5.conf
+    cp -f /etc/krb5.conf /var/lib/ambari-server/resources/scripts
+    ```
 
 1. Ensure the KDC can issue renewable tickets. This can be necessary on a real cluster, but should not be on full-dev. In /var/kerberos/krb5kdc/kdc.conf ensure the following is in the realm section
-   ```
-   max_renewable_life = 7d
-   ```
- 
+
+    ```
+    max_renewable_life = 7d
+    ```
 
 1. Do not copy/paste this full set of commands as the `kdb5_util` command will not run as expected. Run the commands individually to ensure they all execute.  This step takes a moment. It creates the kerberos database.
 
-  	```
-  	kdb5_util create -s
-
-  	/etc/rc.d/init.d/krb5kdc start
-  	chkconfig krb5kdc on
-
-  	/etc/rc.d/init.d/kadmin start
-  	chkconfig kadmin on
-  	```
+    ```
+    kdb5_util create -s
+    /etc/rc.d/init.d/krb5kdc start
+    chkconfig krb5kdc on
+    /etc/rc.d/init.d/kadmin start
+    chkconfig kadmin on
+    ```
 
 1. Setup the `admin` and `metron` principals. You'll `kinit` as the `metron` principal when running topologies. Make sure to remember the passwords.
 
-  	```
-  	kadmin.local -q "addprinc admin/admin"
-  	kadmin.local -q "addprinc metron"
-  	```
+    ```
+    kadmin.local -q "addprinc admin/admin"
+    kadmin.local -q "addprinc metron"
+    ```
 
 Verify KDC
 ----------
 
 
 Ticket renewal is by default disallowed in many linux distributions. If the KDC cannot issue renewable tickets, an error will be thrown when starting Metron's Storm topologies:
-   ```
-   Exception in thread "main" java.lang.RuntimeException: java.lang.RuntimeException: The TGT found is not renewable
-   ```
+
+```
+Exception in thread "main" java.lang.RuntimeException: java.lang.RuntimeException: The TGT found is not renewable
+```
 
 
 Ensure the Metron keytab is renewable.  Look for the 'R' flag from the following command
-   ```
-   klist -f
-   ```
+
+```
+klist -f
+```
 
 If the 'R' flags are present, you may skip to next section.
 
@@ -118,10 +118,11 @@ If the 'R' flags are absent, you will need to follow the below steps:
 If the KDC is already setup, then editing max_life and max_renewable_life in `/var/kerberos/krb5kdc/kdc.conf`, and restarting kadmin and krb5kdc services will not change the policies for existing users. 
 
 You need to set the renew lifetime for existing users and krbtgt realm. Modify the appropriate principals to allow renewable tickets using the following commands. Adjust the parameters to match your desired KDC parameters:
-   ```
-   kadmin.local -q "modprinc -maxlife 1days -maxrenewlife 7days +allow_renewable krbtgt/EXAMPLE.COM@EXAMPLE.COM"
-   kadmin.local -q "modprinc -maxlife 1days -maxrenewlife 7days +allow_renewable metron@EXAMPLE.COM"
-   ```
+
+```
+kadmin.local -q "modprinc -maxlife 1days -maxrenewlife 7days +allow_renewable krbtgt/EXAMPLE.COM@EXAMPLE.COM"
+kadmin.local -q "modprinc -maxlife 1days -maxrenewlife 7days +allow_renewable metron@EXAMPLE.COM"
+```
 
 
 Enable Kerberos
@@ -164,11 +165,11 @@ Enable Kerberos
 1. Create a Metron keytab
 
     ```
-  	kadmin.local -q "ktadd -k metron.headless.keytab metron@EXAMPLE.COM"
-  	cp metron.headless.keytab /etc/security/keytabs
-  	chown metron:hadoop /etc/security/keytabs/metron.headless.keytab
-  	chmod 440 /etc/security/keytabs/metron.headless.keytab
-  	```
+    kadmin.local -q "ktadd -k metron.headless.keytab metron@EXAMPLE.COM"
+    cp metron.headless.keytab /etc/security/keytabs
+    chown metron:hadoop /etc/security/keytabs/metron.headless.keytab
+    chmod 440 /etc/security/keytabs/metron.headless.keytab
+    ```
 
 Kafka Authorization
 -------------------
@@ -176,60 +177,58 @@ Kafka Authorization
 1. Acquire a Kerberos ticket using the `metron` principal.
 
     ```
-  	kinit -kt /etc/security/keytabs/metron.headless.keytab metron@EXAMPLE.COM
-  	```
+    kinit -kt /etc/security/keytabs/metron.headless.keytab metron@EXAMPLE.COM
+    ```
 
 1. Create any additional Kafka topics that you will need. We need to create the topics before adding the required ACLs. The current full dev installation will deploy bro, snort, enrichments, and indexing only.  For example, you may want to add a topic for 'yaf' telemetry.
 
     ```
-  	${KAFKA_HOME}/bin/kafka-topics.sh \
+    ${KAFKA_HOME}/bin/kafka-topics.sh \
       --zookeeper ${ZOOKEEPER} \
       --create \
       --topic yaf \
       --partitions 1 \
       --replication-factor 1
-  	```
+    ```
 
 1. Setup Kafka ACLs for the `bro`, `snort`, `enrichments`, and `indexing` topics.  Run the same command against any additional topics that you might be using; for example `yaf`.
 
     ```
-  	export KERB_USER=metron
-
-  	for topic in bro snort enrichments indexing; do
-  		${KAFKA_HOME}/bin/kafka-acls.sh \
+    export KERB_USER=metron
+    for topic in bro snort enrichments indexing; do
+    	${KAFKA_HOME}/bin/kafka-acls.sh \
           --authorizer kafka.security.auth.SimpleAclAuthorizer \
           --authorizer-properties zookeeper.connect=${ZOOKEEPER} \
           --add \
           --allow-principal User:${KERB_USER} \
           --topic ${topic}
-  	done
-  	```
+    done
+    ```
 
 1. Setup Kafka ACLs for the consumer groups.  This command sets the ACLs for Bro, Snort, YAF, Enrichments, Indexing, and the Profiler.  Execute the same command for any additional Parsers that you may be running.
 
     ```
     export KERB_USER=metron
-
-  	for group in bro_parser snort_parser yaf_parser enrichments indexing profiler; do
-  		${KAFKA_HOME}/bin/kafka-acls.sh \
+    for group in bro_parser snort_parser yaf_parser enrichments indexing profiler; do
+    	${KAFKA_HOME}/bin/kafka-acls.sh \
           --authorizer kafka.security.auth.SimpleAclAuthorizer \
           --authorizer-properties zookeeper.connect=${ZOOKEEPER} \
           --add \
           --allow-principal User:${KERB_USER} \
           --group ${group}
-  	done
-  	```
+    done
+    ```
 
 1. Add the `metron` principal to the `kafka-cluster` ACL.
 
     ```
-  	${KAFKA_HOME}/bin/kafka-acls.sh \
+    ${KAFKA_HOME}/bin/kafka-acls.sh \
         --authorizer kafka.security.auth.SimpleAclAuthorizer \
         --authorizer-properties zookeeper.connect=${ZOOKEEPER} \
         --add \
         --allow-principal User:${KERB_USER} \
         --cluster kafka-cluster
-  	```
+    ```
 
 HBase Authorization
 -------------------
@@ -237,22 +236,22 @@ HBase Authorization
 1. Acquire a Kerberos ticket using the `hbase` principal
 
     ```
-  	kinit -kt /etc/security/keytabs/hbase.headless.keytab hbase-metron_cluster@EXAMPLE.COM
-  	```
+    kinit -kt /etc/security/keytabs/hbase.headless.keytab hbase-metron_cluster@EXAMPLE.COM
+    ```
 
 1. Grant permissions for the HBase tables used in Metron.
 
     ```
-  	echo "grant 'metron', 'RW', 'threatintel'" | hbase shell
-  	echo "grant 'metron', 'RW', 'enrichment'" | hbase shell
-  	```
+    echo "grant 'metron', 'RW', 'threatintel'" | hbase shell
+    echo "grant 'metron', 'RW', 'enrichment'" | hbase shell
+    ```
 
 1. If you are using the Profiler, do the same for its HBase table.
 
     ```
-  	echo "create 'profiler', 'P'" | hbase shell
-  	echo "grant 'metron', 'RW', 'profiler', 'P'" | hbase shell
-  	```
+    echo "create 'profiler', 'P'" | hbase shell
+    echo "grant 'metron', 'RW', 'profiler', 'P'" | hbase shell
+    ```
 
 Storm Authorization
 -------------------
@@ -260,19 +259,18 @@ Storm Authorization
 1. Switch to the `metron` user and acquire a Kerberos ticket for the `metron` principal.
 
     ```
-  	su metron
-  	kinit -kt /etc/security/keytabs/metron.headless.keytab metron@EXAMPLE.COM
-  	```
+    su metron
+    kinit -kt /etc/security/keytabs/metron.headless.keytab metron@EXAMPLE.COM
+    ```
 
 1. Create the directory `/home/metron/.storm` and switch to that directory.
 
     ```
-  	mkdir /home/metron/.storm
-  	cd /home/metron/.storm
-  	```
+    mkdir /home/metron/.storm
+    cd /home/metron/.storm
+    ```
 
-1. Ensure the Metron keytab is renewable. See [Verify KDC](#verify-kdc) above
-
+1. Ensure the Metron keytab is renewable. See [Verify KDC](#verify-kdc) above.
 
 1. Create a client JAAS file at `/home/metron/.storm/client_jaas.conf`.  This should look identical to the Storm client JAAS file located at `/etc/storm/conf/client_jaas.conf` except for the addition of a `Client` stanza. The `Client` stanza is used for Zookeeper. All quotes and semicolons are necessary.
 
@@ -325,18 +323,18 @@ Storm Authorization
     EOF
     ```
 
-1. Configure the Enrichment, Indexing and the Profiler topologies to use the client JAAS file.  Add the following properties to each of the topology properties files.
+1. Configure the Enrichment, Indexing and Profiler topologies to use the client JAAS file.  To do this, the following key-value pairs:
 
-  	```
-  	kafka.security.protocol=PLAINTEXTSASL
-  	topology.worker.childopts=-Djava.security.auth.login.config=/home/metron/.storm/client_jaas.conf
-  	```
+    * `kafka.security.protocol=PLAINTEXTSASL`
+    * `topology.worker.childopts=-Djava.security.auth.login.config=/home/metron/.storm/client_jaas.conf`
+
+    must be added to each of the topology properties files:
 
     * `${METRON_HOME}/config/enrichment.properties`
     * `${METRON_HOME}/config/elasticsearch.properties`
     * `${METRON_HOME}/config/profiler.properties`
 
-    Use the following command to automate this step.
+    You may use the following command to automate this step:
 
     ```
     for file in enrichment.properties elasticsearch.properties profiler.properties; do
@@ -352,9 +350,9 @@ Start Metron
 1. Switch to the `metron` user and acquire a Kerberos ticket for the `metron` principal.
 
     ```
-  	su metron
-  	kinit -kt /etc/security/keytabs/metron.headless.keytab metron@EXAMPLE.COM
-  	```
+    su metron
+    kinit -kt /etc/security/keytabs/metron.headless.keytab metron@EXAMPLE.COM
+    ```
 
 1. Restart the parser topologies. Be sure to pass in the new parameter, `-ksp` or `--kafka_security_protocol`.  The following command will start only the Bro and Snort topologies.  Execute the same command for any other Parsers that you may need, for example `yaf`.
 
@@ -371,9 +369,9 @@ Start Metron
 1. Restart the Enrichment and Indexing topologies.
 
     ```
-  	${METRON_HOME}/bin/start_enrichment_topology.sh
-  	${METRON_HOME}/bin/start_elasticsearch_topology.sh
-  	```
+    ${METRON_HOME}/bin/start_enrichment_topology.sh
+    ${METRON_HOME}/bin/start_elasticsearch_topology.sh
+    ```
 
 Metron should be ready to receive data.
 
@@ -382,18 +380,18 @@ Push Data
 1. Push some sample data to one of the parser topics. E.g for Bro we took raw data from [metron/metron-platform/metron-integration-test/src/main/sample/data/bro/raw/BroExampleOutput](../metron-platform/metron-integration-test/src/main/sample/data/bro/raw/BroExampleOutput)
 
     ```
-  	cat sample-bro.txt | ${KAFKA_HOME}/kafka-broker/bin/kafka-console-producer.sh \
-  	        --broker-list ${BROKERLIST}
-          	--security-protocol SASL_PLAINTEXT \
+    cat sample-bro.txt | ${KAFKA_HOME}/kafka-broker/bin/kafka-console-producer.sh \
+            --broker-list ${BROKERLIST}
+            --security-protocol SASL_PLAINTEXT \
             --topic bro
-  	```
+    ```
 
 1. Wait a few moments for data to flow through the system and then check for data in the Elasticsearch indices. Replace yaf with whichever parser type you’ve chosen.
 
     ```
-  	curl -XGET "${ELASTICSEARCH}/bro*/_search"
-  	curl -XGET "${ELASTICSEARCH}/bro*/_count"
-  	```
+    curl -XGET "${ELASTICSEARCH}/bro*/_search"
+    curl -XGET "${ELASTICSEARCH}/bro*/_count"
+    ```
 
 1. You should have data flowing from the parsers all the way through to the indexes. This completes the Kerberization instructions
 
@@ -428,6 +426,7 @@ KVNO Timestamp         Principal
 
 A couple steps are required to produce data to a Kerberized Kafka topic. On the host you'll be setting up your sensor(s), switch to the metron user and create a client_jaas.conf file in the metron home directory if one doesn't already exist. It should be owned by metron:metron and
 contain at least the following stanza that tells the Kafka client how to interact with Kerberos:
+
 ```
 su - metron
 cat ${METRON_HOME}/client_jaas.conf
@@ -444,6 +443,7 @@ KafkaClient {
 ```
 
 You'll also need to set KAFKA_OPTS to tell the Kafka client how to interact with Kerberos.
+
 ```
 export KAFKA_OPTS="-Djava.security.auth.login.config=${METRON_HOME}/client_jaas.conf"
 ```

--- a/metron-deployment/packaging/docker/ansible-docker/README.md
+++ b/metron-deployment/packaging/docker/ansible-docker/README.md
@@ -3,14 +3,14 @@ The Metron ansible-docker container is provided in an effort reduce the installa
 It is provisioned with software required to sucessfully run the deployment scripts.
 
 ## Building the Container
-1. Install Docker [https://www.docker.com/products/overview]
+1. Install Docker ( https://www.docker.com/products/overview )
 2. Navigate to \<project-directory\>/metron-deployment/packaging/docker/ansible-docker
 3. Build the container `docker build -t ansible-docker:2.0.0.2 .`
 
 ## Using the Container
-Full instructions are found on the wiki [https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=65144361].
+Full instructions are found on the wiki at https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=65144361
 
-tl;dr
+tl;dr:
 
 1. docker run -it -v \<project-directory\>:/root/metron ansible-docker:2.0.0.2 bash
 2. cd /root/metron

--- a/metron-deployment/packaging/docker/rpm-docker/README.md
+++ b/metron-deployment/packaging/docker/rpm-docker/README.md
@@ -3,6 +3,6 @@ The Metron ansible-docker container is provided in an effort reduce the installa
 It is provisioned with software required to sucessfully run the deployment scripts.
 
 ## Building the Container
-1. Install Docker [https://www.docker.com/products/overview]
+1. Install Docker ( https://www.docker.com/products/overview )
 2. Navigate to \<project-directory\>/metron-deployment/packaging/rpm-docker
 3. Build the container `docker build -t rpm-docker .`

--- a/metron-deployment/roles/README.md
+++ b/metron-deployment/roles/README.md
@@ -1,7 +1,7 @@
 # Ansible Roles
 
-- Kibana
 - Monit
 - OpenTaxii
-- Pcap Relay
+- Pcap Replay
+- Sensor Stubs
 - Sensor Test Mode

--- a/metron-interface/metron-config/README.md
+++ b/metron-interface/metron-config/README.md
@@ -12,47 +12,53 @@ This module provides a user interface for management functions in Metron.
 ### From Source
 
 1. Package the application with Maven:
-```
-cd metron-interface/metron-config
-mvn clean package
-```
+
+    ```
+    cd metron-interface/metron-config
+    mvn clean package
+    ```
 
 1. Untar the archive in the $METRON_HOME directory.  The directory structure will look like:
-```
-bin
-  metron-management-ui
-web
-  expressjs
+
+    ```
+    bin
+      metron-management-ui
+    web
+      expressjs
         package.json
         server.js
-  management-ui
+      management-ui
         web assets (html, css, js, ...)
-```
+    ```
 
 1. Copy the `$METRON_HOME/bin/metron-management-ui` script to `/etc/init.d/metron-management-ui`
 
 1. Install the [Express](https://expressjs.com/) web framework from the `package.json` file in `$METRON_HOME/web/expressjs`:
-```
-npm --prefix $METRON_HOME/web/expressjs/ install
-```
+
+    ```
+    npm --prefix $METRON_HOME/web/expressjs/ install
+    ```
 
 ### From Package Manager
 
 1. Deploy the RPM at `/metron/metron-deployment/packaging/docker/rpm-docker/target/RPMS/noarch/metron-config-$METRON_VERSION-*.noarch.rpm`
 
 1. Install the RPM with:
-```
-rpm -ih metron-config-$METRON_VERSION-*.noarch.rpm
-```
+
+    ```
+    rpm -ih metron-config-$METRON_VERSION-*.noarch.rpm
+    ```
 
 1. Install the [Express](https://expressjs.com/) web framework from the `package.json` file in `$METRON_HOME/web/expressjs`:
-```
-npm --prefix $METRON_HOME/web/expressjs/ install
-```
+
+    ```
+    npm --prefix $METRON_HOME/web/expressjs/ install
+    ```
 
 ## Configuration
 
 The Managment UI is configured in the `$METRON_HOME/config/management_ui.yml` file.  Create this file and set the values to match your environment:
+
 ```
 port: port the managment UI will run on
 
@@ -64,6 +70,7 @@ rest:
 ## Usage
 
 After configuration is complete, the Management UI can be managed as a service:
+
 ```
 service metron-management-ui start
 ```
@@ -75,30 +82,34 @@ The application will be available at http://host:4200 assuming the port is set t
 The Management UI can also be started in development mode.  This allows changes to web assets to be seen interactively.
 
 1. Install the application with dev dependencies:
-```
-cd metron-interface/metron-config
-npm install
-```
+
+    ```
+    cd metron-interface/metron-config
+    npm install
+    ```
   
 1. Start the application:
-```
-./scripts/start_dev.sh
-```
+
+    ```
+    ./scripts/start_dev.sh
+    ```
 
 The application will be available at http://localhost:4200/.  The REST application url defaults to `http://localhost:8080` but can be changed in the `proxy.conf.json` file.
 
 ## Testing
 
 1. Install the application with dev dependencies:
-```
-cd metron-interface/metron-config
-npm install
-```
+
+    ```
+    cd metron-interface/metron-config
+    npm install
+    ```
 
 1. Unit tests can be run with:
-```
-npm test
-```
+
+    ```
+    npm test
+    ```
 
 ## License
 

--- a/metron-platform/metron-pcap-backend/README.md
+++ b/metron-platform/metron-pcap-backend/README.md
@@ -1,7 +1,7 @@
 # Metron PCAP Backend
 
 The purpose of the Metron PCAP backend is to create a storm topology
-capable of ingesting rapidly raw packet capture data directly into HDFS
+capable of rapidly ingesting raw packet capture data directly into HDFS
 from Kafka.
 
 * [Sensors](#the-sensors-feeding-kafka)

--- a/metron-sensors/pycapa/README.md
+++ b/metron-sensors/pycapa/README.md
@@ -37,7 +37,6 @@ General notes on the installation of Pycapa.
 
    ```
    export PREFIX=/usr
-
    wget https://github.com/edenhill/librdkafka/archive/v0.9.4.tar.gz  -O - | tar -xz
    cd librdkafka-0.9.4/
    ./configure --prefix=$PREFIX
@@ -251,7 +250,6 @@ The probe can be used in a Kerberized environment.  Follow these additional step
       --add \
       --allow-principal User:metron \
       --topic pcap
-
     ${KAFKA_HOME}/bin/kafka-acls.sh \
       --authorizer kafka.security.auth.SimpleAclAuthorizer \
       --authorizer-properties zookeeper.connect=zookeeper1:2181 \
@@ -264,6 +262,7 @@ The probe can be used in a Kerberized environment.  Follow these additional step
   * `security.protocol`
   * `sasl.kerberos.keytab`
   * `sasl.kerberos.principal`
+
   ```
   $ pycapa --producer \
       --interface eth0 \
@@ -284,6 +283,7 @@ FAQs
 **Question**: How do I get more logs?
 
 Use the following two command-line arguments to get detailed logging.
+
 ```
 -X debug=all --log-level DEBUG
 ```


### PR DESCRIPTION
## Contributor Comments
Fixed multiple problems in markdown docs, mostly related to triple-backtick codeblocks nesting inside numbered lists.  I now understand that blank lines are not allowed within a codeblock nested under a numbered list item, although at the top level (under body text) blank lines in codeblocks are okay.

A few of these changes are for consistency or editorial improvement, but most of them fix actual rendering errors in the doxia site build, without breaking Github rendering.


## Pull Request Checklist

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes: N/A

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? 
    - Yes, verified in doxia build and in github.
