### PR TITLE
METRON-1118 Ignore Profile with Bad 'onlyif' or 'foreach' Expressions

### DIFF
--- a/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/DefaultMessageRouter.java
+++ b/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/DefaultMessageRouter.java
@@ -27,10 +27,14 @@ import org.apache.metron.stellar.common.StellarStatefulExecutor;
 import org.apache.metron.stellar.dsl.Context;
 import org.apache.metron.stellar.dsl.StellarFunctions;
 import org.json.simple.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Routes incoming telemetry messages.
@@ -39,6 +43,8 @@ import java.util.Map;
  * when a message is needed by more than one profile.
  */
 public class DefaultMessageRouter implements MessageRouter {
+
+  protected static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   /**
    * Executes Stellar code.
@@ -62,21 +68,45 @@ public class DefaultMessageRouter implements MessageRouter {
   @Override
   public List<MessageRoute> route(JSONObject message, ProfilerConfig config, Context context) {
     List<MessageRoute> routes = new ArrayList<>();
-    @SuppressWarnings("unchecked")
-    final Map<String, Object> state = (Map<String, Object>) message;
 
     // attempt to route the message to each of the profiles
     for (ProfileConfig profile: config.getProfiles()) {
+      Optional<MessageRoute> route = routeToProfile(message, profile);
+      route.ifPresent(routes::add);
+    }
 
+    return routes;
+  }
+
+  /**
+   * Creates a route if a message is needed by a profile.
+   * @param message The message that needs routed.
+   * @param profile The profile that may need the message.
+   * @return A MessageRoute if the message is needed by the profile.
+   */
+  private Optional<MessageRoute> routeToProfile(JSONObject message, ProfileConfig profile) {
+    Optional<MessageRoute> route = Optional.empty();
+
+    // allow the profile to access the fields defined within the message
+    @SuppressWarnings("unchecked")
+    final Map<String, Object> state = (Map<String, Object>) message;
+
+    try {
       // is this message needed by this profile?
       if (executor.execute(profile.getOnlyif(), state, Boolean.class)) {
 
         // what is the name of the entity in this message?
         String entity = executor.execute(profile.getForeach(), state, String.class);
-        routes.add(new MessageRoute(profile, entity));
+        route = Optional.of(new MessageRoute(profile, entity));
       }
+
+    } catch(Exception e) {
+      // log an error and move on. ignore bad profiles.
+      LOG.error(String.format("error encountered while executing profile; profile='%s', error='%s'", profile.getProfile(), e.getMessage()));
     }
 
-    return routes;
+    return route;
   }
+
+
 }

--- a/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/DefaultMessageRouter.java
+++ b/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/DefaultMessageRouter.java
@@ -36,6 +36,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.lang.String.format;
+
 /**
  * Routes incoming telemetry messages.
  *
@@ -100,13 +102,12 @@ public class DefaultMessageRouter implements MessageRouter {
         route = Optional.of(new MessageRoute(profile, entity));
       }
 
-    } catch(Exception e) {
+    } catch(Throwable e) {
       // log an error and move on. ignore bad profiles.
-      LOG.error(String.format("error encountered while executing profile; profile='%s', error='%s'", profile.getProfile(), e.getMessage()));
+      String msg = format("error while executing profile; profile='%s', error='%s'", profile.getProfile(), e.getMessage());
+      LOG.error(msg, e);
     }
 
     return route;
   }
-
-
 }

--- a/metron-analytics/metron-profiler/src/test/java/org/apache/metron/profiler/bolt/ProfileSplitterBoltTest.java
+++ b/metron-analytics/metron-profiler/src/test/java/org/apache/metron/profiler/bolt/ProfileSplitterBoltTest.java
@@ -227,15 +227,16 @@ public class ProfileSplitterBoltTest extends BaseBoltTest {
   }
 
   /**
-   * What happens when invalid Stella code is used for 'onlyif'?
+   * What happens when invalid Stella code is used for 'onlyif'?  The invalid profile should be ignored.
    */
-  @Test(expected = org.apache.metron.stellar.dsl.ParseException.class)
+  @Test
   public void testOnlyIfInvalid() throws Exception {
 
     // setup
     ProfileSplitterBolt bolt = createBolt(onlyIfInvalid);
-
-    // execute
     bolt.execute(tuple);
+
+    // a tuple should NOT be emitted for the downstream profile builder
+    verify(outputCollector, times(0)).emit(any(Values.class));
   }
 }


### PR DESCRIPTION
The Profiler needs to gracefully ignore profiles that have a bad 'onlyif' or 'foreach' expression.  Under certain conditions a message may not be applied to all valid profiles, due to a single bad profile.

If the Profiler is running with multiple profiles defined and one of those profiles has a Stellar expression that throws an exception for either the 'foreach' or 'onlyif', the current logic will not continue to attempt to apply the message to the remaining valid profiles.  Only valid profiles executed before the bad profile will have the message applied.

## Testing

Unit tests have been added to check for these conditions.  This can be manually tested with either a live Profiler running in a cluster or using the Profiler debugging functions.  

Create two profiles; one that is valid and another that is invalid, like the following.  Ensure that all test messages that are sent through the Profiler, reach the `good-profile` despite the `bad-profile`.

```
 {
   "profiles": [
      {
        "profile": "bad-profile",
        "foreach": "2 / 0",
        "init":   { "x": "0" },
        "update": { "x": "x + 1" },
        "result": "x"
      },
      {
        "profile": "good-profile",
        "foreach": "ip_src_addr",
        "init":   { "x": "0" },
        "update": { "x": "x + 1" },
        "result": "x"
      }
   ]
 }
```

Here are instructions for how to test using the Profiler debugging functions in the REPL. Create a Profiler with the above definition.  Copy and paste the definition above into the editor.
```
[Stellar]>>> conf := SHELL_EDIT()
[Stellar]>>> conf
{
   "profiles": [
      {
        "profile": "bad-profile",
        "foreach": "2 / 0",
        "init":   { "x": "0" },
        "update": { "x": "x + 1" },
        "result": "x"
      },
      {
        "profile": "good-profile",
        "foreach": "ip_src_addr",
        "init":   { "x": "0" },
        "update": { "x": "x + 1" },
        "result": "x"
      }
   ]
 }
[Stellar]>>> p := PROFILER_INIT(conf)
```

Create a message.  Almost any message will do.
```
[Stellar]>>> msg := SHELL_EDIT()
[Stellar]>>> msg
{
  "ip_src_addr": "10.0.0.1"
}
```

Apply the message to the profiler.  If the patch is successful it will look-like the following.
```
[Stellar]>>> PROFILER_APPLY(msg, p)
2017-08-17 23:39:42,605 ERROR [AeshProcess: 4] profiler.DefaultMessageRouter: error encountered while executing profile; profile='bad-profile', error='/ by zero'
org.apache.metron.profiler.StandAloneProfiler@67ea50dd
```

Prior to this patch this would trigger the bug and the same would look-like this.
```
[Stellar]>>> PROFILER_APPLY( msg, p)
[!] / by zero
java.lang.ArithmeticException: / by zero
	at org.apache.metron.stellar.common.evaluators.ArithmeticEvaluator$ArithmeticEvaluatorFunctions.lambda$division$3(ArithmeticEvaluator.java:98)
	at org.apache.metron.stellar.common.evaluators.ArithmeticEvaluator.evaluate(ArithmeticEvaluator.java:39)
	at org.apache.metron.stellar.common.StellarCompiler.lambda$exitArithExpr_div$2(StellarCompiler.java:281)
	at org.apache.metron.stellar.common.StellarCompiler$Expression.apply(StellarCompiler.java:160)
	at org.apache.metron.stellar.common.BaseStellarProcessor.parse(BaseStellarProcessor.java:152)
	at org.apache.metron.stellar.common.DefaultStellarStatefulExecutor.execute(DefaultStellarStatefulExecutor.java:160)
	at org.apache.metron.stellar.common.DefaultStellarStatefulExecutor.execute(DefaultStellarStatefulExecutor.java:123)
	at org.apache.metron.profiler.DefaultMessageRouter.route(DefaultMessageRouter.java:75)
	at org.apache.metron.profiler.StandAloneProfiler.apply(StandAloneProfiler.java:71)
	at org.apache.metron.profiler.client.stellar.ProfilerFunctions$ProfilerApply.apply(ProfilerFunctions.java:150)
	at org.apache.metron.stellar.common.StellarCompiler.lambda$exitTransformationFunc$13(StellarCompiler.java:556)
	at org.apache.metron.stellar.common.StellarCompiler$Expression.apply(StellarCompiler.java:160)
	at org.apache.metron.stellar.common.BaseStellarProcessor.parse(BaseStellarProcessor.java:152)
	at org.apache.metron.stellar.common.shell.StellarExecutor.execute(StellarExecutor.java:287)
	at org.apache.metron.stellar.common.shell.StellarShell.executeStellar(StellarShell.java:364)
	at org.apache.metron.stellar.common.shell.StellarShell.handleStellar(StellarShell.java:267)
	at org.apache.metron.stellar.common.shell.StellarShell.execute(StellarShell.java:403)
	at org.jboss.aesh.console.AeshProcess.run(AeshProcess.java:53)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```

## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:
