### PR TITLE
METRON-987: Allow stellar enrichments to be specified by a list as well as a map

### DIFF
--- a/metron-analytics/metron-profiler-client/src/main/java/org/apache/metron/profiler/client/stellar/GetProfile.java
+++ b/metron-analytics/metron-profiler-client/src/main/java/org/apache/metron/profiler/client/stellar/GetProfile.java
@@ -247,7 +247,7 @@ public class GetProfile implements StellarFunction {
       return provider.getTable(HBaseConfiguration.create(), tableName);
 
     } catch (IOException e) {
-      throw new IllegalArgumentException(String.format("Unable to access table: %s", tableName));
+      throw new IllegalArgumentException(String.format("Unable to access table: %s", tableName), e);
     }
   }
 

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/enrichment/handler/ConfigHandler.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/enrichment/handler/ConfigHandler.java
@@ -34,7 +34,7 @@ public class ConfigHandler {
   }
 
   public ConfigHandler(List<String> obj) {
-    config = new ArrayList();
+    config = new HashMap<>();
     type = Configs.LIST;
   }
   public Object getConfig() {

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/enrichment/handler/ConfigHandler.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/enrichment/handler/ConfigHandler.java
@@ -17,15 +17,13 @@
  */
 package org.apache.metron.common.configuration.enrichment.handler;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class ConfigHandler {
-  private Map<String, Object> config;
+  private Object config;
   private Configs type = Configs.LIST;
   public ConfigHandler(String enrichment, Map<String, Object> obj) {
-    config = (Map<String, Object>) obj.get("config");
+    config = obj.get("config");
     if(obj.containsKey("type")) {
       type = Configs.valueOf((String) obj.get("type"));
     }
@@ -36,14 +34,14 @@ public class ConfigHandler {
   }
 
   public ConfigHandler(List<String> obj) {
-    config = new HashMap<>();
+    config = new ArrayList();
     type = Configs.LIST;
   }
-  public Map<String, Object> getConfig() {
+  public Object getConfig() {
     return config;
   }
 
-  public void setConfig(Map<String, Object> config) {
+  public void setConfig(Object config) {
     this.config = config;
   }
 

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/enrichment/handler/Configs.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/enrichment/handler/Configs.java
@@ -19,6 +19,7 @@ package org.apache.metron.common.configuration.enrichment.handler;
 
 import org.json.simple.JSONObject;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -36,16 +37,20 @@ public enum Configs implements Config {
   public List<JSONObject> splitByFields(JSONObject message
                                  , Object fields
                                  , Function<String, String> fieldToEnrichmentKey
-                                 , Map<String, Object> config
+                                 , Iterable<Map.Entry<String, Object>> config
                                  )
   {
     return configCreator.splitByFields(message, fields, fieldToEnrichmentKey, config);
   }
 
   @Override
-  public List<String> getSubgroups(Map<String, Object> config) {
+  public List<String> getSubgroups(Iterable<Map.Entry<String, Object>> config) {
     return configCreator.getSubgroups(config);
   }
 
+  @Override
+  public Iterable<Map.Entry<String, Object>> toConfig(Object c) {
+    return configCreator.toConfig(c);
+  }
 
 }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/enrichment/handler/ListConfig.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/enrichment/handler/ListConfig.java
@@ -20,6 +20,8 @@ package org.apache.metron.common.configuration.enrichment.handler;
 import com.google.common.collect.ImmutableList;
 import org.json.simple.JSONObject;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -30,7 +32,7 @@ public class ListConfig implements Config {
   public List<JSONObject> splitByFields( JSONObject message
                                  , Object fieldsObj
                                  , Function<String, String> fieldToEnrichmentKey
-                                 , Map<String, Object> config
+                                 , Iterable<Map.Entry<String, Object>> config
                                  )
   {
     List<String> fields = (List<String>)fieldsObj;
@@ -45,7 +47,17 @@ public class ListConfig implements Config {
   }
 
   @Override
-  public List<String> getSubgroups(Map<String, Object> config) {
+  public List<String> getSubgroups(Iterable<Map.Entry<String, Object>> config) {
     return ImmutableList.of("");
+  }
+
+  @Override
+  public Iterable<Map.Entry<String, Object>> toConfig(Object c) {
+    if(c instanceof Map) {
+      return ((Map<String, Object>)c).entrySet();
+    }
+    else {
+      return new ArrayList<>();
+    }
   }
 }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/message/JSONFromPosition.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/message/JSONFromPosition.java
@@ -40,10 +40,12 @@ public class JSONFromPosition implements MessageGetStrategy {
 
   @Override
   public JSONObject get(Tuple tuple) {
+    String s = null;
     try {
-      return (JSONObject) parser.get().parse(new String(tuple.getBinary(position), "UTF8"));
+      s =  new String(tuple.getBinary(position), "UTF8");
+      return (JSONObject) parser.get().parse(s);
     } catch (Exception e) {
-      throw new IllegalStateException(e.getMessage(), e);
+      throw new IllegalStateException("Unable to parse " + s + " due to " + e.getMessage(), e);
     }
   }
 }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/message/JSONFromPosition.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/message/JSONFromPosition.java
@@ -17,6 +17,7 @@
  */
 package org.apache.metron.common.message;
 
+import org.apache.commons.io.Charsets;
 import org.apache.storm.tuple.Tuple;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -42,7 +43,7 @@ public class JSONFromPosition implements MessageGetStrategy {
   public JSONObject get(Tuple tuple) {
     String s = null;
     try {
-      s =  new String(tuple.getBinary(position), "UTF8");
+      s =  new String(tuple.getBinary(position), Charsets.UTF_8);
       return (JSONObject) parser.get().parse(s);
     } catch (Exception e) {
       throw new IllegalStateException("Unable to parse " + s + " due to " + e.getMessage(), e);

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/BaseStellarProcessor.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/BaseStellarProcessor.java
@@ -234,4 +234,5 @@ public class BaseStellarProcessor<T> {
 
     return true;
   }
+
 }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/StellarAssignment.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/StellarAssignment.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.common.stellar;
+
+
+import java.util.Map;
+
+public class StellarAssignment implements Map.Entry<String, Object>{
+  private String variable;
+  private String statement;
+
+  public StellarAssignment(String variable, String statement) {
+    this.variable = variable;
+    this.statement = statement;
+  }
+
+  public String getVariable() {
+    return variable;
+  }
+
+  public String getStatement() {
+    return statement;
+  }
+
+  public static boolean isAssignment(String statement) {
+    return statement != null && statement.contains(":=");
+  }
+
+  public static StellarAssignment from(String statement) {
+    if(statement == null || statement.length() == 0) {
+      return new StellarAssignment(null, null);
+    }
+    char prev = statement.charAt(0);
+    char curr;
+    String variable = "" + prev;
+    String s = null;
+    boolean isAssignment = false;
+    for(int i = 1;i < statement.length();++i,prev=curr) {
+      curr = statement.charAt(i);
+      if(prev == ':' && curr == '=') {
+        isAssignment = true;
+        variable = variable.substring(0, variable.length() - 1);
+        s = "";
+        continue;
+      }
+      if(!isAssignment) {
+        variable += curr;
+      }
+      else {
+        s += curr;
+      }
+    }
+
+    if(!isAssignment) {
+      s = variable;
+      variable = null;
+    }
+
+    if(s != null) {
+      s = s.trim();
+    }
+    if(variable != null) {
+      variable = variable.trim();
+    }
+    return new StellarAssignment(variable, s);
+  }
+
+  /**
+   * Returns the key corresponding to this entry.
+   *
+   * @return the key corresponding to this entry
+   * @throws IllegalStateException implementations may, but are not
+   *                               required to, throw this exception if the entry has been
+   *                               removed from the backing map.
+   */
+  @Override
+  public String getKey() {
+    return variable;
+  }
+
+  /**
+   * Returns the value corresponding to this entry.  If the mapping
+   * has been removed from the backing map (by the iterator's
+   * <tt>remove</tt> operation), the results of this call are undefined.
+   *
+   * @return the value corresponding to this entry
+   * @throws IllegalStateException implementations may, but are not
+   *                               required to, throw this exception if the entry has been
+   *                               removed from the backing map.
+   */
+  @Override
+  public Object getValue() {
+    return statement;
+  }
+
+  /**
+   * Replaces the value corresponding to this entry with the specified
+   * value (optional operation).  (Writes through to the map.)  The
+   * behavior of this call is undefined if the mapping has already been
+   * removed from the map (by the iterator's <tt>remove</tt> operation).
+   *
+   * @param value new value to be stored in this entry
+   * @return old value corresponding to the entry
+   * @throws UnsupportedOperationException if the <tt>put</tt> operation
+   *                                       is not supported by the backing map
+   * @throws ClassCastException            if the class of the specified value
+   *                                       prevents it from being stored in the backing map
+   * @throws NullPointerException          if the backing map does not permit
+   *                                       null values, and the specified value is null
+   * @throws IllegalArgumentException      if some property of this value
+   *                                       prevents it from being stored in the backing map
+   * @throws IllegalStateException         implementations may, but are not
+   *                                       required to, throw this exception if the entry has been
+   *                                       removed from the backing map.
+   */
+  @Override
+  public String setValue(Object value) {
+    throw new UnsupportedOperationException("Assignments are immutable.");
+  }
+}

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/shell/StellarShell.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/shell/StellarShell.java
@@ -33,6 +33,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.metron.common.dsl.Context;
 import org.apache.metron.common.dsl.StellarFunctionInfo;
 import org.apache.metron.common.dsl.functions.resolver.ClasspathFunctionResolver;
+import org.apache.metron.common.stellar.StellarAssignment;
 import org.apache.metron.common.utils.JSONUtils;
 import org.jboss.aesh.complete.CompleteOperation;
 import org.jboss.aesh.complete.Completion;
@@ -247,19 +248,17 @@ public class StellarShell extends AeshConsoleCallback implements Completion {
    */
   private void handleStellar(String expression) {
 
-    Iterable<String> assignmentSplit = Splitter.on(":=").split(expression);
     String stellarExpression = expression;
     String variable = null;
-    if(Iterables.size(assignmentSplit) == 2) {
-      //assignment
-      variable = Iterables.getFirst(assignmentSplit, null);
-      if(variable != null) {
-        variable = variable.trim();
-      }
-      stellarExpression = Iterables.getLast(assignmentSplit, null);
+    if(StellarAssignment.isAssignment(expression)) {
+      StellarAssignment expr = StellarAssignment.from(expression);
+      variable = expr.getVariable();
+      stellarExpression = expr.getStatement();
     }
-    if(!stellarExpression.isEmpty()) {
-      stellarExpression = stellarExpression.trim();
+    else {
+      if (!stellarExpression.isEmpty()) {
+        stellarExpression = stellarExpression.trim();
+      }
     }
     Object result = executeStellar(stellarExpression);
     if(result != null && variable == null) {

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/configuration/StellarEnrichmentConfigTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/configuration/StellarEnrichmentConfigTest.java
@@ -1,6 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.metron.common.configuration;
 
-import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import org.apache.metron.common.configuration.enrichment.EnrichmentConfig;

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/configuration/StellarEnrichmentConfigTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/configuration/StellarEnrichmentConfigTest.java
@@ -1,0 +1,128 @@
+package org.apache.metron.common.configuration;
+
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import org.apache.metron.common.configuration.enrichment.EnrichmentConfig;
+import org.apache.metron.common.configuration.enrichment.handler.ConfigHandler;
+import org.apache.metron.common.configuration.enrichment.handler.Configs;
+import org.apache.metron.common.utils.JSONUtils;
+import org.json.simple.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class StellarEnrichmentConfigTest extends StellarEnrichmentTest {
+
+
+  @Test
+  public void testSplitter_default() throws IOException {
+    JSONObject message = getMessage();
+    for(String c : DEFAULT_CONFIGS) {
+      EnrichmentConfig enrichmentConfig = JSONUtils.INSTANCE.load(c, EnrichmentConfig.class);
+      Assert.assertNotNull(enrichmentConfig.getEnrichmentConfigs().get("stellar"));
+      ConfigHandler handler = enrichmentConfig.getEnrichmentConfigs().get("stellar");
+      List<JSONObject> splits = Configs.STELLAR.splitByFields(message, null, x -> null, handler );
+      Assert.assertEquals(1, splits.size());
+      Map<String, Object> split = (Map<String, Object>) splits.get(0).get("");
+      Assert.assertEquals(3, split.size());
+      Assert.assertEquals("stellar_test", split.get("source.type"));
+      Assert.assertEquals("foo", split.get("string"));
+      Assert.assertNull(split.get("stmt1"));
+    }
+  }
+
+  @Test
+  public void testGetSubgroups_default() throws IOException {
+    for(String c : DEFAULT_CONFIGS) {
+      EnrichmentConfig enrichmentConfig = JSONUtils.INSTANCE.load(c, EnrichmentConfig.class);
+      Assert.assertNotNull(enrichmentConfig.getEnrichmentConfigs().get("stellar"));
+      ConfigHandler handler = enrichmentConfig.getEnrichmentConfigs().get("stellar");
+      List<String> subgroups = Configs.STELLAR.getSubgroups(handler);
+      Assert.assertEquals("", subgroups.get(0));
+      Assert.assertEquals(1, subgroups.size());
+    }
+  }
+
+  @Test
+  public void testSplitter_grouped() throws IOException {
+    JSONObject message = getMessage();
+    for(String c : GROUPED_CONFIGS) {
+      EnrichmentConfig enrichmentConfig = JSONUtils.INSTANCE.load(c, EnrichmentConfig.class);
+      Assert.assertNotNull(enrichmentConfig.getEnrichmentConfigs().get("stellar"));
+      ConfigHandler handler = enrichmentConfig.getEnrichmentConfigs().get("stellar");
+      List<JSONObject> splits = Configs.STELLAR.splitByFields(message, null, x -> null, handler );
+      Assert.assertEquals(2, splits.size());
+      {
+        Map<String, Object> split = (Map<String, Object>) splits.get(0).get("group1");
+        Assert.assertEquals(2, split.size());
+        Assert.assertEquals("stellar_test", split.get("source.type"));
+        Assert.assertNull(split.get("stmt1"));
+      }
+      {
+        Map<String, Object> split = (Map<String, Object>) splits.get(1).get("group2");
+        Assert.assertEquals(1, split.size());
+        Assert.assertEquals("foo", split.get("string"));
+      }
+    }
+  }
+
+  @Test
+  public void testGetSubgroups_grouped() throws IOException {
+    for(String c : GROUPED_CONFIGS) {
+      EnrichmentConfig enrichmentConfig = JSONUtils.INSTANCE.load(c, EnrichmentConfig.class);
+      Assert.assertNotNull(enrichmentConfig.getEnrichmentConfigs().get("stellar"));
+      ConfigHandler handler = enrichmentConfig.getEnrichmentConfigs().get("stellar");
+      List<String> subgroups = Configs.STELLAR.getSubgroups(handler);
+      Assert.assertEquals("group1", subgroups.get(0));
+      Assert.assertEquals("group2", subgroups.get(1));
+      Assert.assertEquals(2, subgroups.size());
+    }
+  }
+
+
+  @Test
+  public void testSplitter_mixed() throws IOException {
+    JSONObject message = getMessage();
+    for(String c : Iterables.concat(MIXED_CONFIGS, ImmutableList.of(tempVarStellarConfig_list))) {
+      EnrichmentConfig enrichmentConfig = JSONUtils.INSTANCE.load(c, EnrichmentConfig.class);
+      Assert.assertNotNull(enrichmentConfig.getEnrichmentConfigs().get("stellar"));
+      ConfigHandler handler = enrichmentConfig.getEnrichmentConfigs().get("stellar");
+      List<JSONObject> splits = Configs.STELLAR.splitByFields(message, null, x -> null, handler );
+      Assert.assertEquals(3, splits.size());
+      {
+        Map<String, Object> split = (Map<String, Object>) splits.get(0).get("group1");
+        Assert.assertEquals(2, split.size());
+        Assert.assertEquals("stellar_test", split.get("source.type"));
+        Assert.assertNull(split.get("stmt1"));
+      }
+      {
+        Map<String, Object> split = (Map<String, Object>) splits.get(1).get("group2");
+        Assert.assertEquals(1, split.size());
+        Assert.assertEquals("foo", split.get("string"));
+      }
+      {
+        Map<String, Object> split = (Map<String, Object>) splits.get(2).get("");
+        Assert.assertEquals(1, split.size());
+        Assert.assertEquals("stellar_test", split.get("source.type"));
+      }
+    }
+  }
+
+  @Test
+  public void testGetSubgroups_mixed() throws IOException {
+    for(String c : MIXED_CONFIGS) {
+      EnrichmentConfig enrichmentConfig = JSONUtils.INSTANCE.load(c, EnrichmentConfig.class);
+      Assert.assertNotNull(enrichmentConfig.getEnrichmentConfigs().get("stellar"));
+      ConfigHandler handler = enrichmentConfig.getEnrichmentConfigs().get("stellar");
+      List<String> subgroups = Configs.STELLAR.getSubgroups(handler);
+      Assert.assertEquals("group1", subgroups.get(0));
+      Assert.assertEquals("group2", subgroups.get(1));
+      Assert.assertEquals("", subgroups.get(2));
+      Assert.assertEquals(3, subgroups.size());
+    }
+  }
+}

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/configuration/StellarEnrichmentTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/configuration/StellarEnrichmentTest.java
@@ -1,0 +1,172 @@
+package org.apache.metron.common.configuration;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.collect.ImmutableList;
+import org.adrianwalker.multilinestring.Multiline;
+import org.apache.metron.common.utils.JSONUtils;
+import org.json.simple.JSONObject;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class StellarEnrichmentTest {
+  /**
+   {
+    "fieldMap": {
+      "stellar" : {
+        "config" : {
+          "stmt1" : "TO_UPPER(source.type)",
+          "stmt2" : "TO_LOWER(stmt1)",
+          "stmt3" : "TO_LOWER(string)"
+        }
+      }
+    }
+  }
+   */
+  @Multiline
+  public static String defaultStellarConfig_map;
+
+  /**
+   {
+    "fieldMap": {
+      "stellar" : {
+        "config" : [
+          "stmt1 := TO_UPPER(source.type)",
+          "stmt2 := TO_LOWER(stmt1)",
+          "stmt3 := TO_LOWER(string)"
+        ]
+      }
+    }
+  }
+   */
+  @Multiline
+  public static String defaultStellarConfig_list;
+  public static List<String> DEFAULT_CONFIGS = ImmutableList.of(defaultStellarConfig_list, defaultStellarConfig_map);
+
+/**
+   {
+    "fieldMap": {
+      "stellar" : {
+        "config" : {
+          "group1" : {
+            "stmt1" : "TO_UPPER(source.type)",
+            "stmt2" : "TO_LOWER(stmt1)"
+          },
+          "group2" : {
+            "stmt3" : "TO_LOWER(string)"
+          }
+        }
+      }
+    }
+  }
+   */
+  @Multiline
+  public static String groupedStellarConfig_map;
+
+  /**
+   {
+    "fieldMap": {
+      "stellar" : {
+        "config" : {
+          "group1" : [
+            "stmt1 := TO_UPPER(source.type)",
+            "stmt2 := TO_LOWER(stmt1)"
+          ],
+          "group2" : [
+            "stmt3 := TO_LOWER(string)"
+          ]
+        }
+      }
+    }
+  }
+   */
+  @Multiline
+  public static String groupedStellarConfig_list;
+  public static List<String> GROUPED_CONFIGS = ImmutableList.of(groupedStellarConfig_list, groupedStellarConfig_map);
+
+  /**
+   {
+    "fieldMap": {
+      "stellar" : {
+        "config" : {
+          "group1" : {
+            "stmt1" : "TO_UPPER(source.type)",
+            "stmt2" : "TO_LOWER(stmt1)"
+          },
+          "group2" : {
+            "stmt3" : "TO_LOWER(string)"
+          },
+          "stmt4" : "1 + 1",
+          "stmt5" : "FORMAT('%s', source.type)"
+        }
+      }
+    }
+  }
+   */
+  @Multiline
+  public static String mixedStellarConfig_map;
+
+  /**
+   {
+    "fieldMap": {
+      "stellar" : {
+        "config" : {
+          "group1" : [
+            "stmt1 := TO_UPPER(source.type)",
+            "stmt2 := TO_LOWER(stmt1)"
+          ],
+          "group2" : [
+            "stmt3 := TO_LOWER(string)"
+          ],
+          "stmt4" : "1 + 1",
+          "stmt5" : "FORMAT('%s', source.type)"
+        }
+      }
+    }
+  }
+   */
+  @Multiline
+  public static String mixedStellarConfig_list;
+  public static List<String> MIXED_CONFIGS = ImmutableList.of(mixedStellarConfig_list, mixedStellarConfig_map);
+
+  /**
+   {
+    "fieldMap": {
+      "stellar" : {
+        "config" : {
+          "group1" : [
+            "stmt1 := TO_UPPER(source.type)",
+            "stmt2 := TO_LOWER(stmt1)",
+            "stmt1 := null"
+          ],
+          "group2" : [
+            "stmt3 := TO_LOWER(string)"
+          ],
+          "stmt4" : "1 + 1",
+          "stmt5" : "FORMAT('%s', source.type)"
+        }
+      }
+    }
+  }
+   */
+  @Multiline
+  public static String tempVarStellarConfig_list;
+
+  /**
+   {
+    "string" : "foo"
+   ,"number" : 2
+   ,"source.type" : "stellar_test"
+   }
+   */
+  @Multiline
+  public static String message;
+
+  public static JSONObject getMessage() throws IOException {
+    Map<String, Object> ret = JSONUtils.INSTANCE.load(message, new TypeReference<Map<String, Object>>() {
+    });
+    return new JSONObject(ret);
+  }
+
+}

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/configuration/StellarEnrichmentTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/configuration/StellarEnrichmentTest.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.metron.common.configuration;
 
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/stellar/StellarAssignmentTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/stellar/StellarAssignmentTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.common.stellar;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StellarAssignmentTest {
+
+  @Test
+  public void testAssignment() {
+    for(String statement : ImmutableList.of( "foo := bar + grok"
+                                           , "foo   := bar + grok"
+                                           , "foo := bar + grok   "
+                                           )
+       )
+    {
+      StellarAssignment assignment = StellarAssignment.from(statement);
+      Assert.assertEquals("foo", assignment.getKey());
+      Assert.assertEquals("foo", assignment.getVariable());
+      Assert.assertEquals("bar + grok", assignment.getStatement());
+      Assert.assertEquals("bar + grok", assignment.getValue());
+    }
+  }
+
+  @Test
+  public void testNonAssignment() {
+    for(String statement : ImmutableList.of( "bar + grok"
+                                           , "  bar + grok"
+                                           , "bar + grok   "
+    )
+            )
+    {
+      StellarAssignment assignment = StellarAssignment.from(statement);
+      Assert.assertNull( assignment.getKey());
+      Assert.assertNull( assignment.getVariable());
+      Assert.assertEquals("bar + grok", assignment.getStatement());
+      Assert.assertEquals("bar + grok", assignment.getValue());
+    }
+  }
+
+  @Test(expected=UnsupportedOperationException.class)
+  public void testImmutability() {
+    StellarAssignment assignment = StellarAssignment.from("foo := bar");
+    assignment.setValue("myval");
+  }
+}

--- a/metron-platform/metron-enrichment/pom.xml
+++ b/metron-platform/metron-enrichment/pom.xml
@@ -40,6 +40,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.metron</groupId>
+            <artifactId>metron-common</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.metron</groupId>
             <artifactId>metron-storm-kafka</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/adapters/stellar/StellarAdapter.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/adapters/stellar/StellarAdapter.java
@@ -17,7 +17,6 @@
  */
 package org.apache.metron.enrichment.adapters.stellar;
 
-import com.google.common.collect.Iterables;
 import org.apache.metron.common.configuration.enrichment.SensorEnrichmentConfig;
 import org.apache.metron.common.configuration.enrichment.handler.ConfigHandler;
 import org.apache.metron.common.dsl.Context;
@@ -25,7 +24,6 @@ import org.apache.metron.common.dsl.MapVariableResolver;
 import org.apache.metron.common.dsl.StellarFunctions;
 import org.apache.metron.common.dsl.VariableResolver;
 import org.apache.metron.common.stellar.StellarProcessor;
-import org.apache.metron.common.stellar.shell.StellarShell;
 import org.apache.metron.common.utils.ConversionUtils;
 import org.apache.metron.enrichment.bolt.CacheKey;
 import org.apache.metron.enrichment.interfaces.EnrichmentAdapter;

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/EnrichmentJoinBolt.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/EnrichmentJoinBolt.java
@@ -55,7 +55,8 @@ public class EnrichmentJoinBolt extends JoinBolt<JSONObject> {
     if(fieldMap != null) {
       for (String enrichmentType : fieldMap.keySet()) {
         ConfigHandler handler = handlerMap.get(enrichmentType);
-        for(String subgroup : handler.getType().getSubgroups(handler.getConfig())) {
+        List<String> subgroups = handler.getType().getSubgroups(handler.getType().toConfig(handler.getConfig()));
+        for(String subgroup : subgroups) {
           streamIds.add(Joiner.on(":").join(enrichmentType, subgroup));
         }
       }

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/EnrichmentSplitterBolt.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/EnrichmentSplitterBolt.java
@@ -124,7 +124,7 @@ public class EnrichmentSplitterBolt extends SplitBolt<JSONObject> {
               .splitByFields( message
                       , fields
                       , field -> getKeyName(enrichmentType, field)
-                      , retriever.getConfig()
+                      , retriever
               );
       for(JSONObject eo : enrichmentObject) {
         eo.put(Constants.SENSOR_TYPE, sensorType);

--- a/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/adapters/stellar/StellarAdapterTest.java
+++ b/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/adapters/stellar/StellarAdapterTest.java
@@ -1,0 +1,134 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.enrichment.adapters.stellar;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.metron.common.configuration.StellarEnrichmentTest;
+import org.apache.metron.common.configuration.enrichment.EnrichmentConfig;
+import org.apache.metron.common.configuration.enrichment.handler.ConfigHandler;
+import org.apache.metron.common.dsl.Context;
+import org.apache.metron.common.dsl.MapVariableResolver;
+import org.apache.metron.common.dsl.VariableResolver;
+import org.apache.metron.common.stellar.StellarProcessor;
+import org.apache.metron.common.utils.JSONUtils;
+import org.json.simple.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StellarAdapterTest extends StellarEnrichmentTest {
+  StellarProcessor processor = new StellarProcessor();
+
+  private JSONObject enrich(JSONObject message, String field, ConfigHandler handler) {
+    VariableResolver resolver = new MapVariableResolver(message);
+    return StellarAdapter.process( message
+                                 , handler
+                                 , field
+                                 , 1000l
+                                 , processor
+                                 , resolver
+                                 , Context.EMPTY_CONTEXT()
+                                 );
+  }
+
+  @Test
+  public void test_default() throws Exception {
+    for(String c : DEFAULT_CONFIGS) {
+      JSONObject message = getMessage();
+      EnrichmentConfig enrichmentConfig = JSONUtils.INSTANCE.load(c, EnrichmentConfig.class);
+      Assert.assertNotNull(enrichmentConfig.getEnrichmentConfigs().get("stellar"));
+      ConfigHandler handler = enrichmentConfig.getEnrichmentConfigs().get("stellar");
+      JSONObject enriched = enrich(message, "", handler);
+      Assert.assertEquals("STELLAR_TEST", enriched.get("stmt1"));
+      Assert.assertEquals("stellar_test", enriched.get("stmt2"));
+      Assert.assertEquals("foo", enriched.get("stmt3"));
+      Assert.assertEquals(3, enriched.size());
+    }
+  }
+
+  @Test
+  public void test_grouped() throws Exception {
+    for(String c : GROUPED_CONFIGS) {
+      JSONObject message = getMessage();
+      EnrichmentConfig enrichmentConfig = JSONUtils.INSTANCE.load(c, EnrichmentConfig.class);
+      Assert.assertNotNull(enrichmentConfig.getEnrichmentConfigs().get("stellar"));
+      ConfigHandler handler = enrichmentConfig.getEnrichmentConfigs().get("stellar");
+      {
+        JSONObject enriched = enrich(message, "group1", handler);
+        Assert.assertEquals("STELLAR_TEST", enriched.get("stmt1"));
+        Assert.assertEquals("stellar_test", enriched.get("stmt2"));
+        Assert.assertEquals(2, enriched.size());
+      }
+      {
+        JSONObject enriched = enrich(message, "group2", handler);
+        Assert.assertEquals("foo", enriched.get("stmt3"));
+        Assert.assertEquals(1, enriched.size());
+      }
+    }
+  }
+
+  @Test
+  public void test_mixed() throws Exception {
+    for(String c : MIXED_CONFIGS) {
+      JSONObject message = getMessage();
+      EnrichmentConfig enrichmentConfig = JSONUtils.INSTANCE.load(c, EnrichmentConfig.class);
+      Assert.assertNotNull(enrichmentConfig.getEnrichmentConfigs().get("stellar"));
+      ConfigHandler handler = enrichmentConfig.getEnrichmentConfigs().get("stellar");
+      {
+        JSONObject enriched = enrich(message, "group1", handler);
+        Assert.assertEquals("STELLAR_TEST", enriched.get("stmt1"));
+        Assert.assertEquals("stellar_test", enriched.get("stmt2"));
+        Assert.assertEquals(2, enriched.size());
+      }
+      {
+        JSONObject enriched = enrich(message, "group2", handler);
+        Assert.assertEquals("foo", enriched.get("stmt3"));
+        Assert.assertEquals(1, enriched.size());
+      }
+      {
+        JSONObject enriched = enrich(message, "", handler);
+        Assert.assertEquals(2, enriched.get("stmt4"));
+        Assert.assertEquals("stellar_test", enriched.get("stmt5"));
+        Assert.assertEquals(2, enriched.size());
+      }
+    }
+  }
+
+  @Test
+  public void test_tempVariable() throws Exception {
+    JSONObject message = getMessage();
+    EnrichmentConfig enrichmentConfig = JSONUtils.INSTANCE.load(tempVarStellarConfig_list, EnrichmentConfig.class);
+    Assert.assertNotNull(enrichmentConfig.getEnrichmentConfigs().get("stellar"));
+    ConfigHandler handler = enrichmentConfig.getEnrichmentConfigs().get("stellar");
+    {
+      JSONObject enriched = enrich(message, "group1", handler);
+      Assert.assertEquals("stellar_test", enriched.get("stmt2"));
+      Assert.assertEquals(1, enriched.size());
+    }
+    {
+      JSONObject enriched = enrich(message, "group2", handler);
+      Assert.assertEquals("foo", enriched.get("stmt3"));
+      Assert.assertEquals(1, enriched.size());
+    }
+    {
+      JSONObject enriched = enrich(message, "", handler);
+      Assert.assertEquals(2, enriched.get("stmt4"));
+      Assert.assertEquals("stellar_test", enriched.get("stmt5"));
+      Assert.assertEquals(2, enriched.size());
+    }
+  }
+}

--- a/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/adapters/stellar/StellarAdapterTest.java
+++ b/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/adapters/stellar/StellarAdapterTest.java
@@ -38,7 +38,7 @@ public class StellarAdapterTest extends StellarEnrichmentTest {
     return StellarAdapter.process( message
                                  , handler
                                  , field
-                                 , 1000l
+                                 , 1000L
                                  , processor
                                  , resolver
                                  , Context.EMPTY_CONTEXT()


### PR DESCRIPTION
## Contributor Comments
Currently, stellar enrichments are specified by a map associating fields with the stellar expressions associated with the fields. There is a significant downside here in that you cannot update previously assigned fields. For instance, the following cannot be represented currently:
```
 "fieldMap": {
       ...
      "stellar" : {
        "config" : {
          "hostname" : "if ENDS_WITH(hostname, '.') then CHOP(hostname) else hostname",
          "hostname" : "TO_LOWER(hostname)"
        }
      }
    }
```
This would now be allowed thusly:
```
"fieldMap": {
       ...
      "stellar" : {
        "config" : [
          "hostname := if ENDS_WITH(hostname, '.') then CHOP(hostname) else hostname",
          "hostname := TO_LOWER(hostname)"
        ]
      }
    }
```
A consequent of this deficiency is that we also cannot use temporary variables and unset them after their use inside an enrichment group.

The proposed change is to allow users to use lists of strings representing stellar expression assignments with the same syntax as the Stellar REPL. This would be as an alternative to maps, but the map syntax would also be supported for legacy.

## Test plan
* Follow the instructions located [here](https://github.com/apache/metron/tree/master/metron-platform/metron-enrichment#example-enrichment-via-stellar) to ensure no regressions
* Adjust the configuration for `$METRON_HOME/config/zookeeper/enrichments/squid.json` to the following and run data through the topologies again:
```
{
 "enrichment" : {
   "fieldMap": {
     "stellar" : {
       "config" : {
         "numeric" : [
                     "foo := 1 + 1",
                     "grok := foo + 3"
                     ]
         ,"ALL_CAPS" : "TO_UPPER(source.type)"
       }
     }
    }
 },
 "threatIntel" : {
   "fieldMap":{
    "stellar" : {
       "config" : [
         "bar := TO_UPPER(source.type)"
       ]
     } 
   },
   "triageConfig" : {
   }
 }
}
```
  * Ensure that each message has `ALL_CAPS`, `foo`, `grok` and `bar` fields.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [ ] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root incubating-metron folder via:
  ```
  mvn -q clean integration-test install && build_utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.

