### PR TITLE
METRON-1044: Disabled writers are not acking messages

### DIFF
--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/BulkWriterComponent.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/BulkWriterComponent.java
@@ -115,6 +115,7 @@ public class BulkWriterComponent<MESSAGE_T> {
                    ) throws Exception
   {
     if(!configurations.isEnabled(sensorType)) {
+      collector.ack(tuple);
       return;
     }
     int batchSize = configurations.getBatchSize(sensorType);

--- a/metron-platform/metron-writer/src/test/java/org/apache/metron/writer/BulkWriterComponentTest.java
+++ b/metron-platform/metron-writer/src/test/java/org/apache/metron/writer/BulkWriterComponentTest.java
@@ -118,6 +118,20 @@ public class BulkWriterComponentTest {
   }
 
   @Test
+  public void writeShouldProperlyAckTuplesWhenWriterDisabled() throws Exception {
+    when(configurations.isEnabled(any())).thenReturn(false);
+
+    BulkWriterComponent<JSONObject> bulkWriterComponent = new BulkWriterComponent<>(collector);
+    bulkWriterComponent.write(sensorType, tuple1, message1, bulkMessageWriter, configurations, messageGetStrategy);
+    bulkWriterComponent.write(sensorType, tuple2, message2, bulkMessageWriter, configurations, messageGetStrategy);
+
+    verify(collector, times(1)).ack(tuple1);
+    verify(collector, times(1)).ack(tuple2);
+    verifyStatic(times(0));
+    ErrorUtils.handleError(eq(collector), any(MetronError.class));
+  }
+
+  @Test
   public void writeShouldProperlyHandleWriterErrors() throws Exception {
     Throwable e = new Exception("test exception");
     MetronError error = new MetronError()

--- a/metron-platform/metron-writer/src/test/java/org/apache/metron/writer/BulkWriterComponentTest.java
+++ b/metron-platform/metron-writer/src/test/java/org/apache/metron/writer/BulkWriterComponentTest.java
@@ -44,6 +44,7 @@ import java.util.List;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -113,20 +114,14 @@ public class BulkWriterComponentTest {
 
     verify(collector, times(1)).ack(tuple1);
     verify(collector, times(1)).ack(tuple2);
-    verifyStatic(times(0));
-    ErrorUtils.handleError(eq(collector), any(MetronError.class));
-  }
 
-  @Test
-  public void writeShouldProperlyAckTuplesWhenWriterDisabled() throws Exception {
-    when(configurations.isEnabled(any())).thenReturn(false);
+    // A disabled writer should still ack
+    Tuple disabledTuple = mock(Tuple.class);
+    String disabledSensorType = "disabled";
+    when(configurations.isEnabled(disabledSensorType)).thenReturn(false);
+    bulkWriterComponent.write(disabledSensorType, disabledTuple, message2, bulkMessageWriter, configurations, messageGetStrategy);
+    verify(collector, times(1)).ack(disabledTuple);
 
-    BulkWriterComponent<JSONObject> bulkWriterComponent = new BulkWriterComponent<>(collector);
-    bulkWriterComponent.write(sensorType, tuple1, message1, bulkMessageWriter, configurations, messageGetStrategy);
-    bulkWriterComponent.write(sensorType, tuple2, message2, bulkMessageWriter, configurations, messageGetStrategy);
-
-    verify(collector, times(1)).ack(tuple1);
-    verify(collector, times(1)).ack(tuple2);
     verifyStatic(times(0));
     ErrorUtils.handleError(eq(collector), any(MetronError.class));
   }


### PR DESCRIPTION
## Contributor Comments
The PR fixes a bug in the indexing topology where a disabled writer will cause messages to fail.  This happens because the BulkWriterComponent simply returns (line 118) when it should ack the message before returning.

This has been tested on full dev along with unit and integration tests.  To verify, spin up full dev and disable the hdfs writer for bro.  The indexing topology should now continue to function normally instead of the spout reporting failures.

I also added a test case to ensure tuples are still acked when a writer is disabled.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && build_utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.

