### PR TITLE
METRON-1117 Filters Functions Returned by '%functions'

### DIFF
--- a/metron-stellar/stellar-common/README.md
+++ b/metron-stellar/stellar-common/README.md
@@ -1024,7 +1024,7 @@ The REPL has a set of magic commands that provide the REPL user with information
 
 #### `%functions`
 
-This command lists all functions resolvable in the Stellar environment.  Stellar searches the classpath for Stellar functions.  This can make it difficult in some cases to understand which functions are resolvable.  
+This command lists all functions resolvable in the Stellar environment.   
 
 ```
 [Stellar]>>> %functions
@@ -1038,7 +1038,13 @@ STATS_POPULATION_VARIANCE, STATS_QUADRATIC_MEAN, STATS_SD, STATS_SKEWNESS, STATS
 STATS_SUM_LOGS, STATS_SUM_SQUARES, STATS_VARIANCE, TO_DOUBLE, TO_EPOCH_TIMESTAMP, TO_FLOAT, 
 TO_INTEGER, TO_LOWER, TO_STRING, TO_UPPER, TRIM, URL_TO_HOST, URL_TO_PATH, URL_TO_PORT, 
 URL_TO_PROTOCOL, WEEK_OF_MONTH, WEEK_OF_YEAR, YEAR
-[Stellar]>>> 
+```
+
+The list of functions returned can also be filtered by passing an argument.  Only the functions containing the argument as a substring will be returned.
+
+```
+[Stellar]>>> %functions NET
+IN_SUBNET
 ```
 
 #### `%vars` 

--- a/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/common/shell/StellarShell.java
+++ b/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/common/shell/StellarShell.java
@@ -449,8 +449,4 @@ public class StellarShell extends AeshConsoleCallback implements Completion {
     }
     return baseString.substring(0, index);
   }
-
-  protected Console getConsole() {
-    return console;
-  }
 }

--- a/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/common/shell/StellarShell.java
+++ b/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/common/shell/StellarShell.java
@@ -283,11 +283,12 @@ public class StellarShell extends AeshConsoleCallback implements Completion {
   }
 
   /**
-   * Handles user interaction when executing a Magic command.
+   * Executes a magic expression.
    * @param rawExpression The expression to execute.
    */
   private void handleMagic( String rawExpression) {
     String expression = rawExpression.trim();
+
     if(MAGIC_FUNCTIONS.equals(expression)) {
 
       // list all functions
@@ -301,7 +302,6 @@ public class StellarShell extends AeshConsoleCallback implements Completion {
     } else if(MAGIC_VARS.equals(expression)) {
 
       // list all variables
-
       executor.getVariables()
               .forEach((k,v) -> writeLine(String.format("%s = %s", k, v)));
 
@@ -311,8 +311,8 @@ public class StellarShell extends AeshConsoleCallback implements Completion {
   }
 
   /**
-   * Handles user interaction when executing a doc command.
-   * @param expression The expression to execute.
+   * Executes a doc expression.
+   * @param expression The doc expression to execute.
    */
   private void handleDoc(String expression) {
 
@@ -322,6 +322,17 @@ public class StellarShell extends AeshConsoleCallback implements Completion {
             .filter(info -> StringUtils.equals(functionName, info.getName()))
             .map(info -> format(info))
             .forEach(doc -> write(doc));
+  }
+
+  /**
+   * Executes a quit.
+   */
+  private void handleQuit() {
+    try {
+      console.stop();
+    } catch (Throwable e) {
+      e.printStackTrace();
+    }
   }
 
   /**
@@ -380,16 +391,12 @@ public class StellarShell extends AeshConsoleCallback implements Completion {
         handleDoc(expression);
 
       } else if (expression.equals("quit")) {
-        try {
-          console.stop();
-        } catch (Throwable e) {
-          e.printStackTrace();
-        }
-      }
-      else if(expression.charAt(0) == '#') {
-        return 0;
-      }
-      else {
+        handleQuit();
+
+      } else if(expression.charAt(0) == '#') {
+        return 0; // comment, do nothing
+
+      } else {
         handleStellar(expression);
       }
     }


### PR DESCRIPTION
As we continue to develop more Stellar functions, the list of functions returned by `%functions` in the REPL becomes hard to grok manually.  I wanted a way to filter that list to narrow my search. 

What is that subnet function that we have?
```
[Stellar]>>> %functions NET
IN_SUBNET
```
If no argument is provided, then all functions will be returned just like before.

The filtering mechanism checks that the argument is a substring of the function name; meaning it uses `String.contains` under the hood.  It does not use a regular expression.  I debated with myself about which way to go and I decided that it would be easier to go this way; `%function NET` is easier than `%functions .*NET.*`

## Testing

To test the change launch the REPL.
```
mvn clean install -DskipTests
mvn exec:java  -Dexec.mainClass="org.apache.metron.stellar.common.shell.StellarShell" -pl metron-platform/metron-enrichment
```
Then try-out the change to %functions.
```
[Stellar]>>> %functions
ABS, APPEND_IF_MISSING, BIN, BLOOM_ADD, BLOOM_EXISTS, BLOOM_INIT, BLOOM_MERGE, CEILING, CHOMP, CHOP, COS, COUNT_MATCHES, DAY_OF_MONTH, DAY_OF_WEEK, DAY_OF_YEAR, DECODE, DOMAIN_REMOVE_SUBDOMAINS, DOMAIN_REMOVE_TLD, DOMAIN_TO_TLD, ENCODE, ENDS_WITH, ENRICHMENT_EXISTS, ENRICHMENT_GET, EXP, FILL_LEFT, FILL_RIGHT, FILTER, FLOOR, FORMAT, GEO_GET, GET, GET_FIRST, GET_LAST, GET_SUPPORTED_ENCODINGS, HLLP_ADD, HLLP_CARDINALITY, HLLP_INIT, HLLP_MERGE, IN_SUBNET, IS_DATE, IS_DOMAIN, IS_EMAIL, IS_EMPTY, IS_ENCODING, IS_INTEGER, IS_IP, IS_URL, JOIN, LENGTH, LIST_ADD, LN, LOG10, LOG2, MAP, MAP_EXISTS, MAP_GET, MONTH, OUTLIER_MAD_ADD, OUTLIER_MAD_SCORE, OUTLIER_MAD_STATE_MERGE, PREPEND_IF_MISSING, PROFILER_APPLY, PROFILER_FLUSH, PROFILER_INIT, PROFILE_FIXED, PROFILE_GET, PROFILE_WINDOW, PROTOCOL_TO_NAME, REDUCE, REGEXP_GROUP_VAL, REGEXP_MATCH, ROUND, SIN, SPLIT, SQRT, STARTS_WITH, STATS_ADD, STATS_BIN, STATS_COUNT, STATS_GEOMETRIC_MEAN, STATS_INIT, STATS_KURTOSIS, STATS_MAX, STATS_MEAN, STATS_MERGE, STATS_MIN, STATS_PERCENTILE, STATS_POPULATION_VARIANCE, STATS_QUADRATIC_MEAN, STATS_SD, STATS_SKEWNESS, STATS_SUM, STATS_SUM_LOGS, STATS_SUM_SQUARES, STATS_VARIANCE, STRING_ENTROPY, SYSTEM_ENV_GET, SYSTEM_PROPERTY_GET, TAN, TO_DOUBLE, TO_EPOCH_TIMESTAMP, TO_FLOAT, TO_INTEGER, TO_LONG, TO_LOWER, TO_STRING, TO_UPPER, TRIM, URL_TO_HOST, URL_TO_PATH, URL_TO_PORT, URL_TO_PROTOCOL, WEEK_OF_MONTH, WEEK_OF_YEAR, YEAR, ZIP, ZIP_LONGEST
[Stellar]>>> %functions TO
DOMAIN_TO_TLD, PROTOCOL_TO_NAME, STATS_KURTOSIS, TO_DOUBLE, TO_EPOCH_TIMESTAMP, TO_FLOAT, TO_INTEGER, TO_LONG, TO_LOWER, TO_STRING, TO_UPPER, URL_TO_HOST, URL_TO_PATH, URL_TO_PORT, URL_TO_PROTOCOL
[Stellar]>>> %functions NET
IN_SUBNET
```

## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron 
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:
