### PR TITLE
METRON-379 STELLAR can differentiate between a value passed as null and a value not passed

### DIFF
--- a/metron-analytics/metron-profiler-client/src/test/java/org/apache/metron/profiler/client/stellar/WindowLookbackTest.java
+++ b/metron-analytics/metron-profiler-client/src/test/java/org/apache/metron/profiler/client/stellar/WindowLookbackTest.java
@@ -22,6 +22,7 @@ package org.apache.metron.profiler.client.stellar;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.Range;
 import org.apache.metron.stellar.dsl.Context;
+import org.apache.metron.stellar.dsl.DefaultVariableResolver;
 import org.apache.metron.stellar.dsl.ParseException;
 import org.apache.metron.stellar.dsl.functions.resolver.FunctionResolver;
 import org.apache.metron.stellar.dsl.functions.resolver.SimpleFunctionResolver;
@@ -71,7 +72,7 @@ public class WindowLookbackTest {
     Map<String, Object> variables = new HashMap<>();
     StellarProcessor stellar = new StellarProcessor();
     List<ProfilePeriod> periods = (List<ProfilePeriod>)stellar.parse( stellarStatement
-                                                                    , k -> variables.get(k)
+                                                                    , new DefaultVariableResolver(k -> variables.get(k),k -> variables.containsKey(k))
                                                                     , resolver
                                                                     , context
                                                                     );
@@ -135,7 +136,7 @@ public class WindowLookbackTest {
     }
     StellarProcessor stellar = new StellarProcessor();
     List<ProfilePeriod> periods = (List<ProfilePeriod>)stellar.parse( stellarStatement
-                                                                    , k -> variables.get(k)
+                                                                    , new DefaultVariableResolver(k -> variables.get(k),k -> variables.containsKey(k))
                                                                     , resolver
                                                                     , context
                                                                     );

--- a/metron-analytics/metron-statistics/src/test/java/org/apache/metron/statistics/BinFunctionsTest.java
+++ b/metron-analytics/metron-statistics/src/test/java/org/apache/metron/statistics/BinFunctionsTest.java
@@ -22,6 +22,7 @@ package org.apache.metron.statistics;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.metron.stellar.dsl.Context;
+import org.apache.metron.stellar.dsl.DefaultVariableResolver;
 import org.apache.metron.stellar.dsl.StellarFunctions;
 import org.apache.metron.stellar.common.StellarProcessor;
 import org.junit.Assert;
@@ -34,7 +35,7 @@ public class BinFunctionsTest {
     Context context = Context.EMPTY_CONTEXT();
     StellarProcessor processor = new StellarProcessor();
     Assert.assertTrue(rule + " not valid.", processor.validate(rule, context));
-    return processor.parse(rule, x -> variables.get(x), StellarFunctions.FUNCTION_RESOLVER(), context);
+    return processor.parse(rule, new DefaultVariableResolver(x -> variables.get(x),x -> variables.containsKey(x)), StellarFunctions.FUNCTION_RESOLVER(), context);
   }
 
   @Test

--- a/metron-analytics/metron-statistics/src/test/java/org/apache/metron/statistics/StellarStatisticsFunctionsTest.java
+++ b/metron-analytics/metron-statistics/src/test/java/org/apache/metron/statistics/StellarStatisticsFunctionsTest.java
@@ -27,6 +27,7 @@ import org.apache.commons.math3.random.MersenneTwister;
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 import org.apache.metron.stellar.dsl.Context;
+import org.apache.metron.stellar.dsl.DefaultVariableResolver;
 import org.apache.metron.stellar.dsl.StellarFunctions;
 import org.apache.metron.stellar.common.StellarProcessor;
 import org.apache.metron.common.utils.SerDeUtils;
@@ -104,7 +105,7 @@ public class StellarStatisticsFunctionsTest {
    */
   private static Object run(String expr, Map<String, Object> variables) {
     StellarProcessor processor = new StellarProcessor();
-    Object ret = processor.parse(expr, x-> variables.get(x), StellarFunctions.FUNCTION_RESOLVER(), Context.EMPTY_CONTEXT());
+    Object ret = processor.parse(expr, new DefaultVariableResolver(x -> variables.get(x),x -> variables.containsKey(x)), StellarFunctions.FUNCTION_RESOLVER(), Context.EMPTY_CONTEXT());
     byte[] raw = SerDeUtils.toBytes(ret);
     Object actual = SerDeUtils.fromBytes(raw, Object.class);
     if(ret instanceof StatisticsProvider) {

--- a/metron-analytics/metron-statistics/src/test/java/org/apache/metron/statistics/outlier/MedianAbsoluteDeviationTest.java
+++ b/metron-analytics/metron-statistics/src/test/java/org/apache/metron/statistics/outlier/MedianAbsoluteDeviationTest.java
@@ -25,6 +25,7 @@ import org.apache.commons.math3.random.GaussianRandomGenerator;
 import org.apache.commons.math3.random.MersenneTwister;
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 import org.apache.metron.stellar.dsl.Context;
+import org.apache.metron.stellar.dsl.DefaultVariableResolver;
 import org.apache.metron.stellar.dsl.StellarFunctions;
 import org.apache.metron.stellar.common.StellarProcessor;
 import org.apache.metron.common.utils.SerDeUtils;
@@ -40,7 +41,7 @@ public class MedianAbsoluteDeviationTest {
     Context context = Context.EMPTY_CONTEXT();
     StellarProcessor processor = new StellarProcessor();
     Assert.assertTrue(rule + " not valid.", processor.validate(rule, context));
-    return processor.parse(rule, x -> variables.get(x), StellarFunctions.FUNCTION_RESOLVER(), context);
+    return processor.parse(rule, new DefaultVariableResolver(x -> variables.get(x),x -> variables.containsKey(x)), StellarFunctions.FUNCTION_RESOLVER(), context);
   }
 
   private void assertScoreEquals(MedianAbsoluteDeviationFunctions.State currentState, MedianAbsoluteDeviationFunctions.State clonedState, double value) {

--- a/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/stellar/GeoEnrichmentFunctionsTest.java
+++ b/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/stellar/GeoEnrichmentFunctionsTest.java
@@ -21,6 +21,7 @@ package org.apache.metron.enrichment.stellar;
 import com.google.common.collect.ImmutableMap;
 import org.adrianwalker.multilinestring.Multiline;
 import org.apache.metron.stellar.dsl.Context;
+import org.apache.metron.stellar.dsl.DefaultVariableResolver;
 import org.apache.metron.stellar.dsl.StellarFunctions;
 import org.apache.metron.stellar.common.StellarProcessor;
 import org.apache.metron.enrichment.adapters.geo.GeoLiteDatabase;
@@ -93,7 +94,7 @@ public class GeoEnrichmentFunctionsTest {
   public Object run(String rule, Map<String, Object> variables) throws Exception {
     StellarProcessor processor = new StellarProcessor();
     Assert.assertTrue(rule + " not valid.", processor.validate(rule, context));
-    return processor.parse(rule, x -> variables.get(x), StellarFunctions.FUNCTION_RESOLVER(), context);
+    return processor.parse(rule, new DefaultVariableResolver(x -> variables.get(x),x -> variables.containsKey(x)), StellarFunctions.FUNCTION_RESOLVER(), context);
   }
 
   @Test

--- a/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/stellar/SimpleHBaseEnrichmentFunctionsTest.java
+++ b/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/stellar/SimpleHBaseEnrichmentFunctionsTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.HTableInterface;
 import org.apache.metron.stellar.dsl.Context;
+import org.apache.metron.stellar.dsl.DefaultVariableResolver;
 import org.apache.metron.stellar.dsl.StellarFunctions;
 import org.apache.metron.stellar.common.StellarProcessor;
 import org.apache.metron.enrichment.converter.EnrichmentHelper;
@@ -77,7 +78,7 @@ public class SimpleHBaseEnrichmentFunctionsTest {
   public Object run(String rule, Map<String, Object> variables) throws Exception {
     StellarProcessor processor = new StellarProcessor();
     Assert.assertTrue(rule + " not valid.", processor.validate(rule, context));
-    return processor.parse(rule, x -> variables.get(x), StellarFunctions.FUNCTION_RESOLVER(), context);
+    return processor.parse(rule, new DefaultVariableResolver(x -> variables.get(x),x -> variables.containsKey(x)), StellarFunctions.FUNCTION_RESOLVER(), context);
   }
 
   @Test

--- a/metron-platform/metron-management/src/test/java/org/apache/metron/management/EnrichmentConfigFunctionsTest.java
+++ b/metron-platform/metron-management/src/test/java/org/apache/metron/management/EnrichmentConfigFunctionsTest.java
@@ -25,6 +25,7 @@ import org.apache.metron.common.utils.JSONUtils;
 import org.apache.metron.stellar.common.StellarProcessor;
 import org.apache.metron.stellar.common.shell.StellarExecutor;
 import org.apache.metron.stellar.dsl.Context;
+import org.apache.metron.stellar.dsl.DefaultVariableResolver;
 import org.apache.metron.stellar.dsl.StellarFunctions;
 import org.junit.Assert;
 import org.junit.Before;
@@ -135,7 +136,7 @@ public class EnrichmentConfigFunctionsTest {
 
   private Object run(String rule, Map<String, Object> variables) {
     StellarProcessor processor = new StellarProcessor();
-    return processor.parse(rule, x -> variables.get(x), StellarFunctions.FUNCTION_RESOLVER(), context);
+    return processor.parse(rule, new DefaultVariableResolver(x -> variables.get(x),x -> variables.containsKey(x)), StellarFunctions.FUNCTION_RESOLVER(), context);
   }
 
   @Test

--- a/metron-platform/metron-management/src/test/java/org/apache/metron/management/IndexingConfigFunctionsTest.java
+++ b/metron-platform/metron-management/src/test/java/org/apache/metron/management/IndexingConfigFunctionsTest.java
@@ -20,6 +20,7 @@ package org.apache.metron.management;
 import com.google.common.collect.ImmutableMap;
 import org.apache.metron.common.configuration.IndexingConfigurations;
 import org.apache.metron.stellar.dsl.Context;
+import org.apache.metron.stellar.dsl.DefaultVariableResolver;
 import org.apache.metron.stellar.dsl.StellarFunctions;
 import org.apache.metron.stellar.common.StellarProcessor;
 import org.apache.metron.stellar.common.shell.StellarExecutor;
@@ -40,7 +41,7 @@ public class IndexingConfigFunctionsTest {
 
   private Object run(String rule, Map<String, Object> variables) {
     StellarProcessor processor = new StellarProcessor();
-    return processor.parse(rule, x -> variables.get(x), StellarFunctions.FUNCTION_RESOLVER(), context);
+    return processor.parse(rule, new DefaultVariableResolver(x -> variables.get(x),x -> variables.containsKey(x)), StellarFunctions.FUNCTION_RESOLVER(), context);
   }
 
   @Before
@@ -66,8 +67,11 @@ public class IndexingConfigFunctionsTest {
 
   @Test(expected=IllegalStateException.class)
   public void testSetBatchBad() {
+    Map<String,Object> variables = new HashMap<String,Object>(){{
+      put("config",null);
+    }};
     run("INDEXING_SET_BATCH(config, 'hdfs', 10)"
-                             , new HashMap<>()
+                             , variables
     );
   }
 
@@ -82,8 +86,11 @@ public class IndexingConfigFunctionsTest {
 
   @Test(expected=IllegalStateException.class)
   public void testSetEnabledBad() {
+    Map<String,Object> variables = new HashMap<String,Object>(){{
+      put("config",null);
+    }};
     run("INDEXING_SET_ENABLED(config, 'hdfs', 10)"
-                             , new HashMap<>()
+                             , variables
     );
   }
 
@@ -98,8 +105,11 @@ public class IndexingConfigFunctionsTest {
 
   @Test(expected= IllegalStateException.class)
   public void testSetIndexBad() {
+    Map<String,Object> variables = new HashMap<String,Object>(){{
+      put("config",null);
+    }};
     run("INDEXING_SET_INDEX(config, 'hdfs', NULL)"
-            , new HashMap<>()
+            , variables
     );
   }
 }

--- a/metron-platform/metron-management/src/test/java/org/apache/metron/management/KafkaFunctionsIntegrationTest.java
+++ b/metron-platform/metron-management/src/test/java/org/apache/metron/management/KafkaFunctionsIntegrationTest.java
@@ -19,6 +19,7 @@
 package org.apache.metron.management;
 
 import org.apache.metron.stellar.dsl.Context;
+import org.apache.metron.stellar.dsl.DefaultVariableResolver;
 import org.apache.metron.stellar.dsl.functions.resolver.FunctionResolver;
 import org.apache.metron.stellar.dsl.functions.resolver.SimpleFunctionResolver;
 import org.apache.metron.stellar.common.StellarProcessor;
@@ -198,7 +199,7 @@ public class KafkaFunctionsIntegrationTest extends BaseIntegrationTest {
             .withClass(KafkaFunctions.KafkaTail.class);
 
     StellarProcessor processor = new StellarProcessor();
-    return processor.parse(expr, x -> variables.get(x), functionResolver, context);
+    return processor.parse(expr, new DefaultVariableResolver(x -> variables.get(x),x -> variables.containsKey(x)), functionResolver, context);
   }
 
 }

--- a/metron-platform/metron-management/src/test/java/org/apache/metron/management/ParserConfigFunctionsTest.java
+++ b/metron-platform/metron-management/src/test/java/org/apache/metron/management/ParserConfigFunctionsTest.java
@@ -173,8 +173,10 @@ public class ParserConfigFunctionsTest {
 
   @Test
   public void testPrintNull() {
-
-    String out = (String) run("PARSER_STELLAR_TRANSFORM_PRINT(config )", new HashMap<>(), context);
+    Map<String,Object> variables = new HashMap<String,Object>(){{
+      put("config",null);
+    }};
+    String out = (String) run("PARSER_STELLAR_TRANSFORM_PRINT(config )", variables, context);
     Assert.assertNull( out);
   }
 }

--- a/metron-platform/metron-management/src/test/java/org/apache/metron/management/ShellFunctionsTest.java
+++ b/metron-platform/metron-management/src/test/java/org/apache/metron/management/ShellFunctionsTest.java
@@ -111,7 +111,9 @@ public class ShellFunctionsTest {
 
   @Test
   public void testMap2TableNullInput() {
-    Map<String, Object> variables = new HashMap<>();
+    Map<String,Object> variables = new HashMap<String,Object>(){{
+      put("map_field",null);
+    }};
     Context context = Context.EMPTY_CONTEXT();
     Object out = run("SHELL_MAP2TABLE(map_field)", variables, context);
     Assert.assertEquals(expectedMap2TableNullInput, out);

--- a/metron-platform/metron-management/src/test/java/org/apache/metron/management/ThreatTriageFunctionsTest.java
+++ b/metron-platform/metron-management/src/test/java/org/apache/metron/management/ThreatTriageFunctionsTest.java
@@ -22,6 +22,7 @@ import org.adrianwalker.multilinestring.Multiline;
 import org.apache.metron.common.configuration.enrichment.SensorEnrichmentConfig;
 import org.apache.metron.common.configuration.enrichment.threatintel.RiskLevelRule;
 import org.apache.metron.stellar.dsl.Context;
+import org.apache.metron.stellar.dsl.DefaultVariableResolver;
 import org.apache.metron.stellar.dsl.StellarFunctions;
 import org.apache.metron.stellar.common.StellarProcessor;
 import org.apache.metron.stellar.common.shell.StellarExecutor;
@@ -62,7 +63,7 @@ public class ThreatTriageFunctionsTest {
 
   private Object run(String rule, Map<String, Object> variables) {
     StellarProcessor processor = new StellarProcessor();
-    return processor.parse(rule, x -> variables.get(x), StellarFunctions.FUNCTION_RESOLVER(), context);
+    return processor.parse(rule, new DefaultVariableResolver(x -> variables.get(x),x -> variables.containsKey(x)), StellarFunctions.FUNCTION_RESOLVER(), context);
   }
 
   @Test
@@ -268,9 +269,12 @@ Aggregation: MAX*/
 
   @Test
   public void testPrintNull() {
+    Map<String,Object> variables = new HashMap<String,Object>(){{
+      put("config",null);
+    }};
     String out = (String) run(
             "THREAT_TRIAGE_PRINT(config)"
-            , new HashMap<>()
+            , variables
     );
     Assert.assertEquals(out, testPrintEmptyExpected);
   }

--- a/metron-platform/metron-pcap/src/main/java/org/apache/metron/pcap/filter/PcapFieldResolver.java
+++ b/metron-platform/metron-pcap/src/main/java/org/apache/metron/pcap/filter/PcapFieldResolver.java
@@ -35,4 +35,9 @@ public class PcapFieldResolver implements VariableResolver {
     return fieldsMap.get(variable);
   }
 
+  @Override
+  public boolean exists(String variable) {
+    return fieldsMap.containsKey(variable);
+  }
+
 }

--- a/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/common/LambdaExpression.java
+++ b/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/common/LambdaExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.metron.stellar.common;
 
+import org.apache.metron.stellar.dsl.DefaultVariableResolver;
 import org.apache.metron.stellar.dsl.Token;
 import org.apache.metron.stellar.dsl.VariableResolver;
 
@@ -56,9 +57,9 @@ public class LambdaExpression extends StellarCompiler.Expression {
       lambdaVariables.put(variables.get(i), null);
     }
 
-    VariableResolver variableResolver = variable -> lambdaVariables.getOrDefault(variable
+    VariableResolver variableResolver = new DefaultVariableResolver(variable -> lambdaVariables.getOrDefault(variable
                                                                                 , state.variableResolver.resolve(variable)
-                                                                                );
+                                                                                ), variable -> true);
     StellarCompiler.ExpressionState localState = new StellarCompiler.ExpressionState(
             state.context
           , state.functionResolver

--- a/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/common/StellarCompiler.java
+++ b/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/common/StellarCompiler.java
@@ -19,6 +19,7 @@ package org.apache.metron.stellar.common;
 
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.metron.stellar.dsl.Context;
+import org.apache.metron.stellar.dsl.Context.ActivityType;
 import org.apache.metron.stellar.dsl.Token;
 import org.apache.metron.stellar.dsl.VariableResolver;
 import org.apache.metron.stellar.dsl.functions.resolver.FunctionResolver;
@@ -352,7 +353,12 @@ public class StellarCompiler extends StellarBaseListener {
   public void exitVariable(StellarParser.VariableContext ctx) {
     final FrameContext.Context context = getArgContext();
     expression.tokenDeque.push(new Token<>( (tokenDeque, state) -> {
-      tokenDeque.push(new Token<>(state.variableResolver.resolve(ctx.getText()), Object.class, context));
+      String varName = ctx.getText();
+      if(state.context.getActivityType().equals(ActivityType.PARSE_ACTIVITY) && !state.variableResolver.exists(varName)) {
+        // when parsing, missing variables are an error!
+        throw new ParseException(String.format("variable: %s is not defined",varName));
+      }
+      tokenDeque.push(new Token<>(state.variableResolver.resolve(varName), Object.class, context));
     }, DeferredFunction.class, context));
     expression.variablesUsed.add(ctx.getText());
   }

--- a/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/common/utils/StellarProcessorUtils.java
+++ b/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/common/utils/StellarProcessorUtils.java
@@ -19,6 +19,7 @@
 package org.apache.metron.stellar.common.utils;
 
 import org.apache.metron.stellar.dsl.Context;
+import org.apache.metron.stellar.dsl.DefaultVariableResolver;
 import org.apache.metron.stellar.dsl.MapVariableResolver;
 import org.apache.metron.stellar.dsl.StellarFunctions;
 import org.apache.metron.stellar.dsl.VariableResolver;
@@ -57,7 +58,7 @@ public class StellarProcessorUtils {
     public static Object run(String rule, Map<String, Object> variables, Context context) {
         StellarProcessor processor = new StellarProcessor();
         Assert.assertTrue(rule + " not valid.", processor.validate(rule, context));
-        Object ret = processor.parse(rule, x -> variables.get(x), StellarFunctions.FUNCTION_RESOLVER(), context);
+        Object ret = processor.parse(rule, new DefaultVariableResolver(x -> variables.get(x),x-> variables.containsKey(x)), StellarFunctions.FUNCTION_RESOLVER(), context);
         byte[] raw = SerDeUtils.toBytes(ret);
         Object actual = SerDeUtils.fromBytes(raw, Object.class);
         Assert.assertEquals(ret, actual);
@@ -66,6 +67,15 @@ public class StellarProcessorUtils {
 
   public static Object run(String rule, Map<String, Object> variables) {
     return run(rule, variables, Context.EMPTY_CONTEXT());
+  }
+
+  public static void validate(String rule, Context context) {
+    StellarProcessor processor = new StellarProcessor();
+    Assert.assertTrue(rule + " not valid.", processor.validate(rule, context));
+  }
+
+  public static void validate(String rule) {
+    validate(rule, Context.EMPTY_CONTEXT());
   }
 
   public static boolean runPredicate(String rule, Map resolver) {

--- a/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/dsl/Context.java
+++ b/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/dsl/Context.java
@@ -36,6 +36,14 @@ public class Context implements Serializable {
     , STELLAR_CONFIG
   }
 
+  public enum ActivityType {
+    VALIDATION_ACTIVITY,
+    PARSE_ACTIVITY
+  }
+
+  private static ThreadLocal<ActivityType> _activityType = ThreadLocal.withInitial(() ->
+      null);
+
   public static class Builder {
 
     private Map<String, Capability> capabilityMap = new HashMap<>();
@@ -73,6 +81,7 @@ public class Context implements Serializable {
             };
   }
 
+
   private Map<String, Capability> capabilities;
 
   private Context( Map<String, Capability> capabilities) {
@@ -109,5 +118,13 @@ public class Context implements Serializable {
 
   public void addCapability(Enum<?> s, Capability capability) {
     this.capabilities.put(s.toString(), capability);
+  }
+
+  public ActivityType getActivityType() {
+    return _activityType.get();
+  }
+
+  public void setActivityType(ActivityType activityType) {
+    _activityType.set(activityType);
   }
 }

--- a/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/dsl/DefaultVariableResolver.java
+++ b/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/dsl/DefaultVariableResolver.java
@@ -18,44 +18,27 @@
 
 package org.apache.metron.stellar.dsl;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.function.Function;
 
-public class MapVariableResolver implements VariableResolver {
+public class DefaultVariableResolver implements VariableResolver{
+  Function<String,Object> resolveFunc;
+  Function<String,Boolean> existsFunc;
 
-  List<Map> variableMappings = new ArrayList<>();
-
-  public MapVariableResolver(Map variableMappingOne, Map... variableMapping) {
-    if (variableMappingOne != null) {
-      variableMappings.add(variableMappingOne);
-    }
-    add(variableMapping);
+  public DefaultVariableResolver(Function<String,Object> resolveFunc, Function<String,Boolean> existsFunc){
+    this.resolveFunc = resolveFunc;
+    this.existsFunc = existsFunc;
   }
-
-  public void add(Map... ms) {
-    if (ms != null) {
-      for (Map m : ms) {
-        if (m != null) {
-          this.variableMappings.add(m);
-        }
-      }
-    }
-  }
-
   @Override
   public Object resolve(String variable) {
-    for (Map variableMapping : variableMappings) {
-      Object o = variableMapping.get(variable);
-      if (o != null) {
-        return o;
-      }
-    }
-    return null;
+    return resolveFunc.apply(variable);
   }
 
   @Override
   public boolean exists(String variable) {
-    return true;
+    return existsFunc.apply(variable);
+  }
+
+  public static DefaultVariableResolver NULL_RESOLVER() {
+    return new DefaultVariableResolver(x -> null, x -> false);
   }
 }

--- a/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/dsl/VariableResolver.java
+++ b/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/dsl/VariableResolver.java
@@ -18,6 +18,8 @@
 
 package org.apache.metron.stellar.dsl;
 
+
 public interface VariableResolver {
   Object resolve(String variable);
+  boolean exists(String variable);
 }

--- a/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/common/StellarComparisonExpressionWithOperatorTest.java
+++ b/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/common/StellarComparisonExpressionWithOperatorTest.java
@@ -19,6 +19,7 @@
 package org.apache.metron.stellar.common;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.metron.stellar.dsl.DefaultVariableResolver;
 import org.apache.metron.stellar.dsl.ParseException;
 import org.junit.Test;
 
@@ -49,8 +50,21 @@ public class StellarComparisonExpressionWithOperatorTest {
     assertEquals(1L < 3.0f, run("1L < 3.0f", ImmutableMap.of()));
     assertEquals(1 < 3.0f, run("1 < 3.0f", ImmutableMap.of()));
     assertEquals(1.0 < 3.0f, run("1.0 < 3.0f", ImmutableMap.of()));
-    assertEquals(false, run("foo < 3.0f", ImmutableMap.of()));
-    assertEquals(false, run("foo < foo", ImmutableMap.of()));
+    boolean thrown = false;
+    try {
+      run("foo < 3.0f", ImmutableMap.of());
+    }catch(ParseException pe){
+      thrown = true;
+    }
+    assertTrue(thrown);
+    thrown = false;
+    try {
+      run("foo < foo", ImmutableMap.of());
+    }catch(ParseException pe){
+      thrown = true;
+    }
+    assertTrue(thrown);
+
     assertEquals(1L < 3.0f ? true : false, run("if 1L < 3.0f then true else false", ImmutableMap.of()));
   }
 
@@ -72,43 +86,47 @@ public class StellarComparisonExpressionWithOperatorTest {
       put("foo.bar", "casey");
     }};
 
-    assertTrue(runPredicate("'casey' == foo.bar", variableMap::get));
-    assertTrue(runPredicate("'casey' == foo", variableMap::get));
-    assertFalse(runPredicate("'casey' != foo", variableMap::get));
-    assertTrue(runPredicate("'stella' == 'stella'", variableMap::get));
-    assertFalse(runPredicate("'stella' == foo", variableMap::get));
-    assertTrue(runPredicate("foo== foo", variableMap::get));
-    assertTrue(runPredicate("empty== ''", variableMap::get));
-    assertTrue(runPredicate("spaced == 'metron is great'", variableMap::get));
-    assertTrue(runPredicate(null, variableMap::get));
-    assertTrue(runPredicate("", variableMap::get));
-    assertTrue(runPredicate(" ", variableMap::get));
+    assertTrue(runPredicate("'casey' == foo.bar", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertTrue(runPredicate("'casey' == foo", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertFalse(runPredicate("'casey' != foo",new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertTrue(runPredicate("'stella' == 'stella'", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertFalse(runPredicate("'stella' == foo", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertTrue(runPredicate("foo== foo", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertTrue(runPredicate("empty== ''", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertTrue(runPredicate("spaced == 'metron is great'", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertTrue(runPredicate(null, new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertTrue(runPredicate("", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertTrue(runPredicate(" ",(new DefaultVariableResolver(variableMap::get,variableMap::containsKey))));
   }
 
   @Test
   public void compareNumberAndStringWithSameValueShouldBeFalse() throws Exception {
-    assertFalse(runPredicate("1 == '1'", new HashMap<>()::get));
-    assertFalse(runPredicate("'1' == 1", new HashMap<>()::get));
+    Map<String,String> variableMap = new HashMap<>();
+    assertFalse(runPredicate("1 == '1'", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertFalse(runPredicate("'1' == 1", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
   }
 
   @Test
   public void comparingNullShouldNotCauseNullPointer() throws Exception {
-    assertFalse(runPredicate("null == '1'", new HashMap<>()::get));
-    assertFalse(runPredicate("\"1\" == null", new HashMap<>()::get));
-    assertTrue(runPredicate("null == null", new HashMap<>()::get));
+    Map<String,String> variableMap = new HashMap<>();
+    assertFalse(runPredicate("null == '1'", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertFalse(runPredicate("\"1\" == null", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertTrue(runPredicate("null == null", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
   }
 
   @Test
   public void makeSureSingleQuotesAndDoubleQuotesAreEqual() throws Exception {
-    assertTrue(runPredicate("\"1\" == '1'", new HashMap<>()::get));
-    assertTrue(runPredicate("'1' == \"1\"", new HashMap<>()::get));
-    assertTrue(runPredicate("'1' == \"1\"", new HashMap<>()::get));
+    Map<String,String> variableMap = new HashMap<>();
+    assertTrue(runPredicate("\"1\" == '1'", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertTrue(runPredicate("'1' == \"1\"", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertTrue(runPredicate("'1' == \"1\"", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
   }
 
   @Test
   public void makeSureSingleQuoteStringsAreEvaluatedAsStrings() throws Exception {
-    assertFalse(runPredicate("55 == '7'", new HashMap<>()::get));
-    assertFalse(runPredicate("97 == 'a'", new HashMap<>()::get));
+    Map<String,String> variableMap = new HashMap<>();
+    assertFalse(runPredicate("55 == '7'", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertFalse(runPredicate("97 == 'a'", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
   }
 
   @Test
@@ -124,16 +142,16 @@ public class StellarComparisonExpressionWithOperatorTest {
       put("empty", "");
       put("spaced", "metron is great");
     }};
-    assertTrue(runPredicate("num == 7", variableMap::get));
-    assertTrue(runPredicate("num < num2", variableMap::get));
-    assertTrue(runPredicate("num < TO_DOUBLE(num2)", variableMap::get));
-    assertTrue(runPredicate("num < TO_DOUBLE(num4)", variableMap::get));
-    assertTrue(runPredicate("num < 100", variableMap::get));
-    assertTrue(runPredicate("num == num3", variableMap::get));
-    assertFalse(runPredicate("num == num2", variableMap::get));
-    assertTrue(runPredicate("num == num2 || true", variableMap::get));
-    assertFalse(runPredicate("num > num2", variableMap::get));
-    assertTrue(runPredicate("num == 7 && num > 2", variableMap::get));
+    assertTrue(runPredicate("num == 7", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertTrue(runPredicate("num < num2", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertTrue(runPredicate("num < TO_DOUBLE(num2)", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertTrue(runPredicate("num < TO_DOUBLE(num4)", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertTrue(runPredicate("num < 100", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertTrue(runPredicate("num == num3", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertFalse(runPredicate("num == num2", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertTrue(runPredicate("num == num2 || true", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertFalse(runPredicate("num > num2", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertTrue(runPredicate("num == 7 && num > 2", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
   }
 
   @Test
@@ -143,14 +161,14 @@ public class StellarComparisonExpressionWithOperatorTest {
     }};
 
     Arrays.asList("!=", "==").forEach(op -> {
-      assertEquals("==".equals(op), runPredicate("num " + op + " 0", variableMap::get));
-      assertEquals("==".equals(op), runPredicate("0 " + op + " -0", variableMap::get));
-      assertEquals("==".equals(op), runPredicate("0 " + op + " -0d", variableMap::get));
-      assertEquals("==".equals(op), runPredicate("-0 " + op + " 0", variableMap::get));
-      assertEquals("==".equals(op), runPredicate("-0F " + op + " 0D", variableMap::get));
-      assertEquals("==".equals(op), runPredicate("-0.F " + op + " 0", variableMap::get));
-      assertEquals("==".equals(op), runPredicate("-0.F " + op + " 0F", variableMap::get));
-      assertEquals("==".equals(op), runPredicate("-0.D " + op + " 0D", variableMap::get));
+      assertEquals("==".equals(op), runPredicate("num " + op + " 0", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals("==".equals(op), runPredicate("0 " + op + " -0", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals("==".equals(op), runPredicate("0 " + op + " -0d", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals("==".equals(op), runPredicate("-0 " + op + " 0", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals("==".equals(op), runPredicate("-0F " + op + " 0D", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals("==".equals(op), runPredicate("-0.F " + op + " 0", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals("==".equals(op), runPredicate("-0.F " + op + " 0F", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals("==".equals(op), runPredicate("-0.D " + op + " 0D", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
     });
   }
 
@@ -158,20 +176,20 @@ public class StellarComparisonExpressionWithOperatorTest {
   public void naNIsNotEqualToNaN() throws Exception {
     final Map<String, Object> variableMap = new HashMap<>();
     Arrays.asList("!=", "==").forEach(op -> {
-      assertEquals("!=".equals(op), runPredicate("(0f/0f) " + op + " (0f/0f)", variableMap::get));
-      assertEquals("!=".equals(op), runPredicate("(-0f/0f) " + op + " (0f/0f)", variableMap::get));
-      assertEquals("!=".equals(op), runPredicate("(-0f/-0f) " + op + " (0f/0f)", variableMap::get));
-      assertEquals("!=".equals(op), runPredicate("(-0f/-0f) " + op + " (-0f/0f)", variableMap::get));
-      assertEquals("!=".equals(op), runPredicate("(-0f/-0f) " + op + " (-0f/-0f)", variableMap::get));
-      assertEquals("!=".equals(op), runPredicate("(0f/-0f) " + op + " (0f/0f)", variableMap::get));
-      assertEquals("!=".equals(op), runPredicate("(0f/-0f) " + op + " (-0f/0f)", variableMap::get));
-      assertEquals("!=".equals(op), runPredicate("(0f/-0f) " + op + " (-0f/-0f)", variableMap::get));
-      assertEquals("!=".equals(op), runPredicate("(0f/0f) " + op + " (-0f/0f)", variableMap::get));
-      assertEquals("!=".equals(op), runPredicate("(0f/0d) " + op + " (-0f/-0f)", variableMap::get));
-      assertEquals("!=".equals(op), runPredicate("(0d/-0f) " + op + " (0f/-0f)", variableMap::get));
-      assertEquals("!=".equals(op), runPredicate("(-0f/0f) " + op + " (0f/-0d)", variableMap::get));
-      assertEquals("!=".equals(op), runPredicate("(-0d/-0d) " + op + " (0d/-0d)", variableMap::get));
-      assertEquals("!=".equals(op), runPredicate("(0d/0d) " + op + " (0d/0d)", variableMap::get));
+      assertEquals("!=".equals(op), runPredicate("(0f/0f) " + op + " (0f/0f)", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals("!=".equals(op), runPredicate("(-0f/0f) " + op + " (0f/0f)", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals("!=".equals(op), runPredicate("(-0f/-0f) " + op + " (0f/0f)", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals("!=".equals(op), runPredicate("(-0f/-0f) " + op + " (-0f/0f)", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals("!=".equals(op), runPredicate("(-0f/-0f) " + op + " (-0f/-0f)", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals("!=".equals(op), runPredicate("(0f/-0f) " + op + " (0f/0f)", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals("!=".equals(op), runPredicate("(0f/-0f) " + op + " (-0f/0f)", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals("!=".equals(op), runPredicate("(0f/-0f) " + op + " (-0f/-0f)", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals("!=".equals(op), runPredicate("(0f/0f) " + op + " (-0f/0f)", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals("!=".equals(op), runPredicate("(0f/0d) " + op + " (-0f/-0f)", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals("!=".equals(op), runPredicate("(0d/-0f) " + op + " (0f/-0f)", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals("!=".equals(op), runPredicate("(-0f/0f) " + op + " (0f/-0d)", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals("!=".equals(op), runPredicate("(-0d/-0d) " + op + " (0d/-0d)", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals("!=".equals(op), runPredicate("(0d/0d) " + op + " (0d/0d)", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
     });
   }
 
@@ -182,70 +200,70 @@ public class StellarComparisonExpressionWithOperatorTest {
       put("f", false);
     }};
 
-    assertTrue(runPredicate("t != f", variableMap::get));
-    assertTrue(runPredicate("f != t", variableMap::get));
-    assertTrue(runPredicate("true != false", variableMap::get));
-    assertFalse(runPredicate("true != true", variableMap::get));
-    assertTrue(runPredicate("false != true", variableMap::get));
-    assertFalse(runPredicate("false != false", variableMap::get));
+    assertTrue(runPredicate("t != f", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertTrue(runPredicate("f != t", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertTrue(runPredicate("true != false", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertFalse(runPredicate("true != true", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertTrue(runPredicate("false != true", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertFalse(runPredicate("false != false", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
 
-    assertFalse(runPredicate("t == f", variableMap::get));
-    assertFalse(runPredicate("f == t", variableMap::get));
-    assertFalse(runPredicate("true == false", variableMap::get));
-    assertTrue(runPredicate("true == true", variableMap::get));
-    assertFalse(runPredicate("false == true", variableMap::get));
-    assertTrue(runPredicate("false == false", variableMap::get));
+    assertFalse(runPredicate("t == f", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertFalse(runPredicate("f == t", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertFalse(runPredicate("true == false", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertTrue(runPredicate("true == true", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertFalse(runPredicate("false == true", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertTrue(runPredicate("false == false", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
 
-    assertFalse(runPredicate("null == false", variableMap::get));
-    assertFalse(runPredicate("null == true", variableMap::get));
-    assertFalse(runPredicate("true == NULL", variableMap::get));
-    assertFalse(runPredicate("false == NULL", variableMap::get));
+    assertFalse(runPredicate("null == false", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertFalse(runPredicate("null == true", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertFalse(runPredicate("true == NULL", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertFalse(runPredicate("false == NULL", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
   }
 
   @Test
   public void nullComparisonTests() throws Exception {
     final Map<String, Object> variableMap = new HashMap<>();
 
-    assertFalse(runPredicate("null == false", variableMap::get));
-    assertFalse(runPredicate("null == true", variableMap::get));
-    assertFalse(runPredicate("true == NULL", variableMap::get));
-    assertFalse(runPredicate("false == NULL", variableMap::get));
-    assertFalse(runPredicate("1 == NULL", variableMap::get));
-    assertFalse(runPredicate("'null' == NULL", variableMap::get));
-    assertFalse(runPredicate("'' == NULL", variableMap::get));
-    assertFalse(runPredicate("null == ''", variableMap::get));
+    assertFalse(runPredicate("null == false", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertFalse(runPredicate("null == true", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertFalse(runPredicate("true == NULL", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertFalse(runPredicate("false == NULL", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertFalse(runPredicate("1 == NULL", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertFalse(runPredicate("'null' == NULL", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertFalse(runPredicate("'' == NULL", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+    assertFalse(runPredicate("null == ''", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
 
-    assertTrue(runPredicate("NULL == null", variableMap::get));
+    assertTrue(runPredicate("NULL == null", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
   }
 
   @Test
   public void precisionEqualityTests() throws Exception {
     final Map<String, Object> variableMap = new HashMap<>();
-    assertEquals(0.1 + 0.2 == 0.3, runPredicate("0.1 + 0.2 == 0.3", variableMap::get));
+    assertEquals(0.1 + 0.2 == 0.3, runPredicate("0.1 + 0.2 == 0.3", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
   }
 
   @Test(expected = ParseException.class)
   public void differentTypesShouldThrowErrorWhenUsingLT() throws Exception {
     final Map<String, Object> variableMap = new HashMap<>();
-    runPredicate("1 < '1'", variableMap::get);
+    runPredicate("1 < '1'", new DefaultVariableResolver(variableMap::get,variableMap::containsKey));
   }
 
   @Test(expected = ParseException.class)
   public void differentTypesShouldThrowErrorWhenUsingLTE() throws Exception {
     final Map<String, Object> variableMap = new HashMap<>();
-    runPredicate("'1' <= 1", variableMap::get);
+    runPredicate("'1' <= 1", new DefaultVariableResolver(variableMap::get,variableMap::containsKey));
   }
 
   @Test(expected = ParseException.class)
   public void differentTypesShouldThrowErrorWhenUsingGT() throws Exception {
     final Map<String, Object> variableMap = new HashMap<>();
-    runPredicate("1 > '1'", variableMap::get);
+    runPredicate("1 > '1'", new DefaultVariableResolver(variableMap::get,variableMap::containsKey));
   }
 
   @Test(expected = ParseException.class)
   public void differentTypesShouldThrowErrorWhenUsingGTE() throws Exception {
     final Map<String, Object> variableMap = new HashMap<>();
-    runPredicate("'1' >= 1", variableMap::get);
+    runPredicate("'1' >= 1", new DefaultVariableResolver(variableMap::get,variableMap::containsKey));
   }
 
   @Test
@@ -254,7 +272,7 @@ public class StellarComparisonExpressionWithOperatorTest {
     final Integer[] result = {0};
 
     Stream.of("<", "<=", ">", ">=").forEach(op -> {
-      assertFalse(runPredicate("'1' " + op + " null", variableMap::get));
+      assertFalse(runPredicate("'1' " + op + " null", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
     });
   }
 
@@ -262,32 +280,32 @@ public class StellarComparisonExpressionWithOperatorTest {
   public void makeSurePrecisionIsProperlyHandled() throws Exception {
     final Map<String, Object> variableMap = new HashMap<>();
     {
-      assertEquals(1 == 1.00000001, runPredicate("1 == 1.00000001", variableMap::get));
-      assertEquals(1 < 1.00000001, runPredicate("1 < 1.00000001", variableMap::get));
-      assertEquals(1 <= 1.00000001, runPredicate("1 <= 1.00000001", variableMap::get));
-      assertEquals(1 > 1.00000001, runPredicate("1 > 1.00000001", variableMap::get));
-      assertEquals(1 >= 1.00000001, runPredicate("1 >= 1.00000001", variableMap::get));
+      assertEquals(1 == 1.00000001, runPredicate("1 == 1.00000001", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals(1 < 1.00000001, runPredicate("1 < 1.00000001", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals(1 <= 1.00000001, runPredicate("1 <= 1.00000001", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals(1 > 1.00000001, runPredicate("1 > 1.00000001", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals(1 >= 1.00000001, runPredicate("1 >= 1.00000001", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
     }
     {
-      assertEquals(1 == 1.00000001F, runPredicate("1 == 1.00000001F", variableMap::get));
-      assertEquals(1 < 1.00000001F, runPredicate("1 < 1.00000001F", variableMap::get));
-      assertEquals(1 <= 1.00000001F, runPredicate("1 <= 1.00000001F", variableMap::get));
-      assertEquals(1 > 1.00000001F, runPredicate("1 > 1.00000001F", variableMap::get));
-      assertEquals(1 >= 1.00000001F, runPredicate("1 >= 1.00000001F", variableMap::get));
+      assertEquals(1 == 1.00000001F, runPredicate("1 == 1.00000001F", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals(1 < 1.00000001F, runPredicate("1 < 1.00000001F", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals(1 <= 1.00000001F, runPredicate("1 <= 1.00000001F", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals(1 > 1.00000001F, runPredicate("1 > 1.00000001F", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals(1 >= 1.00000001F, runPredicate("1 >= 1.00000001F", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
     }
     {
-      assertEquals(1.00000001F == 1.00000001, runPredicate("1.00000001F == 1.00000001", variableMap::get));
-      assertEquals(1.00000001F < 1.00000001, runPredicate("1.00000001F < 1.00000001", variableMap::get));
-      assertEquals(1.00000001F <= 1.00000001, runPredicate("1.00000001F <= 1.00000001", variableMap::get));
-      assertEquals(1.00000001F > 1.00000001, runPredicate("1.00000001F > 1.00000001", variableMap::get));
-      assertEquals(1.00000001F >= 1.00000001, runPredicate("1.00000001F >= 1.00000001", variableMap::get));
+      assertEquals(1.00000001F == 1.00000001, runPredicate("1.00000001F == 1.00000001", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals(1.00000001F < 1.00000001, runPredicate("1.00000001F < 1.00000001", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals(1.00000001F <= 1.00000001, runPredicate("1.00000001F <= 1.00000001", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals(1.00000001F > 1.00000001, runPredicate("1.00000001F > 1.00000001", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals(1.00000001F >= 1.00000001, runPredicate("1.00000001F >= 1.00000001", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
     }
     {
-      assertEquals(-1L == -1.00000001F, runPredicate("-1L == -1.00000001F", variableMap::get));
-      assertEquals(-1L < -1.00000001F, runPredicate("-1L < -1.00000001F", variableMap::get));
-      assertEquals(-1L <= -1.00000001F, runPredicate("-1L <= -1.00000001F", variableMap::get));
-      assertEquals(-1L > -1.00000001F, runPredicate("-1L > -1.00000001F", variableMap::get));
-      assertEquals(-1L >= -1.00000001F, runPredicate("-1L >= -1.00000001F", variableMap::get));
+      assertEquals(-1L == -1.00000001F, runPredicate("-1L == -1.00000001F", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals(-1L < -1.00000001F, runPredicate("-1L < -1.00000001F", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals(-1L <= -1.00000001F, runPredicate("-1L <= -1.00000001F", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals(-1L > -1.00000001F, runPredicate("-1L > -1.00000001F", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
+      assertEquals(-1L >= -1.00000001F, runPredicate("-1L >= -1.00000001F", new DefaultVariableResolver(variableMap::get,variableMap::containsKey)));
     }
   }
 }

--- a/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/common/shell/StellarShellOptionsValidatorTest.java
+++ b/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/common/shell/StellarShellOptionsValidatorTest.java
@@ -89,106 +89,106 @@ public class StellarShellOptionsValidatorTest {
 
     // these should not
 
-    boolean caught = false;
+    boolean thrown = false;
 
     try {
       commandLine = parser.parse(options, invalidZNoPortArg);
       StellarShellOptionsValidator.validateOptions(commandLine);
     } catch (IllegalArgumentException e) {
-      caught = true;
+      thrown = true;
     }
-    Assert.assertTrue("Did not catch failure for not providing port with host name ", caught);
-    caught = false;
+    Assert.assertTrue("Did not catch failure for not providing port with host name ", thrown);
+    thrown = false;
 
     try {
       commandLine = parser.parse(options, invalidZIPNoPortArg);
       StellarShellOptionsValidator.validateOptions(commandLine);
     } catch (IllegalArgumentException e) {
-      caught = true;
+      thrown = true;
     }
-    Assert.assertTrue("Did not catch failure for not providing port with ip address ", caught);
-    caught = false;
+    Assert.assertTrue("Did not catch failure for not providing port with ip address ", thrown);
+    thrown = false;
 
     try {
       commandLine = parser.parse(options, invalidZNameArg);
       StellarShellOptionsValidator.validateOptions(commandLine);
     } catch (IllegalArgumentException e) {
-      caught = true;
+      thrown = true;
     }
-    Assert.assertTrue("Did not catch failure for providing invalid host name ", caught);
-    caught = false;
+    Assert.assertTrue("Did not catch failure for providing invalid host name ", thrown);
+    thrown = false;
 
     try {
       commandLine = parser.parse(options, invalidZIPArg);
       StellarShellOptionsValidator.validateOptions(commandLine);
     } catch (IllegalArgumentException e) {
-      caught = true;
+      thrown = true;
     }
-    Assert.assertTrue("Did not catch failure for providing invalid ip address ", caught);
-    caught = false;
+    Assert.assertTrue("Did not catch failure for providing invalid ip address ", thrown);
+    thrown = false;
 
     try {
       commandLine = parser.parse(options, invalidZMissingNameArg);
       StellarShellOptionsValidator.validateOptions(commandLine);
     } catch (IllegalArgumentException e) {
-      caught = true;
+      thrown = true;
     }
-    Assert.assertTrue("Did not catch failure for only providing port ", caught);
-    caught = false;
+    Assert.assertTrue("Did not catch failure for only providing port ", thrown);
+    thrown = false;
 
     try {
       commandLine = parser.parse(options, invalidZZeroPortArg);
       StellarShellOptionsValidator.validateOptions(commandLine);
     } catch (IllegalArgumentException e) {
-      caught = true;
+      thrown = true;
     }
-    Assert.assertTrue("Did not catch failure for 0 port ", caught);
-    caught = false;
+    Assert.assertTrue("Did not catch failure for 0 port ", thrown);
+    thrown = false;
 
     try {
       commandLine = parser.parse(options, invalidZHugePortArg);
       StellarShellOptionsValidator.validateOptions(commandLine);
     } catch (IllegalArgumentException e) {
-      caught = true;
+      thrown = true;
     }
-    Assert.assertTrue("Did not catch failure for port out of range ", caught);
-    caught = false;
+    Assert.assertTrue("Did not catch failure for port out of range ", thrown);
+    thrown = false;
 
     try {
       commandLine = parser.parse(options, invalidVFileArg);
       StellarShellOptionsValidator.validateOptions(commandLine);
     } catch (IllegalArgumentException e) {
-      caught = true;
+      thrown = true;
     }
-    Assert.assertTrue("Did not catch failure for passing non-existant file to -v ", caught);
-    caught = false;
+    Assert.assertTrue("Did not catch failure for passing non-existant file to -v ", thrown);
+    thrown = false;
 
     try {
       commandLine = parser.parse(options, invalidVFileArg);
       StellarShellOptionsValidator.validateOptions(commandLine);
     } catch (IllegalArgumentException e) {
-      caught = true;
+      thrown = true;
     }
-    Assert.assertTrue("Did not catch failure for passing non-existant file to -v ", caught);
-    caught = false;
+    Assert.assertTrue("Did not catch failure for passing non-existant file to -v ", thrown);
+    thrown = false;
 
     try {
       commandLine = parser.parse(options, invalidIrcFileArg);
       StellarShellOptionsValidator.validateOptions(commandLine);
     } catch (IllegalArgumentException e) {
-      caught = true;
+      thrown = true;
     }
-    Assert.assertTrue("Did not catch failure for passing non-existant file to -irc ", caught);
-    caught = false;
+    Assert.assertTrue("Did not catch failure for passing non-existant file to -irc ", thrown);
+    thrown = false;
 
     try {
       commandLine = parser.parse(options, invalidPFileArg);
       StellarShellOptionsValidator.validateOptions(commandLine);
     } catch (IllegalArgumentException e) {
-      caught = true;
+      thrown = true;
     }
-    Assert.assertTrue("Did not catch failure for passing non-existant file to -p ", caught);
-    caught = false;
+    Assert.assertTrue("Did not catch failure for passing non-existant file to -p ", thrown);
+    thrown = false;
   }
 
 }

--- a/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/common/utils/BloomFilterTest.java
+++ b/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/common/utils/BloomFilterTest.java
@@ -20,6 +20,7 @@
 package org.apache.metron.stellar.common.utils;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.metron.stellar.dsl.ParseException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -88,8 +89,13 @@ public class BloomFilterTest {
       Assert.assertFalse(result);
     }
     {
-      Boolean result = (Boolean) run("BLOOM_EXISTS(BLOOM_ADD(BLOOM_INIT(), string, double, integer, map), sam)", variables);
-      Assert.assertFalse(result);
+      boolean thrown = false;
+      try{
+        run("BLOOM_EXISTS(BLOOM_ADD(BLOOM_INIT(), string, double, integer, map), sam)", variables);
+      }catch(ParseException pe){
+        thrown = true;
+      }
+      Assert.assertTrue(thrown);
     }
   }
 }

--- a/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/dsl/functions/DateFunctionsTest.java
+++ b/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/dsl/functions/DateFunctionsTest.java
@@ -22,6 +22,8 @@ package org.apache.metron.stellar.dsl.functions;
 
 import org.apache.metron.stellar.common.StellarProcessor;
 import org.apache.metron.stellar.dsl.Context;
+import org.apache.metron.stellar.dsl.DefaultVariableResolver;
+import org.apache.metron.stellar.dsl.ParseException;
 import org.apache.metron.stellar.dsl.StellarFunctions;
 import org.junit.Before;
 import org.junit.Test;
@@ -48,7 +50,7 @@ public class DateFunctionsTest {
   private Object run(String expr) {
     StellarProcessor processor = new StellarProcessor();
     assertTrue(processor.validate(expr));
-    return processor.parse(expr, x -> variables.get(x), StellarFunctions.FUNCTION_RESOLVER(), Context.EMPTY_CONTEXT());
+    return processor.parse(expr, new DefaultVariableResolver( x -> variables.get(x), x -> variables.containsKey(x)), StellarFunctions.FUNCTION_RESOLVER(), Context.EMPTY_CONTEXT());
   }
 
   /**
@@ -78,12 +80,11 @@ public class DateFunctionsTest {
   }
 
   /**
-   * If refer to variable that does not exist, expect null returned.
+   * If refer to variable that does not exist, expect ParseException.
    */
-  @Test
+  @Test(expected = ParseException.class)
   public void testDayOfWeekNull() {
     Object result = run("DAY_OF_WEEK(nada)");
-    assertEquals(null, result);
   }
 
   @Test
@@ -102,12 +103,11 @@ public class DateFunctionsTest {
   }
 
   /**
-   * If refer to variable that does not exist, expect null returned.
+   * If refer to variable that does not exist, expect ParseException.
    */
-  @Test
+  @Test(expected = ParseException.class)
   public void testWeekOfMonthNull() {
     Object result = run("WEEK_OF_MONTH(nada)");
-    assertEquals(null, result);
   }
 
   @Test
@@ -126,12 +126,11 @@ public class DateFunctionsTest {
   }
 
   /**
-   * If refer to variable that does not exist, expect null returned.
+   * If refer to variable that does not exist, expect ParseException.
    */
-  @Test
+  @Test(expected = ParseException.class)
   public void testMonthNull() {
     Object result = run("MONTH(nada)");
-    assertEquals(null, result);
   }
 
   @Test
@@ -150,12 +149,11 @@ public class DateFunctionsTest {
   }
 
   /**
-   * If refer to variable that does not exist, expect null returned.
+   * If refer to variable that does not exist, expect ParseException.
    */
-  @Test
+  @Test(expected = ParseException.class)
   public void testYearNull() {
     Object result = run("YEAR(nada)");
-    assertEquals(null, result);
   }
 
   @Test
@@ -174,12 +172,11 @@ public class DateFunctionsTest {
   }
 
   /**
-   * If refer to variable that does not exist, expect null returned.
+   * If refer to variable that does not exist, expect ParseException.
    */
-  @Test
+  @Test(expected = ParseException.class)
   public void testDayOfMonthNull() {
     Object result = run("DAY_OF_MONTH(nada)");
-    assertEquals(null, result);
   }
 
   @Test
@@ -198,12 +195,11 @@ public class DateFunctionsTest {
   }
 
   /**
-   * If refer to variable that does not exist, expect null returned.
+   * If refer to variable that does not exist, expect ParseException.
    */
-  @Test
+  @Test(expected = ParseException.class)
   public void testWeekOfYearNull() {
     Object result = run("WEEK_OF_YEAR(nada)");
-    assertEquals(null, result);
   }
 
   @Test
@@ -222,11 +218,10 @@ public class DateFunctionsTest {
   }
 
   /**
-   * If refer to variable that does not exist, expect null returned.
+   * If refer to variable that does not exist, expect ParseException.
    */
-  @Test
+  @Test(expected = ParseException.class)
   public void testDayOfYearNull() {
     Object result = run("DAY_OF_YEAR(nada)");
-    assertEquals(null, result);
   }
 }

--- a/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/dsl/functions/EncodingFunctionsTest.java
+++ b/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/dsl/functions/EncodingFunctionsTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.metron.stellar.common.encoding.Encodings;
+import org.apache.metron.stellar.dsl.DefaultVariableResolver;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -62,16 +63,16 @@ public class EncodingFunctionsTest {
 
   @Test
   public void testEncodingIs() throws Exception{
-    Assert.assertTrue(runPredicate("IS_ENCODING(BASE32_FIXTURE,'BASE32')", v -> variableMap.get(v)));
-    Assert.assertFalse(runPredicate("IS_ENCODING(STRING_FIXTURE,'BASE32')", v -> variableMap.get(v)));
-    Assert.assertTrue(runPredicate("IS_ENCODING(BASE32HEX_FIXTURE,'BASE32HEX')", v -> variableMap.get(v)));
-    Assert.assertFalse(runPredicate("IS_ENCODING(STRING_FIXTURE,'BASE32HEX')", v -> variableMap.get(v)));
-    Assert.assertTrue(runPredicate("IS_ENCODING(BASE64_FIXTURE,'BASE64')", v -> variableMap.get(v)));
-    Assert.assertFalse(runPredicate("IS_ENCODING(STRING_FIXTURE_PLUS_NULL,'BASE64')", v -> variableMap.get(v)));
-    Assert.assertTrue(runPredicate("IS_ENCODING(BINARY_FIXTURE,'BINARY')", v -> variableMap.get(v)));
-    Assert.assertFalse(runPredicate("IS_ENCODING(STRING_FIXTURE,'BINARY')", v -> variableMap.get(v)));
-    Assert.assertTrue(runPredicate("IS_ENCODING(HEX_FIXTURE,'HEX')", v -> variableMap.get(v)));
-    Assert.assertFalse(runPredicate("IS_ENCODING(STRING_FIXTURE,'HEX')", v -> variableMap.get(v)));
+    Assert.assertTrue(runPredicate("IS_ENCODING(BASE32_FIXTURE,'BASE32')", new DefaultVariableResolver(v -> variableMap.get(v),v -> variableMap.containsKey(v))));
+    Assert.assertFalse(runPredicate("IS_ENCODING(STRING_FIXTURE,'BASE32')", new DefaultVariableResolver(v -> variableMap.get(v),v -> variableMap.containsKey(v))));
+    Assert.assertTrue(runPredicate("IS_ENCODING(BASE32HEX_FIXTURE,'BASE32HEX')", new DefaultVariableResolver(v -> variableMap.get(v),v -> variableMap.containsKey(v))));
+    Assert.assertFalse(runPredicate("IS_ENCODING(STRING_FIXTURE,'BASE32HEX')", new DefaultVariableResolver(v -> variableMap.get(v),v -> variableMap.containsKey(v))));
+    Assert.assertTrue(runPredicate("IS_ENCODING(BASE64_FIXTURE,'BASE64')", new DefaultVariableResolver(v -> variableMap.get(v),v -> variableMap.containsKey(v))));
+    Assert.assertFalse(runPredicate("IS_ENCODING(STRING_FIXTURE_PLUS_NULL,'BASE64')", new DefaultVariableResolver(v -> variableMap.get(v),v -> variableMap.containsKey(v))));
+    Assert.assertTrue(runPredicate("IS_ENCODING(BINARY_FIXTURE,'BINARY')", new DefaultVariableResolver(v -> variableMap.get(v),v -> variableMap.containsKey(v))));
+    Assert.assertFalse(runPredicate("IS_ENCODING(STRING_FIXTURE,'BINARY')", new DefaultVariableResolver(v -> variableMap.get(v),v -> variableMap.containsKey(v))));
+    Assert.assertTrue(runPredicate("IS_ENCODING(HEX_FIXTURE,'HEX')", new DefaultVariableResolver(v -> variableMap.get(v),v -> variableMap.containsKey(v))));
+    Assert.assertFalse(runPredicate("IS_ENCODING(STRING_FIXTURE,'HEX')", new DefaultVariableResolver(v -> variableMap.get(v),v -> variableMap.containsKey(v))));
   }
 
   @Test

--- a/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/dsl/functions/FunctionalFunctionsTest.java
+++ b/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/dsl/functions/FunctionalFunctionsTest.java
@@ -195,7 +195,12 @@ public class FunctionalFunctionsTest {
     )
             )
     {
-      Object o = run(expr, ImmutableMap.of("foo", 2, "bar", 3));
+      Map<String,Object> variableMap = new HashMap<String,Object>(){{
+        put("foo",2);
+        put("bar", 3);
+        put("baz",null);
+      }};
+      Object o = run(expr,variableMap);
       Assert.assertTrue(o instanceof List);
       List<String> result = (List<String>) o;
       Assert.assertEquals(3, result.size());
@@ -287,7 +292,12 @@ public class FunctionalFunctionsTest {
                                        )
         )
     {
-      Object o = run(expr, ImmutableMap.of("foo", "foo", "bar", "bar"));
+      Map<String,Object> variableMap = new HashMap<String,Object>(){{
+        put("foo","foo");
+        put("bar","bar");
+        put("baz",null);
+      }};
+      Object o = run(expr,variableMap);
       Assert.assertTrue(o instanceof List);
       List<String> result = (List<String>) o;
       Assert.assertEquals(1, result.size());
@@ -303,7 +313,12 @@ public class FunctionalFunctionsTest {
                                        )
         )
     {
-      Object o = run(expr, ImmutableMap.of("foo", "foo", "bar", "bar"));
+      Map<String,Object> variableMap = new HashMap<String,Object>(){{
+        put("foo","foo");
+        put("bar","bar");
+        put("baz",null);
+      }};
+      Object o = run(expr,variableMap);
       Assert.assertTrue(o instanceof List);
       List<String> result = (List<String>) o;
       Assert.assertEquals(1, result.size());
@@ -355,7 +370,12 @@ public class FunctionalFunctionsTest {
                                        )
         )
     {
-      Object o = run(expr, ImmutableMap.of("foo", 1, "bar", 2));
+      Map<String,Object> variableMap = new HashMap<String,Object>(){{
+        put("foo",1);
+        put("bar", 2);
+        put("baz",null);
+      }};
+      Object o = run(expr,variableMap);
       Assert.assertTrue(o instanceof Number);
       Number result = (Number) o;
       Assert.assertEquals(6, result.intValue());
@@ -407,7 +427,7 @@ public class FunctionalFunctionsTest {
                                        )
         )
     {
-      Object o = run(expr, ImmutableMap.of("foo", 1, "bar", 2));
+      Object o = run(expr, ImmutableMap.of("foo", 1, "bar", 2,"x",0,"y",0));
       Assert.assertTrue(o instanceof List);
       List<String> result = (List<String>) o;
       Assert.assertEquals(3, result.size());

--- a/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/dsl/functions/MathFunctionsTest.java
+++ b/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/dsl/functions/MathFunctionsTest.java
@@ -176,7 +176,7 @@ public class MathFunctionsTest {
          )
       {
         if (Double.isNaN(test.getValue())) {
-          Assert.assertTrue(expr + " != NaN, where value == " + test.getKey(), Double.isNaN(toDouble(run(expr, ImmutableMap.of("value", test.getKey())))));
+          Assert.assertTrue(expr + " != NaN, where value == " + test.getKey(), Double.isNaN(toDouble(run(expr, ImmutableMap.of("value", test.getKey(),"NaN",Double.NaN)))));
         } else {
           Assert.assertEquals(expr + " != " + test.getValue() + " (where value == " + test.getKey() + ")", test.getValue(), toDouble(run(expr, ImmutableMap.of("value", test.getKey()))), EPSILON);
         }

--- a/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/dsl/functions/MathFunctionsTest.java
+++ b/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/dsl/functions/MathFunctionsTest.java
@@ -22,6 +22,7 @@ package org.apache.metron.stellar.dsl.functions;
 import com.google.common.collect.ImmutableMap;
 import org.apache.metron.stellar.common.StellarProcessor;
 import org.apache.metron.stellar.dsl.Context;
+import org.apache.metron.stellar.dsl.DefaultVariableResolver;
 import org.apache.metron.stellar.dsl.StellarFunctions;
 import org.junit.Assert;
 import org.junit.Test;
@@ -33,7 +34,7 @@ public class MathFunctionsTest {
     Context context = Context.EMPTY_CONTEXT();
     StellarProcessor processor = new StellarProcessor();
     Assert.assertTrue(rule + " not valid.", processor.validate(rule, context));
-    return processor.parse(rule, x -> variables.get(x), StellarFunctions.FUNCTION_RESOLVER(), context);
+    return processor.parse(rule, new DefaultVariableResolver(v -> variables.get(v),v -> variables.containsKey(v)), StellarFunctions.FUNCTION_RESOLVER(), context);
   }
 
   @Test

--- a/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/dsl/functions/RegExFunctionsTest.java
+++ b/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/dsl/functions/RegExFunctionsTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.metron.stellar.dsl.functions;
 
+import org.apache.metron.stellar.dsl.DefaultVariableResolver;
 import org.apache.metron.stellar.dsl.ParseException;
 import org.junit.Assert;
 import org.junit.Test;
@@ -39,8 +40,8 @@ public class RegExFunctionsTest {
       put("empty", "");
     }};
 
-    Assert.assertTrue(runPredicate("REGEXP_MATCH(numbers,numberPattern)", v -> variableMap.get(v)));
-    Assert.assertFalse(runPredicate("REGEXP_MATCH(letters,numberPattern)", v -> variableMap.get(v)));
+    Assert.assertTrue(runPredicate("REGEXP_MATCH(numbers,numberPattern)", new DefaultVariableResolver(v -> variableMap.get(v),v -> variableMap.containsKey(v))));
+    Assert.assertFalse(runPredicate("REGEXP_MATCH(letters,numberPattern)", new DefaultVariableResolver(v -> variableMap.get(v),v -> variableMap.containsKey(v))));
   }
 
   @Test
@@ -52,18 +53,18 @@ public class RegExFunctionsTest {
       put("letters", "abcde");
       put("empty", "");
     }};
-    Assert.assertTrue(runPredicate("REGEXP_GROUP_VAL(numbers,numberPattern,2) == '3'", v -> variableMap.get(v)));
-    Assert.assertTrue(runPredicate("REGEXP_GROUP_VAL(letters,numberPattern,2) == null", v -> variableMap.get(v)));
-    Assert.assertTrue(runPredicate("REGEXP_GROUP_VAL(empty,numberPattern,2) == null", v -> variableMap.get(v)));
-    Assert.assertTrue(runPredicate("REGEXP_GROUP_VAL(numbers,numberPatternNoCaptures,2) == null", v -> variableMap.get(v)));
+    Assert.assertTrue(runPredicate("REGEXP_GROUP_VAL(numbers,numberPattern,2) == '3'", new DefaultVariableResolver(v -> variableMap.get(v),v -> variableMap.containsKey(v))));
+    Assert.assertTrue(runPredicate("REGEXP_GROUP_VAL(letters,numberPattern,2) == null", new DefaultVariableResolver(v -> variableMap.get(v),v -> variableMap.containsKey(v))));
+    Assert.assertTrue(runPredicate("REGEXP_GROUP_VAL(empty,numberPattern,2) == null", new DefaultVariableResolver(v -> variableMap.get(v),v -> variableMap.containsKey(v))));
+    Assert.assertTrue(runPredicate("REGEXP_GROUP_VAL(numbers,numberPatternNoCaptures,2) == null", new DefaultVariableResolver(v -> variableMap.get(v),v -> variableMap.containsKey(v))));
 
-    boolean caught = false;
+    boolean thrown = false;
     try{
-      runPredicate("REGEXP_GROUP_VAL(2) == null", v -> variableMap.get(v));
+      runPredicate("REGEXP_GROUP_VAL(2) == null", new DefaultVariableResolver(v -> variableMap.get(v),v -> variableMap.containsKey(v)));
     }catch(ParseException | IllegalStateException ise){
-      caught = true;
+      thrown = true;
     }
-    if(!caught){
+    if(!thrown){
       Assert.assertTrue("Did not fail on wrong number of parameters",false);
     }
   }


### PR DESCRIPTION
That being that there IS a variable at all vs. there is a variable, and its value is NULL.

Referenced variables in Stellar statements with the default variable resolver will throw ParseExceptions
if they are not included or passed.  Other variable resolvers can implement this policy as they need.
For example the LambdaExpression's VariableResolver as well as the MapResolver used in enrichments and parsers allow missing variables, since the variable naming in the lambda expression is arbitrary and separate from the original call context.  This means that for StellarFieldTransforms and StellarEnrichment there is no change in behavior.

The context supports this by maintaining a thread local activity type, such that the context can be inspected for a validation vs. a parse operation. Variables are not present during validation and this is allowed.

Tests have been changed or updated ( hopefully ) to thier _intent_ where possible.  If they were testing
for handling a variable that *is* null vs a missing variable etc.

### Implementation
The VariableResolver interface now has a second function -> exists(). This allows for checking if there is a variable at all.  The resolve method would return null for both cases.   A new DefaultVariableResolver class has been created, to help callers who were only passing something like (x) -> hashMap.get(x),  to parse.

The ActivityType enum has been added ( see Context.java ).  It is stored as a thread local var in the Context.  We set this to Parse or Validate depending on the operation. We don't need to check during validation. It is a implemented as a thread local var to support instances where we use a single context in multiple threads.

### Testing
All tests should pass when building the product
Full Dev should run and have data

### Questions for Review

1.  Are there issues here that are not accounted for with upgrading or ????
2. I am not sure that some of the classes and interfaces in DSL shouldn't be in Common ( like VariableResolver ).


### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [ ] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [ ] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && build_utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
