### PR TITLE
METRON-1119 Bad Out-of-Order Logic for SaltyRowKeyBuilder

### DIFF
--- a/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/hbase/SaltyRowKeyBuilder.java
+++ b/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/hbase/SaltyRowKeyBuilder.java
@@ -83,8 +83,9 @@ public class SaltyRowKeyBuilder implements RowKeyBuilder {
   @Override
   public List<byte[]> rowKeys(String profile, String entity, List<Object> groups, long start, long end) {
     // be forgiving of out-of-order start and end times; order is critical to this algorithm
-    end = Math.max(start, end);
+    long max = Math.max(start, end);
     start = Math.min(start, end);
+    end = max;
 
     // find the starting period and advance until the end time is reached
     return ProfilePeriod.visitPeriods( start


### PR DESCRIPTION
This is a bug that was previously Identified by @mattf-horton 
https://github.com/apache/metron/pull/622#pullrequestreview-51351898

The 'out-of-order' logic for the `SaltyRowKeyBuilder.encode` function does not work.

> If it starts out in the wrong order, say end is 1 and start is 5, won't this pair of statements result in both end and start being equal to the larger, ie 5 ? We need an intermediate variable for a binary swap!

## Pull Request Checklist
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
