### PR TITLE
METRON-1043: Profiler Should be Less Dramatic When Missing Configuration

### DIFF
--- a/metron-analytics/metron-profiler/src/main/java/org/apache/metron/profiler/bolt/ProfileSplitterBolt.java
+++ b/metron-analytics/metron-profiler/src/main/java/org/apache/metron/profiler/bolt/ProfileSplitterBolt.java
@@ -113,13 +113,15 @@ public class ProfileSplitterBolt extends ConfiguredProfilerBolt {
 
     // ensure there is a valid profiler configuration
     ProfilerConfig config = getProfilerConfig();
-    if(config == null) {
-      throw new IllegalArgumentException("Fatal: Unable to find valid profiler definition");
-    }
+    if(config != null) {
 
-    // apply the message to each of the profile definitions
-    for (ProfileConfig profile: config.getProfiles()) {
-      applyProfile(profile, input, message);
+      // apply the message to each of the profile definitions
+      for (ProfileConfig profile: config.getProfiles()) {
+        applyProfile(profile, input, message);
+      }
+
+    } else {
+      LOG.warn("No Profiler configuration found.  Nothing to do.");
     }
   }
 

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/profiler/ProfileConfig.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/profiler/ProfileConfig.java
@@ -167,7 +167,7 @@ public class ProfileConfig implements Serializable {
   }
 
   public void setExpires(Long expiresDays) {
-    this.expires = TimeUnit.DAYS.toMillis(expiresDays);
+    this.expires = expiresDays;
   }
 
   @Override


### PR DESCRIPTION
When the Profiler topology is running, but no Profiler definition is found in Zookeeper, the Profiler will now just calmly log a warning.  Previously the Profiler would throw a rather nasty looking exception.

I also refactored the logic for Profile `expires` handling.  Previously, this code was not all in one place (`ProfileHBaseMapper` + `ProfileConfig`), which made it less than clear what units the code base supported for `expires`.   I refactored the code so that it is all in one place (`ProfileHBaseMapper`) and very clear what is happening to avoid confusion.

### Testing

Beyond the automated tests that already test this functionality, a manual acceptance test would look like the following.

1. Start Full Dev
1. Complete all of the[ "Installation" steps here](https://github.com/apache/metron/tree/master/metron-analytics/metron-profiler#installation).  At this point the Profiler will be running, but no Profiler configuration exists.
1. Ensure that telemetry is being consumed by the Profiler.
1. Open up the Storm logs and make sure that `IllegalArgumentException`s are not being logged. 
1. Also in the Storm logs, there should be a WARN log statement from the Profiler indicating that the configuration cannot be found.
