### PR TITLE
METRON-1006 Remove Incubator DISCLAIMER file and fix Release Process doc

### DIFF
--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,7 +1,0 @@
-Apache Metron is an effort undergoing incubation at The Apache Software
-Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is required
-of all newly accepted projects until a further review indicates that the
-infrastructure, communications, and decision making process have stabilized in
-a manner consistent with other successful ASF projects. While incubation status
-is not necessarily a reflection of the completeness or stability of the code,
-it does indicate that the project has yet to be fully endorsed by the ASF.


### PR DESCRIPTION
## Contributor Comments
The Release Process document at https://cwiki.apache.org/confluence/display/METRON/Release+Process
currently states that a file named DISCLAIMER is a required artifact in the release package.  The contents of this file are:
```
Apache Metron is an effort undergoing incubation at The Apache Software
Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is required
of all newly accepted projects until a further review indicates that the
infrastructure, communications, and decision making process have stabilized in
a manner consistent with other successful ASF projects. While incubation status
is not necessarily a reflection of the completeness or stability of the code,
it does indicate that the project has yet to be fully endorsed by the ASF.
```
This clearly seems to be left over from our incubation days.  I propose to entirely remove the DISCLAIMER file, from the source tree and from the Release Process document.

The usual disclaimers remain in the LICENSE file, of course.


## Pull Request Checklist

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes: NA

### For documentation related changes: NA
