### PR TITLE
METRON-1021 increment metron version number to 0.4.1 in poms etc

### DIFF
--- a/metron-analytics/metron-maas-common/pom.xml
+++ b/metron-analytics/metron-maas-common/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.metron</groupId>
     <artifactId>metron-analytics</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1</version>
   </parent>
   <artifactId>metron-maas-common</artifactId>
   <url>https://metron.apache.org/</url>

--- a/metron-analytics/metron-maas-service/pom.xml
+++ b/metron-analytics/metron-maas-service/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.metron</groupId>
     <artifactId>metron-analytics</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1</version>
   </parent>
   <artifactId>metron-maas-service</artifactId>
   <url>https://metron.apache.org/</url>

--- a/metron-analytics/metron-profiler-client/README.md
+++ b/metron-analytics/metron-profiler-client/README.md
@@ -362,7 +362,7 @@ These instructions step through the process of using the Stellar Client API on a
 To validate that everything is working, login to the server hosting Metron.  We will use the Stellar Shell to replicate the execution environment of Stellar running in a Storm topology, like Metron's Parser or Enrichment topology.  Replace 'node1:2181' with the URL to a Zookeeper Broker.  
 
 ```
-[root@node1 0.3.1]# bin/stellar -z node1:2181
+[root@node1 0.4.1]# bin/stellar -z node1:2181
 Stellar, Go!
 Please note that functions are loading lazily in the background and will be unavailable until loaded fully.
 {es.clustername=metron, es.ip=node1, es.port=9300, es.date.format=yyyy.MM.dd.HH}

--- a/metron-analytics/metron-profiler-client/pom.xml
+++ b/metron-analytics/metron-profiler-client/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-analytics</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <artifactId>metron-profiler-client</artifactId>
     <url>https://metron.apache.org/</url>

--- a/metron-analytics/metron-profiler-common/pom.xml
+++ b/metron-analytics/metron-profiler-common/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>metron-analytics</artifactId>
         <groupId>org.apache.metron</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <artifactId>metron-profiler-common</artifactId>
     <url>https://metron.apache.org/</url>

--- a/metron-analytics/metron-profiler/pom.xml
+++ b/metron-analytics/metron-profiler/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-analytics</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <artifactId>metron-profiler</artifactId>
     <url>https://metron.apache.org/</url>

--- a/metron-analytics/metron-statistics/pom.xml
+++ b/metron-analytics/metron-statistics/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>metron-analytics</artifactId>
         <groupId>org.apache.metron</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <artifactId>metron-statistics</artifactId>
     <url>https://metron.apache.org/</url>

--- a/metron-analytics/pom.xml
+++ b/metron-analytics/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>org.apache.metron</groupId>
 		<artifactId>Metron</artifactId>
-		<version>0.4.0</version>
+		<version>0.4.1</version>
 	</parent>
 	<description>Stream analytics for Metron</description>
 	<url>https://metron.apache.org/</url>

--- a/metron-deployment/Kerberos-manual-setup.md
+++ b/metron-deployment/Kerberos-manual-setup.md
@@ -30,7 +30,7 @@ Setup
     export BROKERLIST=node1:6667
     export HDP_HOME="/usr/hdp/current"
     export KAFKA_HOME="${HDP_HOME}/kafka-broker"
-    export METRON_VERSION="0.4.0"
+    export METRON_VERSION="0.4.1"
     export METRON_HOME="/usr/metron/${METRON_VERSION}"
     ```
 

--- a/metron-deployment/amazon-ec2/conf/defaults.yml
+++ b/metron-deployment/amazon-ec2/conf/defaults.yml
@@ -67,7 +67,7 @@ num_partitions: 3
 retention_in_gb: 25
 
 # metron variables
-metron_version: 0.4.0
+metron_version: 0.4.1
 metron_directory: /usr/metron/{{ metron_version }}
 pcapservice_port: 8081
 

--- a/metron-deployment/inventory/full-dev-platform/group_vars/all
+++ b/metron-deployment/inventory/full-dev-platform/group_vars/all
@@ -40,7 +40,7 @@ threatintel_hbase_table: threatintel
 enrichment_hbase_table: enrichment
 
 # metron
-metron_version: 0.4.0
+metron_version: 0.4.1
 metron_directory: /usr/metron/{{ metron_version }}
 bro_version: "2.4.1"
 fixbuf_version: "1.7.1"

--- a/metron-deployment/inventory/quick-dev-platform/group_vars/all
+++ b/metron-deployment/inventory/quick-dev-platform/group_vars/all
@@ -39,7 +39,7 @@ threatintel_hbase_table: threatintel
 enrichment_hbase_table: enrichment
 
 # metron
-metron_version: 0.4.0
+metron_version: 0.4.1
 metron_directory: /usr/metron/{{ metron_version }}
 bro_version: "2.4.1"
 fixbuf_version: "1.7.1"

--- a/metron-deployment/packaging/ambari/metron-mpack/pom.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/pom.xml
@@ -20,13 +20,13 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.metron.packaging.mpacks</groupId>
     <artifactId>metron_mpack</artifactId>
-    <version>0.4.0.0</version>
+    <version>0.4.1.0</version>
     <name>Metron Ambari Management Pack</name>
 
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-deployment</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
         <relativePath>../../..</relativePath>
     </parent>
 

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/mpack.json
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/mpack.json
@@ -1,7 +1,7 @@
 {
   "type": "full-release",
   "name": "metron-ambari.mpack",
-  "version": "0.4.0.0",
+  "version": "0.4.1.0",
   "description": "Ambari Management Pack for Apache Metron",
   "prerequisites": {
     "min-ambari-version": "2.4.0.0",

--- a/metron-deployment/packaging/docker/rpm-docker/SPECS/metron.spec
+++ b/metron-deployment/packaging/docker/rpm-docker/SPECS/metron.spec
@@ -428,7 +428,7 @@ chkconfig --del metron-management-ui
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 %changelog
-* Thu Jun 29 2017 Apache Metron <dev@metron.apache.org> - 0.4.0+1
+* Thu Jun 29 2017 Apache Metron <dev@metron.apache.org> - 0.4.1
 - Add Metron Management jar 
 * Thu May 15 2017 Apache Metron <dev@metron.apache.org> - 0.4.0
 - Added Management UI

--- a/metron-deployment/packaging/docker/rpm-docker/pom.xml
+++ b/metron-deployment/packaging/docker/rpm-docker/pom.xml
@@ -21,11 +21,11 @@
     <artifactId>metron-rpm</artifactId>
     <packaging>pom</packaging>
     <name>metron-rpm</name>
-    <version>0.4.0</version>
+    <version>0.4.1</version>
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-deployment</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
         <relativePath>../../..</relativePath>
     </parent>
     <description>RPM Builder for Apache Metron</description>

--- a/metron-deployment/playbooks/docker_probe_install.yml
+++ b/metron-deployment/playbooks/docker_probe_install.yml
@@ -30,7 +30,7 @@
 
 - hosts: sensors
   vars:
-    metron_version: 0.4.0
+    metron_version: 0.4.1
     metron_directory: /usr/metron/{{ metron_version }}
     bro_version: "2.4.1"
     fixbuf_version: "1.7.1"

--- a/metron-deployment/pom.xml
+++ b/metron-deployment/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>Metron</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <description>Building and deploying Metron</description>
     <url>https://metron.apache.org/</url>

--- a/metron-deployment/roles/ambari_master/defaults/main.yml
+++ b/metron-deployment/roles/ambari_master/defaults/main.yml
@@ -16,4 +16,4 @@
 #
 ---
 ambari_server_mem: 2048
-ambari_mpack_version: 0.4.0.0
+ambari_mpack_version: 0.4.1.0

--- a/metron-deployment/roles/ambari_master/tasks/main.yml
+++ b/metron-deployment/roles/ambari_master/tasks/main.yml
@@ -44,7 +44,7 @@
     dest: /tmp
 
 - name: Install MPack on Ambari Host
-  shell: ambari-server install-mpack --mpack=/tmp/metron_mpack-0.4.0.0.tar.gz
+  shell: ambari-server install-mpack --mpack=/tmp/metron_mpack-0.4.1.0.tar.gz
   args:
     creates: /var/lib/ambari-server/resources/mpacks/metron-ambari.mpack-{{ ambari_mpack_version }}/addon-services
 

--- a/metron-deployment/roles/metron_pcapservice/defaults/main.yml
+++ b/metron-deployment/roles/metron_pcapservice/defaults/main.yml
@@ -15,7 +15,7 @@
 #  limitations under the License.
 #
 ---
-metron_version: 0.4.0
+metron_version: 0.4.1
 metron_directory: /usr/metron/{{ metron_version }}
 pcapservice_jar_name: metron-api-{{ metron_version }}.jar
 pcapservice_jar_src: "{{ playbook_dir }}/../../metron-platform/metron-api/target/{{ pcapservice_jar_name }}"

--- a/metron-docker/pom.xml
+++ b/metron-docker/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>Metron</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <description>Metron Docker</description>
     <url>https://metron.apache.org/</url>

--- a/metron-interface/metron-config/package.json
+++ b/metron-interface/metron-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metron-management-ui",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "Apache 2.0",
   "config": {
     "node_ace": "node_modules/ace-builds/src-min-noconflict/"

--- a/metron-interface/metron-config/pom.xml
+++ b/metron-interface/metron-config/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-interface</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <artifactId>metron-config</artifactId>
     <url>https://metron.apache.org/</url>

--- a/metron-interface/metron-config/scripts/package.json
+++ b/metron-interface/metron-config/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metron-management-ui-web-server",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Metron management ui web server",
   "main": "server.js",
   "dependencies": {

--- a/metron-interface/metron-rest-client/pom.xml
+++ b/metron-interface/metron-rest-client/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-interface</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <artifactId>metron-rest-client</artifactId>
     <url>https://metron.apache.org/</url>

--- a/metron-interface/metron-rest/pom.xml
+++ b/metron-interface/metron-rest/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-interface</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <artifactId>metron-rest</artifactId>
     <url>https://metron.apache.org/</url>

--- a/metron-interface/metron-rest/src/main/resources/application.yml
+++ b/metron-interface/metron-rest/src/main/resources/application.yml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 metron:
-  version: 0.4.0
+  version: 0.4.1
 
 logging:
   level:

--- a/metron-interface/pom.xml
+++ b/metron-interface/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>Metron</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <description>Interfaces for Metron</description>
     <url>https://metron.apache.org/</url>

--- a/metron-platform/README.md
+++ b/metron-platform/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 # Current Build
 
-The latest build of metron-platform is 0.4.0.
+The latest build of metron-platform is 0.4.1.
 
 We are still in the process of merging/porting additional features from our production code base into this open source release. This release will be followed by a number of additional beta releases until the port is complete. We will also work on getting additional documentation and user/developer guides to the community as soon as we can. At this time we offer no support for the beta software, but will try to respond to requests as promptly as we can.
 

--- a/metron-platform/elasticsearch-shaded/pom.xml
+++ b/metron-platform/elasticsearch-shaded/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>metron-platform</artifactId>
         <groupId>org.apache.metron</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>elasticsearch-shaded</artifactId>

--- a/metron-platform/metron-api/pom.xml
+++ b/metron-platform/metron-api/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.apache.metron</groupId>
 		<artifactId>metron-platform</artifactId>
-		<version>0.4.0</version>
+		<version>0.4.1</version>
 	</parent>
 	<artifactId>metron-api</artifactId>
     <name>metron-api</name>

--- a/metron-platform/metron-common/pom.xml
+++ b/metron-platform/metron-common/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-platform</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <artifactId>metron-common</artifactId>
     <name>metron-common</name>

--- a/metron-platform/metron-data-management/pom.xml
+++ b/metron-platform/metron-data-management/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-platform</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <artifactId>metron-data-management</artifactId>
     <name>metron-data-management</name>

--- a/metron-platform/metron-elasticsearch/pom.xml
+++ b/metron-platform/metron-elasticsearch/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-platform</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <artifactId>metron-elasticsearch</artifactId>
     <name>metron-elasticsearch</name>

--- a/metron-platform/metron-enrichment/pom.xml
+++ b/metron-platform/metron-enrichment/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-platform</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <artifactId>metron-enrichment</artifactId>
     <name>metron-enrichment</name>

--- a/metron-platform/metron-hbase/pom.xml
+++ b/metron-platform/metron-hbase/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-platform</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <artifactId>metron-hbase</artifactId>
     <name>metron-hbase</name>

--- a/metron-platform/metron-indexing/pom.xml
+++ b/metron-platform/metron-indexing/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-platform</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <artifactId>metron-indexing</artifactId>
     <name>metron-indexing</name>

--- a/metron-platform/metron-integration-test/pom.xml
+++ b/metron-platform/metron-integration-test/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.metron</groupId>
     <artifactId>metron-platform</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1</version>
   </parent>
   <artifactId>metron-integration-test</artifactId>
   <name>metron-integration-test</name>

--- a/metron-platform/metron-management/pom.xml
+++ b/metron-platform/metron-management/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-platform</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <artifactId>metron-management</artifactId>
     <name>metron-management</name>

--- a/metron-platform/metron-parsers/pom.xml
+++ b/metron-platform/metron-parsers/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-platform</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <artifactId>metron-parsers</artifactId>
     <name>metron-parsers</name>

--- a/metron-platform/metron-pcap-backend/pom.xml
+++ b/metron-platform/metron-pcap-backend/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-platform</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <artifactId>metron-pcap-backend</artifactId>
     <name>metron-pcap-backend</name>

--- a/metron-platform/metron-pcap-backend/src/main/scripts/pcap_zeppelin_run.sh
+++ b/metron-platform/metron-pcap-backend/src/main/scripts/pcap_zeppelin_run.sh
@@ -17,7 +17,7 @@
 # limitations under the License.
 # 
 
-METRON_VERSION=0.4.0
+METRON_VERSION=0.4.1
 METRON_HOME=${METRON_HOME:-"/usr/metron/$METRON_VERSION"}
 DATE_FORMAT=${DATE_FORMAT:-"yyyyMMdd"}
 USER=$(whoami)

--- a/metron-platform/metron-pcap/pom.xml
+++ b/metron-platform/metron-pcap/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-platform</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <artifactId>metron-pcap</artifactId>
     <name>metron-pcap</name>

--- a/metron-platform/metron-solr/pom.xml
+++ b/metron-platform/metron-solr/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-platform</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <artifactId>metron-solr</artifactId>
     <name>metron-solr</name>

--- a/metron-platform/metron-storm-kafka-override/pom.xml
+++ b/metron-platform/metron-storm-kafka-override/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-platform</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <artifactId>metron-storm-kafka-override</artifactId>
     <name>metron-storm-kafka-override</name>

--- a/metron-platform/metron-storm-kafka/pom.xml
+++ b/metron-platform/metron-storm-kafka/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-platform</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <artifactId>metron-storm-kafka</artifactId>
     <name>metron-storm-kafka</name>

--- a/metron-platform/metron-test-utilities/pom.xml
+++ b/metron-platform/metron-test-utilities/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.metron</groupId>
     <artifactId>metron-platform</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1</version>
   </parent>
   <artifactId>metron-test-utilities</artifactId>
   <name>metron-test-utilities</name>

--- a/metron-platform/metron-writer/pom.xml
+++ b/metron-platform/metron-writer/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-platform</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <artifactId>metron-writer</artifactId>
     <name>metron-writer</name>

--- a/metron-platform/pom.xml
+++ b/metron-platform/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>org.apache.metron</groupId>
 		<artifactId>Metron</artifactId>
-		<version>0.4.0</version>
+		<version>0.4.1</version>
 	</parent>
 	<description>Stream analytics for Metron</description>
 	<url>https://metron.apache.org/</url>

--- a/metron-stellar/pom.xml
+++ b/metron-stellar/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>Metron</artifactId>
         <groupId>org.apache.metron</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <description>DSL for stream analytics</description>
     <url>https://metron.apache.org/</url>

--- a/metron-stellar/stellar-common/3rdPartyStellar.md
+++ b/metron-stellar/stellar-common/3rdPartyStellar.md
@@ -17,7 +17,7 @@ since the epoch.  I notice that there's nothing like that currently in Metron,
 so I embark on the adventure of adding it for my cluster.
 
 I will presume that you have an installed Metron into your local maven repo via `mvn install` .  In the future, when we publish to a maven repo,
-you will not need this.  I will depend on 0.4.0 for the
+you will not need this.  I will depend on 0.4.1 for the
 purpose of this demonstration
 
 ### Hack, Hack, Hack
@@ -49,7 +49,7 @@ First, we should depend on `metron-common` and we can do that by adjusting the `
     <dependency>
       <groupId>org.apache.metron</groupId>
       <artifactId>metron-common</artifactId>
-      <version>0.4.0</version>
+      <version>0.4.1</version>
       <!-- NOTE: We will want to depend on the deployed common on the classpath. -->
       <scope>provided</scope>
     </dependency>

--- a/metron-stellar/stellar-common/README.md
+++ b/metron-stellar/stellar-common/README.md
@@ -987,7 +987,7 @@ This path is a comma separated list of
 ```json
 {
  ...
-  "stellar.function.paths" : "hdfs://node1:8020/apps/metron/stellar/metron-management-0.4.0.jar, hdfs://node1:8020/apps/metron/3rdparty/.*.jar"
+  "stellar.function.paths" : "hdfs://node1:8020/apps/metron/stellar/metron-management-0.4.1.jar, hdfs://node1:8020/apps/metron/3rdparty/.*.jar"
 }
 ```
 

--- a/metron-stellar/stellar-common/pom.xml
+++ b/metron-stellar/stellar-common/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>metron-stellar</artifactId>
         <groupId>org.apache.metron</groupId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </parent>
     <artifactId>stellar-common</artifactId>
     <name>stellar-common</name>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.metron</groupId>
     <artifactId>Metron</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1</version>
     <packaging>pom</packaging>
     <name>Metron</name>
     <description>Metron Top Level Project</description>

--- a/site-book/pom.xml
+++ b/site-book/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>org.apache.metron</groupId>
 		<artifactId>Metron</artifactId>
-		<version>0.4.0</version>
+		<version>0.4.1</version>
 	</parent>
 	<description>User Documentation for Metron</description>
 	<url>https://metron.apache.org/</url>


### PR DESCRIPTION
## Contributor Comments
Consistent with proposed post-release actions, incrementing the minor release number to 0.4.1, so that going forward, builds with additional commits cannot be mistaken for the recently released 0.4.0 release.

I built, ran all tests, and brought it up briefly in full-dev.  Seems okay.  Artifacts have appropriate version numbers.

## Pull Request Checklist

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

### For code changes:
- [NA] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [NA] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root incubating-metron folder via:
  ```
  mvn -q clean integration-test install && build_utils/verify_licenses.sh 
  ```

- [NA] Have you written or updated unit tests and or integration tests to verify your changes?
- [NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes: 
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? 
