### PR TITLE
METRON-1003 ParserUtil parses dates incorrect

### DIFF
--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/utils/ParserUtils.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/utils/ParserUtils.java
@@ -46,6 +46,17 @@ public class ParserUtils {
     return tempFile;
   }
 
+  /**
+   * Converts passed month (human short form), day, time and current year
+   * to milliseconds since epoch
+   *
+   * @param m                   Month in human short form (3 letters) (MMM)
+   * @param d                   Day (dd)
+   * @param ts                  Time (HH:mm:ss)
+   * @param adjust_timezone     If True set GMT timezone for input time
+   * @return                    Number of milliseconds since epoch
+   * @exception ParseException  If a date parsing error occured
+   */
   public static Long convertToEpoch(String m, String d, String ts,
                                     boolean adjust_timezone) throws ParseException {
     d = d.trim();

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/utils/ParserUtils.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/utils/ParserUtils.java
@@ -55,7 +55,7 @@ public class ParserUtils {
     Date date = new SimpleDateFormat("MMM", Locale.ENGLISH).parse(m);
     Calendar cal = Calendar.getInstance();
     cal.setTime(date);
-    String month = String.valueOf(cal.get(Calendar.MONTH));
+    String month = String.valueOf(cal.get(Calendar.MONTH) + 1);
     int year = Calendar.getInstance().get(Calendar.YEAR);
     if (month.length() <= 2) {
       month = "0" + month;

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/utils/ParserUtilsTest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/utils/ParserUtilsTest.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.metron.parsers.utils;
+
+import junit.framework.TestCase;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import java.text.ParseException;
+
+public class ParserUtilsTest extends TestCase {
+
+    public void testConvertToEpoch() throws ParseException {
+        Boolean adjustTimezone = true;
+        String[] timeToTest = {"Mar", "2", "05:24:39"};
+        int year = Calendar.getInstance().get(Calendar.YEAR);
+        String timeToTestWithYear = String.valueOf(year) + " " + timeToTest[0] + " " + timeToTest[1] + " " + timeToTest[2];
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy MMM d HH:mm:ss", Locale.ENGLISH);
+        sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+        Date date = sdf.parse(timeToTestWithYear);
+        Long expectedTs = date.getTime();
+        Long ts = ParserUtils.convertToEpoch(timeToTest[0], timeToTest[1], timeToTest[2], adjustTimezone);
+        assertEquals(expectedTs, ts);
+    }
+}


### PR DESCRIPTION
## Contributor Comments
org.apache.metron.parsers.utils.ParserUtils.convertToEpoch parses dates incorrectly.
It invokes method "get(Calendar.MONTH)" from  Calendar object but not increase result value.
According to documentation months are started from 0: https://docs.oracle.com/javase/7/docs/api/java/util/Calendar.html#MONTH)

**Steps to reproduce:**
Import ParserUtils and call convertToEpoch method with any parameters.
For example:
`Long ts = ParserUtils.convertToEpoch("Mar", "2", "05:24:39", true);`
Method will return **1486013079000**. And after converting to human format: 
**Thu, 02 Feb 2017 05:24:39 GMT**
Got "Feb" instead of "Mar"

Example of code for manual testing:
```
import org.apache.metron.parsers.utils.ParserUtils;
import java.text.ParseException;

class Main {
        public static void main(String[] argv) throws ParseException {
                Long ts = ParserUtils.convertToEpoch("Mar", "2", "05:24:39", true);
                System.out.println(ts);
        }
}
```
To run:
```
javac -cp ~/incubator-metron/metron-platform/metron-parsers/target/classes/  Main.java
java -classpath ~/incubator-metron/metron-platform/metron-parsers/target/classes/:. Main
```
## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root incubating-metron folder via:
  ```
  mvn -q clean integration-test install && build_utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.

