### PR TITLE
METRON-995: Temporary variables in stellar enrichments which are maps do not function as expected

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/enrichment/handler/StellarConfig.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/enrichment/handler/StellarConfig.java
@@ -81,10 +81,10 @@ public class StellarConfig implements Config {
   {
     StellarProcessor processor = new StellarProcessor();
     List<JSONObject> messages = new ArrayList<>();
-    Map<String, String> defaultStellarStatementGroup = new HashMap<>();
+    List<String> defaultStellarStatementGroup = new ArrayList<>();
     for(Map.Entry<String, Object> kv : config) {
       if(kv.getValue() instanceof String) {
-        defaultStellarStatementGroup.put(kv.getKey(), (String)kv.getValue());
+        defaultStellarStatementGroup.add((String)kv.getValue());
       }
       else if(kv.getValue() instanceof Map) {
         JSONObject ret = new JSONObject();

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/enrichment/handler/StellarConfig.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/enrichment/handler/StellarConfig.java
@@ -17,18 +17,18 @@
  */
 package org.apache.metron.common.configuration.enrichment.handler;
 
-import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
+import com.google.common.base.Joiner;
 import org.apache.metron.common.stellar.StellarAssignment;
 import org.apache.metron.common.stellar.StellarProcessor;
 import org.json.simple.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.function.Function;
 
 public class StellarConfig implements Config {
-
+  protected static final Logger _LOG = LoggerFactory.getLogger(StellarConfig.class);
   @Override
   public List<String> getSubgroups(Iterable<Map.Entry<String, Object>> config) {
     boolean includeEmpty = false;
@@ -103,6 +103,7 @@ public class StellarConfig implements Config {
       ret.put("", getMessage(getFields(processor, defaultStellarStatementGroup), message));
       messages.add(ret);
     }
+    _LOG.debug("Stellar enrichment split: {}", messages );
     return messages;
   }
 

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/StellarCompiler.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/StellarCompiler.java
@@ -348,17 +348,6 @@ public class StellarCompiler extends StellarBaseListener {
     }, DeferredFunction.class, context));
   }
 
-  /**
-   * {@inheritDoc}
-   * <p>
-   * <p>The default implementation does nothing.</p>
-   *
-   * @param ctx
-   */
-  @Override
-  public void enterEveryRule(ParserRuleContext ctx) {
-    super.enterEveryRule(ctx);
-  }
 
   @Override
   public void exitVariable(StellarParser.VariableContext ctx) {

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/StellarCompiler.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/StellarCompiler.java
@@ -17,6 +17,7 @@
  */
 package org.apache.metron.common.stellar;
 
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.metron.common.dsl.Context;
 import org.apache.metron.common.dsl.Token;
@@ -345,6 +346,18 @@ public class StellarCompiler extends StellarBaseListener {
     Token<Boolean> arg = (Token<Boolean>) popDeque(tokenDeque);
     tokenDeque.push(new Token<>(!arg.getValue(), Boolean.class, context));
     }, DeferredFunction.class, context));
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p>
+   * <p>The default implementation does nothing.</p>
+   *
+   * @param ctx
+   */
+  @Override
+  public void enterEveryRule(ParserRuleContext ctx) {
+    super.enterEveryRule(ctx);
   }
 
   @Override

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/configuration/StellarEnrichmentTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/configuration/StellarEnrichmentTest.java
@@ -59,7 +59,25 @@ public class StellarEnrichmentTest {
    */
   @Multiline
   public static String defaultStellarConfig_list;
-  public static List<String> DEFAULT_CONFIGS = ImmutableList.of(defaultStellarConfig_list, defaultStellarConfig_map);
+
+  /**
+   {
+    "fieldMap": {
+      "stellar" : {
+        "config" : [
+          "stmt1 := TO_UPPER(source.type)",
+          "stmt4 := TO_LOWER(string)",
+          "stmt2 := TO_LOWER(stmt1)",
+          "stmt3 := TO_LOWER(string)",
+          "stmt4 := null"
+        ]
+      }
+    }
+  }
+   */
+  @Multiline
+  public static String defaultStellarConfig_listWithTemp;
+  public static List<String> DEFAULT_CONFIGS = ImmutableList.of(defaultStellarConfig_list, defaultStellarConfig_map, defaultStellarConfig_listWithTemp);
 
 /**
    {
@@ -100,7 +118,29 @@ public class StellarEnrichmentTest {
    */
   @Multiline
   public static String groupedStellarConfig_list;
-  public static List<String> GROUPED_CONFIGS = ImmutableList.of(groupedStellarConfig_list, groupedStellarConfig_map);
+
+  /**
+   {
+    "fieldMap": {
+      "stellar" : {
+        "config" : {
+          "group1" : [
+            "stmt1 := TO_UPPER(source.type)",
+            "stmt2 := TO_LOWER(stmt1)"
+          ],
+          "group2" : [
+            "stmt3 := TO_LOWER(string)",
+            "stmt4 := TO_LOWER(string)",
+            "stmt4 := null"
+          ]
+        }
+      }
+    }
+  }
+   */
+  @Multiline
+  public static String groupedStellarConfig_listWithTemp;
+  public static List<String> GROUPED_CONFIGS = ImmutableList.of(groupedStellarConfig_listWithTemp, groupedStellarConfig_list, groupedStellarConfig_map);
 
   /**
    {

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/stellar/StellarTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/stellar/StellarTest.java
@@ -183,7 +183,12 @@ public class StellarTest {
       Assert.assertEquals(ImmutableSet.of("one", "two")
                          , processor.variablesUsed("if 1 < 2 then one else two"));
     }
+    {
+      Assert.assertEquals(ImmutableSet.of("bar")
+                         , processor.variablesUsed("MAP_GET('foo', { 'foo' : bar})"));
+    }
   }
+
 
   @Test
   public void testFunctionEmptyArgs() {

--- a/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/integration/EnrichmentIntegrationTest.java
+++ b/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/integration/EnrichmentIntegrationTest.java
@@ -260,6 +260,11 @@ public class EnrichmentIntegrationTest extends BaseIntegrationTest {
     Assert.assertNotNull(jsonDoc.get(DST_IP));
 
     Assert.assertNotNull(jsonDoc.get("ALL_CAPS"));
+    Assert.assertNotNull(jsonDoc.get("map.blah"));
+    Assert.assertNull(jsonDoc.get("map"));
+    Assert.assertNotNull(jsonDoc.get("one"));
+    Assert.assertEquals(1, jsonDoc.get("one"));
+    Assert.assertEquals(1, jsonDoc.get("map.blah"));
     Assert.assertNotNull(jsonDoc.get("foo"));
     Assert.assertEquals("TEST", jsonDoc.get("ALL_CAPS"));
     Assert.assertNotNull(jsonDoc.get("bar"));

--- a/metron-platform/metron-integration-test/src/main/config/zookeeper/enrichments/test.json
+++ b/metron-platform/metron-integration-test/src/main/config/zookeeper/enrichments/test.json
@@ -16,7 +16,9 @@
       "stellar" : {
         "config" : {
           "numeric" : {
-                      "foo": "1 + 1"
+                      "map" : "{ 'blah' : 1}"
+                      ,"one" : "MAP_GET('blah', map)"
+                      ,"foo": "1 + 1"
                       }
           ,"ALL_CAPS" : "TO_UPPER(source.type)"
           ,"src_enrichment" : {


### PR DESCRIPTION
## Contributor Comments
If you construct a variable which returns a map in a stellar enrichment, it is not able to be used in statements afterwards due to the fact that we explode the map.
For instance, an enrichment like so:
```
foo := { 'foo' : 7}
foo_num := MAP_GET('foo', foo)
foo := null
```
would yield the following fields:
* `foo.foo == 7` 
* `foo_num := null` 

What we would prefer is just `foo_num == 7` because we've explicitly set the map variable to `null` and removed it.  As a policy, we should only explode the fields which are maps that are around at the end of the enrichments. Also, the map itself should be available to be used in downstream enrichments.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root incubating-metron folder via:
  ```
  mvn -q clean integration-test install && build_utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.

