### PR TITLE
METRON-1060: Add performance timing logging to enrichment topology

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/performance/PerformanceLogger.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/performance/PerformanceLogger.java
@@ -1,0 +1,188 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.metron.common.performance;
+
+import java.util.Map;
+import java.util.function.Supplier;
+import org.apache.metron.stellar.common.utils.ConversionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.FormattingTuple;
+import org.slf4j.helpers.MessageFormatter;
+
+public class PerformanceLogger {
+
+  private static final String LOG_PERCENT = "performance.logging.percent.records";
+  private static final Integer LOG_PERCENT_DEFAULT = 1;
+  private Supplier<Map<String, Object>> configSupplier;
+  private ThresholdCalculator thresholdCalc;
+  private Timing timing;
+  private Logger logger;
+
+  /**
+   * Minimum constructor for this class.
+   * <p>
+   *   Options:
+   * </p>
+   * <ul>
+   *   <li>performance.logging.percent.records = Integer value 1-100 indicating percent probability
+   *        that a logging statement should trigger writing timing info.
+   *   </li>
+   * </ul>
+   *
+   * @param configSupplier provides configuration for the logger as a Map&lt;String, Object&gt;
+   * @param loggerName     name for the underlying logger. This name is used when enabling/disabling
+   * the logger.
+   */
+  public PerformanceLogger(Supplier<Map<String, Object>> configSupplier, String loggerName) {
+    this(configSupplier, LoggerFactory.getLogger(loggerName), new ThresholdCalculator(),
+        new Timing());
+  }
+
+  public PerformanceLogger(Supplier<Map<String, Object>> configSupplier, Logger logger,
+      ThresholdCalculator thresholdCalc, Timing timing) {
+    this.configSupplier = configSupplier;
+    this.thresholdCalc = thresholdCalc;
+    this.timing = timing;
+    this.logger = logger;
+    this.logger.info("{} set to {}", LOG_PERCENT, getPercentThreshold());
+  }
+
+  /**
+   * Marks a timer start. Works in conjunction with the log methods. Calling log after
+   * calling mark will log elapsed time for the provided markName.
+   *
+   * @param markName
+   */
+  public void mark(String markName) {
+    timing.mark(markName);
+  }
+
+  /**
+   * Log a message at DEBUG level for the given markName.
+   * Warns when logging for a markName that hasn't been set.
+   * <p/>
+   * <p>This form avoids superfluous string concatenation when the logger
+   * is disabled for the DEBUG level.</p>
+   *
+   * @param markName  name of the marked timer to log elapsed time for
+   */
+  public void log(String markName) {
+    if (okToLog()) {
+      log(markName, "");
+    }
+  }
+
+  /**
+   * Log a message at DEBUG level for the given markName according to the specified message.
+   * Warns when logging for a markName that hasn't been set.
+   * <p/>
+   * <p>This form avoids superfluous string concatenation when the logger
+   * is disabled for the DEBUG level.</p>
+   *
+   * @param markName  name of the marked timer to log elapsed time for
+   * @param message   message to log
+   */
+  public void log(String markName, String message) {
+    if (okToLog()) {
+      if (timing.exists(markName)) {
+        logger.debug("markName={},time(ns)={},message={}", markName, timing.getElapsed(markName),
+            message);
+      } else {
+        logger.debug("markName={},time(ns)={},message={}", "WARNING - MARK NOT SET",
+            timing.getElapsed(markName), message);
+      }
+    }
+  }
+
+  private boolean okToLog() {
+    return logger.isDebugEnabled() && thresholdCalc.isPast(getPercentThreshold());
+  }
+
+  private Integer getPercentThreshold() {
+    return ConversionUtils.convert(getProperty(LOG_PERCENT, LOG_PERCENT_DEFAULT), Integer.class);
+  }
+
+  private Object getProperty(String key, Object defaultValue) {
+    return configSupplier.get().getOrDefault(key, defaultValue);
+  }
+
+
+  /**
+   * Log a message at DEBUG level for the given markName according to the specified format
+   * and argument. Warns when logging for a markName that hasn't been set.
+   * <p/>
+   * <p>This form avoids superfluous string concatenation when the logger
+   * is disabled for the DEBUG level.</p>
+   *
+   * @param markName  name of the marked timer to log elapsed time for
+   * @param format    the format string
+   * @param arg       argument to the format String
+   */
+  public void log(String markName, String format, Object arg) {
+    if (okToLog()) {
+      FormattingTuple formattedMessage = MessageFormatter.format(format, arg);
+      log(markName, formattedMessage.getMessage());
+    }
+  }
+
+  /**
+   * Log a message at DEBUG level according to the specified format and argument.
+   * <p/>
+   * <p>This form avoids superfluous string concatenation when the logger
+   * is disabled for the DEBUG level.</p>
+   *
+   * @param markName  name of the marked timer to log elapsed time for
+   * @param format    the format string
+   * @param arg1      first argument to the format String
+   * @param arg2      second argument to the format String
+   */
+  public void log(String markName, String format, Object arg1, Object arg2) {
+    if (okToLog()) {
+      FormattingTuple formattedMessage = MessageFormatter.format(format, arg1, arg2);
+      log(markName, formattedMessage.getMessage());
+    }
+  }
+
+  /**
+   * Log a message at DEBUG level according to the specified format and arguments.
+   * <p/>
+   * <p>This form avoids superfluous string concatenation when the logger
+   * is disabled for the DEBUG level. However, this variant incurs the hidden
+   * (and relatively small) cost of creating an <code>Object[]</code> before invoking the method,
+   * even if this logger is disabled for DEBUG. The variants taking
+   * {@link #log(String, String, Object) one} and {@link #log(String, String, Object, Object) two}
+   * arguments exist solely in order to avoid this hidden cost.</p>
+   *
+   * @param markName  name of the marked timer to log elapsed time for
+   * @param format    the format string
+   * @param arguments a list of 3 or more arguments
+   */
+  public void log(String markName, String format, Object... arguments) {
+    if (okToLog()) {
+      FormattingTuple formattedMessage = MessageFormatter.arrayFormat(format, arguments);
+      log(markName, formattedMessage.getMessage());
+    }
+  }
+
+  public boolean isDebugEnabled() {
+    return logger.isDebugEnabled();
+  }
+
+}

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/performance/ThresholdCalculator.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/performance/ThresholdCalculator.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.metron.common.performance;
+
+public class ThresholdCalculator {
+
+  /**
+   * Returns true roughly the provided percent of the time, false 100%-'percent' of the time
+   *
+   * @param percent Desired probability to return true
+   * @return true if the percent probability is true for this call.
+   */
+  public boolean isPast(int percent) {
+    double rd = Math.random();
+    if (rd <= toDecimal(percent)) {
+      return true;
+    }
+    return false;
+  }
+
+  private double toDecimal(int percent) {
+    return percent / 100.0;
+  }
+
+}

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/performance/Timing.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/performance/Timing.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.metron.common.performance;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Timing {
+
+  Map<String, Long> startTimes;
+
+  public Timing() {
+    this.startTimes = new HashMap<>();
+  }
+
+  /**
+   * Stores a starting time from current nanoTime with the provided name
+   *
+   * @param name starting time mark name
+   */
+  public void mark(String name) {
+    startTimes.put(name, System.nanoTime());
+  }
+
+  /**
+   * Returns elapsed nanoTime given a stored marked time for the given name. Returns 0 for
+   * non-existent mark names
+   *
+   * @param name mark name to get elapsed time for.
+   */
+  public long getElapsed(String name) {
+    if (startTimes.containsKey(name)) {
+      return System.nanoTime() - startTimes.get(name);
+    } else {
+      return 0;
+    }
+  }
+
+  /**
+   * Checks existence of timing marker.
+   *
+   * @param name mark name to lookup.
+   * @return true if mark has been called with this name, false otherwise.
+   */
+  public boolean exists(String name) {
+    return startTimes.containsKey(name);
+  }
+
+}

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/performance/PerformanceLoggerTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/performance/PerformanceLoggerTest.java
@@ -1,0 +1,173 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.metron.common.performance;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+
+public class PerformanceLoggerTest {
+
+  private int thresholdPercent = 10;
+  private Supplier<Map<String, Object>> configSupplier;
+  @Mock
+  private Timing timing;
+  @Mock
+  private ThresholdCalculator thresholdCalc;
+  @Mock
+  private Logger logger;
+  private PerformanceLogger perfLogger;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    configSupplier = () -> ImmutableMap.of("performance.logging.percent.records", thresholdPercent);
+    when(thresholdCalc.isPast(thresholdPercent)).thenReturn(false).thenReturn(false)
+        .thenReturn(true);
+    when(logger.isDebugEnabled()).thenReturn(true);
+    when(timing.exists("t1")).thenReturn(true);
+    perfLogger = new PerformanceLogger(configSupplier, logger, thresholdCalc, timing);
+  }
+
+  @Test
+  public void logs_on_threshold() throws Exception {
+    when(timing.getElapsed("t1")).thenReturn(111L).thenReturn(222L).thenReturn(333L);
+    perfLogger.mark("t1");
+    perfLogger.log("t1");
+    perfLogger.log("t1");
+    perfLogger.log("t1");
+    verify(timing).mark("t1");
+    verify(logger, times(1)).debug(anyString(), anyObject(), eq(111L), eq(""));
+  }
+
+  @Test
+  public void logs_on_threshold_with_message() throws Exception {
+    when(timing.getElapsed("t1")).thenReturn(111L).thenReturn(222L).thenReturn(333L);
+    perfLogger.mark("t1");
+    perfLogger.log("t1", "my message");
+    perfLogger.log("t1", "my message");
+    perfLogger.log("t1", "my message");
+    verify(timing).mark("t1");
+    verify(logger, times(1)).debug(anyString(), anyObject(), eq(111L), eq("my message"));
+  }
+
+  @Test
+  public void warns_when_logging_nonexisting_marks() throws Exception {
+    when(thresholdCalc.isPast(thresholdPercent)).thenReturn(true);
+    when(timing.getElapsed("t1")).thenReturn(111L);
+    when(timing.getElapsed("t2")).thenReturn(222L);
+    when(timing.getElapsed("t3")).thenReturn(333L);
+    when(timing.exists("t1")).thenReturn(true);
+    when(timing.exists("t2")).thenReturn(false);
+    when(timing.exists("t3")).thenReturn(false);
+    perfLogger.mark("t1");
+    perfLogger.log("t1", "my message");
+    perfLogger.log("t2", "my message");
+    perfLogger.log("t3", "my message");
+    verify(timing).mark("t1");
+    verify(timing, never()).mark("t2");
+    verify(timing, never()).mark("t3");
+    verify(logger).debug(anyString(), anyObject(), eq(111L), eq("my message"));
+    verify(logger)
+        .debug(anyString(), eq("WARNING - MARK NOT SET"), eq(222L), eq("my message"));
+    verify(logger)
+        .debug(anyString(), eq("WARNING - MARK NOT SET"), eq(333L), eq("my message"));
+  }
+
+  @Test
+  public void logs_with_multiple_markers() throws Exception {
+    when(thresholdCalc.isPast(thresholdPercent)).thenReturn(true);
+    when(timing.getElapsed("t1")).thenReturn(111L);
+    when(timing.getElapsed("t2")).thenReturn(222L);
+    perfLogger.mark("t1");
+    perfLogger.mark("t2");
+    perfLogger.log("t2", "my message 2");
+    perfLogger.log("t1", "my message 1");
+    verify(timing).mark("t1");
+    verify(timing).mark("t2");
+    verify(logger).debug(anyString(), anyObject(), eq(111L), eq("my message 1"));
+    verify(logger).debug(anyString(), anyObject(), eq(222L), eq("my message 2"));
+  }
+
+  @Test
+  public void defaults_to_1_percent_threshold() throws Exception {
+    configSupplier = () -> new HashMap<>();
+    when(thresholdCalc.isPast(1)).thenReturn(false).thenReturn(false)
+        .thenReturn(true);
+    when(timing.getElapsed("t1")).thenReturn(111L).thenReturn(222L).thenReturn(333L);
+    perfLogger.mark("t1");
+    perfLogger.log("t1", "my message");
+    perfLogger.log("t1", "my message");
+    perfLogger.log("t1", "my message");
+    verify(timing).mark("t1");
+    verify(logger, times(1)).debug(anyString(), anyObject(), eq(111L), eq("my message"));
+  }
+
+  @Test
+  public void does_not_log_when_debugging_disabled() throws Exception {
+    when(logger.isDebugEnabled()).thenReturn(false);
+    when(timing.getElapsed("t1")).thenReturn(111L).thenReturn(222L).thenReturn(333L);
+    perfLogger.mark("t1");
+    perfLogger.log("t1", "my message");
+    perfLogger.log("t1", "my message");
+    perfLogger.log("t1", "my message");
+    verify(timing).mark("t1");
+    verify(logger, times(0)).debug(anyString(), anyObject(), eq(111L), eq("my message"));
+  }
+
+  @Test
+  public void logs_formatted_message_provided_format_args() throws Exception {
+    when(thresholdCalc.isPast(thresholdPercent)).thenReturn(true);
+    when(timing.getElapsed("t1")).thenReturn(111L).thenReturn(222L).thenReturn(333L)
+        .thenReturn(444L);
+    perfLogger.mark("t1");
+    perfLogger.log("t1", "my {} message", "1");
+    perfLogger.log("t1", "my {} message {}", "1", "2");
+    perfLogger.log("t1", "my {} message {} {}", "1", "2", "3");
+    perfLogger.log("t1", "my {} message {} {} {}", "1", "2", "3", "4");
+    verify(timing).mark("t1");
+    verify(logger, times(1)).debug(anyString(), anyObject(), eq(111L), eq("my 1 message"));
+    verify(logger, times(1)).debug(anyString(), anyObject(), eq(222L), eq("my 1 message 2"));
+    verify(logger, times(1)).debug(anyString(), anyObject(), eq(333L), eq("my 1 message 2 3"));
+    verify(logger, times(1)).debug(anyString(), anyObject(), eq(444L), eq("my 1 message 2 3 4"));
+  }
+
+  @Test
+  public void isDebugEnabled_returns_true_when_debugging_is_set() {
+    when(logger.isDebugEnabled()).thenReturn(true);
+    assertThat(perfLogger.isDebugEnabled(), equalTo(true));
+  }
+
+}

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/performance/TimingTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/performance/TimingTest.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.metron.common.performance;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class TimingTest {
+
+  private Timing timing;
+
+  @Before
+  public void setup() {
+    timing = new Timing();
+  }
+
+  @Test
+  public void provides_monotonically_increasing_times_for_single_marker()
+      throws InterruptedException {
+    timing.mark("mark1");
+    long tlast = 0;
+    for (int i = 0; i < 10; i++) {
+      tlast = timing.getElapsed("mark1");
+      Thread.sleep(10);
+      assertThat(timing.getElapsed("mark1") > tlast, equalTo(true));
+    }
+  }
+
+  @Test
+  public void provides_monotonically_increasing_times_for_multiple_markers()
+      throws InterruptedException {
+    timing.mark("mark1");
+    timing.mark("mark2");
+    long tlast1 = 0;
+    long tlast2 = 0;
+    for (int i = 0; i < 10; i++) {
+      tlast1 = timing.getElapsed("mark1");
+      tlast2 = timing.getElapsed("mark2");
+      Thread.sleep(10);
+      assertThat(timing.getElapsed("mark1") > tlast1, equalTo(true));
+      assertThat(timing.getElapsed("mark2") > tlast2, equalTo(true));
+    }
+  }
+
+  @Test
+  public void elapsed_time_on_nonexistent_marker_is_zero() throws InterruptedException {
+    timing.mark("mark1");
+    long tlast1 = 0;
+    for (int i = 0; i < 10; i++) {
+      tlast1 = timing.getElapsed("mark1");
+      Thread.sleep(10);
+      assertThat(timing.getElapsed("mark1") > tlast1, equalTo(true));
+      assertThat(timing.getElapsed("mark2"), equalTo(0L));
+    }
+  }
+
+  @Test
+  public void marking_again_resets_timing() throws InterruptedException {
+    timing.mark("mark1");
+    long tlast1 = 0;
+    for (int i = 0; i < 5; i++) {
+      Thread.sleep(10);
+      tlast1 = timing.getElapsed("mark1");
+      timing.mark("mark1");
+      assertThat(timing.getElapsed("mark1") < tlast1, equalTo(true));
+    }
+  }
+
+  @Test
+  public void exists_checks_mark_existence() {
+    timing.mark("mark1");
+    assertThat(timing.exists("mark1"), equalTo(true));
+    assertThat(timing.exists("mark2"), equalTo(false));
+    assertThat(timing.exists("mark3"), equalTo(false));
+  }
+
+}

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/SplitBolt.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/SplitBolt.java
@@ -21,18 +21,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.metron.common.bolt.ConfiguredEnrichmentBolt;
+import org.apache.metron.common.performance.PerformanceLogger;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public abstract class SplitBolt<T extends Cloneable> extends ConfiguredEnrichmentBolt {
   public static class Perf {} // used for performance logging
-  private static final Logger PERF_LOG = LoggerFactory.getLogger(Perf.class);
+  private PerformanceLogger perfLog; // not static bc multiple bolts may exist in same worker
 
   protected OutputCollector collector;
 
@@ -44,6 +43,7 @@ public abstract class SplitBolt<T extends Cloneable> extends ConfiguredEnrichmen
   public final void prepare(Map map, TopologyContext topologyContext,
                        OutputCollector outputCollector) {
     super.prepare(map, topologyContext, outputCollector);
+    perfLog = new PerformanceLogger(() -> getConfigurations().getGlobalConfig(), Perf.class.getName());
     collector = outputCollector;
     prepare(map, topologyContext);
   }
@@ -64,37 +64,35 @@ public abstract class SplitBolt<T extends Cloneable> extends ConfiguredEnrichmen
   }
 
   public void emit(Tuple tuple, T message) {
-    long texecute1 = System.currentTimeMillis();
+    perfLog.mark("emit");
     if (message == null) return;
     String key = getKey(tuple, message);
 
-    long tsplit1 = System.currentTimeMillis();
+    perfLog.mark("split-message");
     Map<String, List<T>> streamMessageMap = splitMessage(message);
-    PERF_LOG.debug("key={}, execute() time (ms): {}", key, System.currentTimeMillis() - tsplit1);
+    perfLog.log("split-message", "key={}, elapsed time to split message", key);
 
     for (String streamId : streamMessageMap.keySet()) {
       List<T> streamMessages = streamMessageMap.get(streamId);
-      if(streamMessages != null) {
-        for(T streamMessage : streamMessages) {
+      if (streamMessages != null) {
+        for (T streamMessage : streamMessages) {
           if (streamMessage == null) {
             streamMessage = getDefaultMessage(streamId);
           }
           collector.emit(streamId, new Values(key, streamMessage));
         }
-      }
-      else {
+      } else {
         throw new IllegalArgumentException("Enrichment must send some list of messages, not null.");
       }
     }
     collector.emit("message", tuple, new Values(key, message, ""));
     collector.ack(tuple);
     emitOther(tuple, message);
-    PERF_LOG.debug("key={}, execute() time (ms): {}", key, System.currentTimeMillis() - texecute1);
+    perfLog.log("emit", "key={}, elapsed time to run emit", key);
   }
 
   protected T getDefaultMessage(String streamId) {
-    throw new IllegalArgumentException("Could not find a message for" +
-            " stream: " + streamId);
+    throw new IllegalArgumentException("Could not find a message for stream: " + streamId);
   }
 
   public abstract void prepare(Map map, TopologyContext topologyContext);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/METRON-1060

Adds performance logging timers to the enrichment topology. I've made this configurable so that the timers are separate from our standard logging. Any opinions on documenting this, ie should it be added to the enrichment docs? I also noticed some performance logging added to the StellarAdapter class, but we haven't added documentation for the "feature."

### Testing

Run full dev
```
cd metron/metron-deployment/vagrant/full-dev-platform
vagrant up
```

**Set the log levels**

Go to the storm UI - http://node1:8744 and select the enrichment topology. Scroll down to "Change Log Level" and enter the following loggers, level=DEBUG, timeout=5000 sec:

> org.apache.metron.enrichment.bolt.GenericEnrichmentBolt$Perf
> org.apache.metron.enrichment.bolt.SplitBolt$Perf
> org.apache.metron.enrichment.bolt.JoinBolt$Perf 

In the enrichment worker log you should see lines similar to the following indicating that performance logging has been enabled:
> 2017-07-21 20:53:42.673 o.a.s.d.worker [INFO] Adding config for: org.apache.metron.enrichment.bolt.SplitBolt$Perf with level: DEBUG
> 2017-07-21 20:54:14.747 o.a.s.d.worker [INFO] Adding config for: org.apache.metron.enrichment.bolt.JoinBolt$Perf with level: DEBUG
> 2017-07-21 20:54:39.914 o.a.s.d.worker [INFO] Adding config for: org.apache.metron.enrichment.bolt.GenericEnrichmentBolt$Perf with level: DEBUG

**Check the log output**

You should see log entries similar to the following:

> 2017-07-28 17:22:39.432 o.a.m.e.b.GenericEnrichmentBolt$Perf [DEBUG] markName=enrich,time(ns)=16992,message=key=9e21e859-9da8-40db-89b1-59d1395ceabb, time to run enrichment type=geo
> 2017-07-28 17:23:28.148 o.a.m.e.b.JoinBolt$Perf [DEBUG] markName=execute,time(ns)=31933,message=key=4502ddc1-25db-4c33-a8d9-af8725ee1a44, elapsed time to run execute
> 2017-07-28 17:26:57.478 o.a.m.e.b.SplitBolt$Perf [DEBUG] markName=split-message,time(ns)=23744,message=key=0caa19e3-786f-49f7-89bf-8f2900d56d38, elapsed time to split message
> 2017-07-28 17:29:25.042 o.a.m.e.b.JoinBolt$Perf [DEBUG] markName=join-message,time(ns)=30122,message=key=a35950c1-a473-4172-afc3-61a8172d66fb, elapsed time to join messages
> 2017-07-28 17:32:14.146 o.a.m.e.b.SplitBolt$Perf [DEBUG] markName=split-message,time(ns)=90933,message=key=4d5c2ac3-aea1-4010-b902-1b9726ee78ac, elapsed time to split message
> 2017-07-28 17:32:48.825 o.a.m.e.b.SplitBolt$Perf [DEBUG] markName=emit,time(ns)=30827,message=key=4d4d54da-6033-4318-8855-425f017a6c32, elapsed time to run emit
> 2017-07-28 17:32:50.866 o.a.m.e.b.GenericEnrichmentBolt$Perf [DEBUG] markName=execute,time(ns)=14299,message=key=5cba5c1c-2989-49dc-a1b6-6c561e956725, elapsed time to run execute

Also try changing the global config setting `performance.logging.percent.records` to something >= 10. The default is to log only 1% of the messages.

Change $METRON_HOME/config/zookeeper/global.json by adding the following key/value.
`"performance.logging.percent.records" : 20`. Push the changes to Zookeeper and then verify the settings have persisted.

```
${METRON_HOME}/bin/zk_load_configs.sh -i ${METRON_HOME}/config/zookeeper -m PUSH -z $ZOOKEEPER
${METRON_HOME}/bin/zk_load_configs.sh -m DUMP -z $ZOOKEEPER
```

Now re-examine your logs again. You should see a much higher frequency of messages being logged. For extra credit, switch the setting back to 1% again and verify that the volume of logging statements has dropped significantly.

That should do it!

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && build_utils/verify_licenses.sh 
  ```

- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.

