### PR TITLE
METRON-1110: REST jvm flags property is being overwritten when Kerberos is enabled

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/management_ui_master.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/management_ui_master.py
@@ -43,8 +43,10 @@ class ManagementUIMaster(Script):
     def configure(self, env, upgrade_type=None, config_dir=None):
         print 'configure managment_ui'
         from params import params
-        env.set_params(params)
+        if params.security_enabled:
+          params.metron_jvm_flags += format(' -Djava.security.auth.login.config={client_jaas_path}')
 
+        env.set_params(params)
         File(format("/etc/default/metron"),
              content=Template("metron.j2")
              )

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/management_ui_master.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/management_ui_master.py
@@ -43,9 +43,6 @@ class ManagementUIMaster(Script):
     def configure(self, env, upgrade_type=None, config_dir=None):
         print 'configure managment_ui'
         from params import params
-        if params.security_enabled:
-          params.metron_jvm_flags += format(' -Djava.security.auth.login.config={client_jaas_path}')
-
         env.set_params(params)
         File(format("/etc/default/metron"),
              content=Template("metron.j2")

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/params_linux.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/params_linux.py
@@ -203,6 +203,7 @@ client_jaas_path = metron_home + '/client_jaas.conf'
 client_jaas_arg = '-Djava.security.auth.login.config=' + metron_home + '/client_jaas.conf'
 enrichment_topology_worker_childopts = client_jaas_arg if security_enabled else ''
 indexing_topology_worker_childopts = client_jaas_arg if security_enabled else ''
+metron_jvm_flags += (' ' + client_jaas_arg) if security_enabled else ''
 topology_auto_credentials = config['configurations']['storm-site'].get('nimbus.credential.renewers.classes', [])
 # Needed for storm.config, because it needs Java String
 topology_auto_credentials_double_quotes = str(topology_auto_credentials).replace("'", '"')

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/rest_master.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/rest_master.py
@@ -38,9 +38,6 @@ class RestMaster(Script):
 
     def configure(self, env, upgrade_type=None, config_dir=None):
         from params import params
-        if params.security_enabled:
-            params.metron_jvm_flags += format(' -Djava.security.auth.login.config={client_jaas_path}')
-
         env.set_params(params)
         File(format("/etc/default/metron"),
              content=Template("metron.j2")

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/rest_master.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/rest_master.py
@@ -39,7 +39,7 @@ class RestMaster(Script):
     def configure(self, env, upgrade_type=None, config_dir=None):
         from params import params
         if params.security_enabled:
-            params.metron_jvm_flags = format('-Djava.security.auth.login.config={client_jaas_path}')
+            params.metron_jvm_flags += format(' -Djava.security.auth.login.config={client_jaas_path}')
 
         env.set_params(params)
         File(format("/etc/default/metron"),


### PR DESCRIPTION
## Contributor Comments
When Kerberos is enabled, the REST JVM flags property is being overwritten with the jaas property.  The jaas property should be appended instead.  This can be verified in full dev by enabling Kerberos and adding a property to the "Metron JVM flags" setting in Ambari under the REST tab.  Running `ps -ef | grep metron-rest` on the command line should show that the added property is now present in the start command.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && build_utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.

