### PR TITLE
METRON-1048 Intermittent Test Failure for SimpleHBaseEnrichmentWriterLoggingTest

### DIFF
--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/writers/SimpleHBaseEnrichmentWriterLoggingTest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/writers/SimpleHBaseEnrichmentWriterLoggingTest.java
@@ -41,7 +41,6 @@ import java.util.*;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.*;
 
@@ -75,7 +74,7 @@ public class SimpleHBaseEnrichmentWriterLoggingTest {
   public void shouldWarnOnMissingConfig() {
     SimpleHbaseEnrichmentWriter.Configurations config = getHbaseTableConfig();
     config.get(Collections.emptyMap());
-    verify(logger).warn("No config object found for key: '{}'", config.getKey());
+    verify(logger, atLeastOnce()).warn("No config object found for key: '{}'", config.getKey());
   }
 
   @Test
@@ -99,14 +98,14 @@ public class SimpleHBaseEnrichmentWriterLoggingTest {
     keyTransformer.transform(message);
 
     // Proof the result has been captured
-    verify(logger).debug("Transformed message: '{}'", value);
+    verify(logger, atLeastOnce()).debug("Transformed message: '{}'", value);
   }
 
   @Test
   public void shouldDebugSensorConfig() {
     String sensorName = "someSensor";
     hbaseEnrichmentWriter.configure(sensorName, getMockWriterConfiguration());
-    verify(logger).debug("Sensor: '{}': {Provider: '{}', Converter: '{}'}",
+    verify(logger, atLeastOnce()).debug("Sensor: '{}': {Provider: '{}', Converter: '{}'}",
         sensorName, MockTableProvider.class.getName(), EnrichmentConverter.class.getName());
   }
 
@@ -116,7 +115,7 @@ public class SimpleHBaseEnrichmentWriterLoggingTest {
     String tableName = "someTable";
     hbaseEnrichmentWriter.configure(sensorName, getMockWriterConfiguration());
     hbaseEnrichmentWriter.getTable(tableName, COLUMN_FAMILY);
-    verify(logger).debug("Fetching table '{}', column family: '{}'", tableName, COLUMN_FAMILY);
+    verify(logger, atLeastOnce()).debug("Fetching table '{}', column family: '{}'", tableName, COLUMN_FAMILY);
   }
 
   @Test

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/writers/SimpleHBaseEnrichmentWriterLoggingTest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/writers/SimpleHBaseEnrichmentWriterLoggingTest.java
@@ -41,6 +41,7 @@ import java.util.*;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.*;
 
@@ -80,7 +81,7 @@ public class SimpleHBaseEnrichmentWriterLoggingTest {
   @Test
   public void shouldWarnOnMissedConfigConversion() {
     getHbaseTableConfig().getAndConvert(Collections.emptyMap(), String.class);
-    verify(logger).warn("No object of type '{}' found in config", String.class);
+    verify(logger, atLeastOnce()).warn("No object of type '{}' found in config", String.class);
   }
 
   @Test


### PR DESCRIPTION
### Problem

This unit test failure seems to occur sporadically.  The same test passed after an inconsequential change forced a re-run of the tests.

```
Tests run: 6, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 11.596 sec <<< FAILURE! - in org.apache.metron.writers.SimpleHBaseEnrichmentWriterLoggingTest
shouldWarnOnMissingConfig(org.apache.metron.writers.SimpleHBaseEnrichmentWriterLoggingTest)  Time elapsed: 0.047 sec  <<< FAILURE!
org.mockito.exceptions.verification.TooManyActualInvocations: 
logger.warn(
    "No config object found for key: '{}'",
    "shew.table"
);
Wanted 1 time:
-> at org.apache.metron.writers.SimpleHBaseEnrichmentWriterLoggingTest.shouldWarnOnMissingConfig(SimpleHBaseEnrichmentWriterLoggingTest.java:77)
But was 2 times. Undesired invocation:
-> at org.apache.metron.enrichment.writer.SimpleHbaseEnrichmentWriter$Configurations.get(SimpleHbaseEnrichmentWriter.java:72)

	at org.apache.metron.writers.SimpleHBaseEnrichmentWriterLoggingTest.shouldWarnOnMissingConfig(SimpleHBaseEnrichmentWriterLoggingTest.java:77)
```

### Solution

The test was expecting the call to occur only once, when in-fact it could occur a few times.  This is why it would fail sporadically. This doesn't impact the validity of the test.

