### PR TITLE
METRON-979 markdown errors in site-book, part 3

### DIFF
--- a/metron-deployment/Kerberos-manual-setup.md
+++ b/metron-deployment/Kerberos-manual-setup.md
@@ -381,11 +381,7 @@ Push Data
 
     ```
     cat sample-bro.txt | ${KAFKA_HOME}/kafka-broker/bin/kafka-console-producer.sh \
-<<<<<<< HEAD
             --broker-list ${BROKERLIST} \
-=======
-            --broker-list ${BROKERLIST}
->>>>>>> d550b9eff34d931aeae7151713c0e07f28719d4c
             --security-protocol SASL_PLAINTEXT \
             --topic bro
     ```


### PR DESCRIPTION
## Contributor Comments
Due to an integration error on my part, one editorial glitch remains, in the form of an unresolved merge fragment in metron-deployment/Kerberos-manual-setup.md. This PR is to fix this.

## Pull Request Checklist

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes: NA

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? 

