### PR TITLE
METRON-1129 Management UI - Package Node Dependencies in RPM

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/management_ui_master.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/management_ui_master.py
@@ -38,7 +38,6 @@ class ManagementUIMaster(Script):
         from params import params
         env.set_params(params)
         self.install_packages(env)
-        Execute('npm --prefix ' + params.metron_home + '/web/expressjs/ install')
 
     def configure(self, env, upgrade_type=None, config_dir=None):
         print 'configure managment_ui'

--- a/metron-deployment/packaging/docker/rpm-docker/Dockerfile
+++ b/metron-deployment/packaging/docker/rpm-docker/Dockerfile
@@ -27,3 +27,7 @@ RUN mv apache-maven-3.2.5 /opt/maven
 RUN ln -s /opt/maven/bin/mvn /usr/bin/mvn
 RUN yum -y install asciidoc rpm-build rpm2cpio tar unzip xmlto zip rpmlint && yum clean all
 WORKDIR /root
+
+# install node so that the node dependencies can be packaged into the RPMs
+RUN curl --silent --location https://rpm.nodesource.com/setup_6.x | bash -
+RUN yum -y install gcc-c++ make nodejs

--- a/metron-deployment/packaging/docker/rpm-docker/SPECS/metron.spec
+++ b/metron-deployment/packaging/docker/rpm-docker/SPECS/metron.spec
@@ -17,7 +17,7 @@
 %define timestamp           %(date +%Y%m%d%H%M)
 %define version             %{?_version}%{!?_version:UNKNOWN}
 %define full_version        %{version}%{?_prerelease}
-%define prerelease_fmt      %{?_prerelease:.%{_prerelease}}          
+%define prerelease_fmt      %{?_prerelease:.%{_prerelease}}
 %define vendor_version      %{?_vendor_version}%{!?_vendor_version: UNKNOWN}
 %define url                 http://metron.apache.org/
 %define base_name           metron
@@ -29,6 +29,8 @@
 
 %define metron_root         %{_prefix}/%{base_name}
 %define metron_home         %{metron_root}/%{full_version}
+
+%define _binaries_in_noarch_packages_terminate_build   0
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -90,6 +92,8 @@ tar -xzf %{SOURCE11} -C %{buildroot}%{metron_home}
 
 install %{buildroot}%{metron_home}/bin/metron-rest %{buildroot}/etc/init.d/
 install %{buildroot}%{metron_home}/bin/metron-management-ui %{buildroot}/etc/init.d/
+
+npm install --prefix="%{buildroot}%{metron_home}/web/expressjs" --only=production
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -389,6 +393,8 @@ This package installs the Metron Management UI %{metron_home}
 %dir %{metron_home}/bin
 %dir %{metron_home}/web
 %dir %{metron_home}/web/expressjs
+%dir %{metron_home}/web/expressjs/node_modules
+%dir %{metron_home}/web/expressjs/node_modules/.bin
 %dir %{metron_home}/web/management-ui
 %dir %{metron_home}/web/management-ui/assets
 %dir %{metron_home}/web/management-ui/assets/ace
@@ -399,6 +405,8 @@ This package installs the Metron Management UI %{metron_home}
 %dir %{metron_home}/web/management-ui/license
 %{metron_home}/bin/metron-management-ui
 /etc/init.d/metron-management-ui
+%attr(0755,root,root) %{metron_home}/web/expressjs/node_modules/*
+%attr(0755,root,root) %{metron_home}/web/expressjs/node_modules/.bin/*
 %attr(0755,root,root) %{metron_home}/web/expressjs/server.js
 %attr(0644,root,root) %{metron_home}/web/expressjs/package.json
 %attr(0644,root,root) %{metron_home}/web/management-ui/favicon.ico
@@ -428,7 +436,7 @@ chkconfig --del metron-management-ui
 
 %changelog
 * Thu Jun 29 2017 Apache Metron <dev@metron.apache.org> - 0.4.1
-- Add Metron Management jar 
+- Add Metron Management jar
 * Thu May 15 2017 Apache Metron <dev@metron.apache.org> - 0.4.0
 - Added Management UI
 * Tue May 9 2017 Apache Metron <dev@metron.apache.org> - 0.4.0
@@ -442,7 +450,7 @@ chkconfig --del metron-management-ui
 * Thu Jan 19 2017 Justin Leet <justinjleet@gmail.com> - 0.3.1
 - Replace GeoIP files with new implementation
 * Thu Nov 03 2016 David Lyle <dlyle65535@gmail.com> - 0.2.1
-- Add ASA parser/enrichment configuration files 
+- Add ASA parser/enrichment configuration files
 * Thu Jul 21 2016 Michael Miklavcic <michael.miklavcic@gmail.com> - 0.2.1
 - Remove parser flux files
 - Add new enrichment files

--- a/metron-deployment/packaging/docker/rpm-docker/SPECS/metron.spec
+++ b/metron-deployment/packaging/docker/rpm-docker/SPECS/metron.spec
@@ -93,6 +93,7 @@ tar -xzf %{SOURCE11} -C %{buildroot}%{metron_home}
 install %{buildroot}%{metron_home}/bin/metron-rest %{buildroot}/etc/init.d/
 install %{buildroot}%{metron_home}/bin/metron-management-ui %{buildroot}/etc/init.d/
 
+# allows node dependencies to be packaged in the RPMs
 npm install --prefix="%{buildroot}%{metron_home}/web/expressjs" --only=production
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/metron-deployment/packaging/docker/rpm-docker/build.sh
+++ b/metron-deployment/packaging/docker/rpm-docker/build.sh
@@ -36,7 +36,7 @@ if [ $? -ne 0 ] && [ $OWNER_UID -ne 0 ]; then
 fi
 
 rm -rf SRPMS/ RPMS/ && \
-rpmbuild -v -ba --define "_topdir $(pwd)" --define "_version ${VERSION}" --define "_prerelease ${PRERELEASE}" SPECS/metron.spec && \
+QA_SKIP_BUILD_ROOT=1 rpmbuild -v -ba --define "_topdir $(pwd)" --define "_version ${VERSION}" --define "_prerelease ${PRERELEASE}" SPECS/metron.spec && \
 rpmlint -i SPECS/metron.spec RPMS/*/metron* SRPMS/metron
 
 # Ensure original user permissions are maintained after build

--- a/metron-interface/metron-config/README.md
+++ b/metron-interface/metron-config/README.md
@@ -49,12 +49,6 @@ This module provides a user interface for management functions in Metron.
     rpm -ih metron-config-$METRON_VERSION-*.noarch.rpm
     ```
 
-1. Install the [Express](https://expressjs.com/) web framework from the `package.json` file in `$METRON_HOME/web/expressjs`:
-
-    ```
-    npm --prefix $METRON_HOME/web/expressjs/ install
-    ```
-
 ## Configuration
 
 The Managment UI is configured in the `$METRON_HOME/config/management_ui.yml` file.  Create this file and set the values to match your environment:
@@ -87,7 +81,7 @@ The Management UI can also be started in development mode.  This allows changes 
     cd metron-interface/metron-config
     npm install
     ```
-  
+
 1. Start the application:
 
     ```


### PR DESCRIPTION
If you install the Management UI using the RPM, it will not install all of the required Node dependencies.  You have to manually run `npm install ...` to get those dependencies installed.  

This works just fine in an environment that can access the interwebs.  This does not work so well when installing in an offline environment with no interweb access.  If we package all Node dependencies in the RPM itself, this makes it much simpler to install in an offline environment.  And this, of course, will also work in an online environment and removes a manual steps.  So win, win.

### Testing

I tested this change in two ways.
* I built the RPMs and then manually copied them to a raw CentOS box.  I installed Node on the box, but did not install any dependencies with NPM.  I then installed the RPMs and was able to launch the Management UI.  All dependencies were satisfied based on what was contained in the RPM.
* I launched Full Dev, which builds the RPMs and deploys them with the Mpack.  The Management UI and all other core functions worked.