### PR TITLE
METRON-1111 Mislabeled Configuration Property in Ambari

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/configuration/metron-enrichment-env.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/configuration/metron-enrichment-env.xml
@@ -83,19 +83,19 @@
   </property>
   <property>
     <name>enrichment_workers</name>
-    <description>Number of Enrichment Topology Workers</description>
+    <description>Number of Workers for the Enrichment Topology</description>
     <value>1</value>
     <display-name>Enrichment Workers</display-name>
   </property>
   <property>
     <name>enrichment_acker_executors</name>
-    <description>Number of Enrichment Topology Ackers</description>
+    <description>Number of Ackers for the Enrichment Topology</description>
     <value>1</value>
     <display-name>Enrichment Ackers</display-name>
   </property>
   <property>
     <name>enrichment_topology_worker_childopts</name>
-    <description>Enrichment Topology JVM Options</description>
+    <description>JVM Options for the Enrichment Topology</description>
     <value/>
     <display-name>Enrichment childopts</display-name>
     <value-attributes>
@@ -104,7 +104,7 @@
   </property>
   <property>
     <name>enrichment_topology_max_spout_pending</name>
-    <description>Enrichment Topology Spout Max Pending Tuples</description>
+    <description>Spout Max Pending Tuples for the Enrichment Topology</description>
     <value/>
     <display-name>Enrichment Max Pending</display-name>
     <value-attributes>
@@ -125,49 +125,49 @@
   </property>
   <property>
     <name>enrichment_kafka_spout_parallelism</name>
-    <description>Enrichment Topology Kafka Spout Parallelism</description>
+    <description>Kafka Spout Parallelism for the Enrichment Topology</description>
     <value>1</value>
     <display-name>Enrichment Spout Parallelism</display-name>
   </property>
   <property>
     <name>enrichment_split_parallelism</name>
-    <description>Enrichment Topology Enrichment Split Bolt Parallelism</description>
+    <description>Enrichment Split Bolt Parallelism for the Enrichment Topology</description>
     <value>1</value>
     <display-name>Enrichment Split Parallelism</display-name>
   </property>
   <property>
     <name>enrichment_stellar_parallelism</name>
-    <description>Enrichment Topology Enrichment Stellar Bolt Parallelism</description>
+    <description>Stellar Enrichment Bolt Parallelism for the Enrichment Topology</description>
     <value>1</value>
-    <display-name>Enrichment Stellar Parallelism</display-name>
+    <display-name>Stellar Enrichment Parallelism</display-name>
   </property>
   <property>
     <name>enrichment_join_parallelism</name>
-    <description>Enrichment Topology Enrichment Join Bolt Parallelism</description>
+    <description>Enrichment Join Bolt Parallelism for the Enrichment Topology</description>
     <value>1</value>
     <display-name>Enrichment Join Parallelism</display-name>
   </property>
   <property>
     <name>threat_intel_split_parallelism</name>
-    <description>Enrichment Topology Threat Intel Split Bolt Parallelism</description>
+    <description>Threat Intel Split Bolt Parallelism for the Enrichment Topology</description>
     <value>1</value>
-    <display-name>Threat Intel Spout Parallelism</display-name>
+    <display-name>Threat Intel Split Parallelism</display-name>
   </property>
   <property>
     <name>threat_intel_stellar_parallelism</name>
-    <description>Enrichment Topology Threat Intel Stellar Bolt Parallelism</description>
+    <description>Threat Intel Stellar Bolt Parallelism for the Enrichment Topology</description>
     <value>1</value>
-    <display-name>Threat Intel Spout Parallelism</display-name>
+    <display-name>Threat Intel Stellar Parallelism</display-name>
   </property>
   <property>
     <name>threat_intel_join_parallelism</name>
-    <description>Enrichment Topology Threat Intel Join Bolt Parallelism</description>
+    <description>Threat Intel Join Bolt Parallelism for the Enrichment Topology</description>
     <value>1</value>
     <display-name>Threat Intel Join Parallelism</display-name>
   </property>
   <property>
     <name>kafka_writer_parallelism</name>
-    <description>Enrichment Topology Kafka Writer Parallelism</description>
+    <description>Kafka Writer Parallelism for the Enrichment Topology</description>
     <value>1</value>
     <display-name>Enrichment Kafka Writer Parallelism</display-name>
   </property>


### PR DESCRIPTION
In Ambari there are two input boxes with the same caption 'Threat Intel Spout Parallelism'.  I fixed the label to correctly identify each one.  I also re-phrased some of the other descriptions to make them more clear.  This PR is completely underwhelming, I assure you.

To test this change, launch the Full Dev environment and open Ambari.  Navigate to Metron > Configs > Enrichment.  Ensure that there are two input boxes (among many) with the following name and description.
* Threat Intel Split Parallelism: Threat Intel Split Bolt Parallelism for the Enrichment Topology
* Threat Intel Stellar Parallelism: Threat Intel Stellar Bolt Parallelism for the Enrichment Topology

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron 
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

