### PR TITLE
METRON-1134: Allow parser command line options to be specified in the zookeeper parser config.

### DIFF
--- a/metron-interface/metron-rest/src/test/java/org/apache/metron/rest/controller/SensorParserConfigControllerIntegrationTest.java
+++ b/metron-interface/metron-rest/src/test/java/org/apache/metron/rest/controller/SensorParserConfigControllerIntegrationTest.java
@@ -19,6 +19,7 @@ package org.apache.metron.rest.controller;
 
 import org.adrianwalker.multilinestring.Multiline;
 import org.apache.commons.io.FileUtils;
+import org.apache.metron.common.configuration.SensorParserConfig;
 import org.apache.metron.rest.MetronRestConstants;
 import org.apache.metron.rest.service.GrokService;
 import org.apache.metron.rest.service.SensorParserConfigService;
@@ -37,6 +38,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
 
 import static org.apache.metron.rest.MetronRestConstants.TEST_PROFILE;
 import static org.hamcrest.Matchers.hasSize;
@@ -196,11 +198,17 @@ public class SensorParserConfigControllerIntegrationTest {
     cleanFileSystem();
     this.sensorParserConfigService.delete("broTest");
     this.sensorParserConfigService.delete("squidTest");
-
+    Method[] method = SensorParserConfig.class.getMethods();
+    int numFields = 0;
+    for(Method m : method) {
+      if(m.getName().startsWith("set")) {
+        numFields++;
+      }
+    }
     this.mockMvc.perform(post(sensorParserConfigUrl).with(httpBasic(user, password)).with(csrf()).contentType(MediaType.parseMediaType("application/json;charset=UTF-8")).content(squidJson))
             .andExpect(status().isCreated())
             .andExpect(content().contentType(MediaType.parseMediaType("application/json;charset=UTF-8")))
-            .andExpect(jsonPath("$.*", hasSize(10)))
+            .andExpect(jsonPath("$.*", hasSize(numFields)))
             .andExpect(jsonPath("$.parserClassName").value("org.apache.metron.parsers.GrokParser"))
             .andExpect(jsonPath("$.sensorTopic").value("squidTest"))
             .andExpect(jsonPath("$.parserConfig.grokPath").value("target/patterns/squidTest"))
@@ -215,7 +223,7 @@ public class SensorParserConfigControllerIntegrationTest {
     this.mockMvc.perform(get(sensorParserConfigUrl + "/squidTest").with(httpBasic(user,password)))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.parseMediaType("application/json;charset=UTF-8")))
-            .andExpect(jsonPath("$.*", hasSize(10)))
+            .andExpect(jsonPath("$.*", hasSize(numFields)))
             .andExpect(jsonPath("$.parserClassName").value("org.apache.metron.parsers.GrokParser"))
             .andExpect(jsonPath("$.sensorTopic").value("squidTest"))
             .andExpect(jsonPath("$.parserConfig.grokPath").value("target/patterns/squidTest"))
@@ -244,7 +252,7 @@ public class SensorParserConfigControllerIntegrationTest {
     this.mockMvc.perform(post(sensorParserConfigUrl).with(httpBasic(user, password)).with(csrf()).contentType(MediaType.parseMediaType("application/json;charset=UTF-8")).content(broJson))
             .andExpect(status().isCreated())
             .andExpect(content().contentType(MediaType.parseMediaType("application/json;charset=UTF-8")))
-            .andExpect(jsonPath("$.*", hasSize(10)))
+            .andExpect(jsonPath("$.*", hasSize(numFields)))
             .andExpect(jsonPath("$.parserClassName").value("org.apache.metron.parsers.bro.BasicBroParser"))
             .andExpect(jsonPath("$.sensorTopic").value("broTest"))
             .andExpect(jsonPath("$.readMetadata").value("true"))
@@ -254,7 +262,7 @@ public class SensorParserConfigControllerIntegrationTest {
     this.mockMvc.perform(post(sensorParserConfigUrl).with(httpBasic(user, password)).with(csrf()).contentType(MediaType.parseMediaType("application/json;charset=UTF-8")).content(broJson))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.parseMediaType("application/json;charset=UTF-8")))
-            .andExpect(jsonPath("$.*", hasSize(10)))
+            .andExpect(jsonPath("$.*", hasSize(numFields)))
             .andExpect(jsonPath("$.parserClassName").value("org.apache.metron.parsers.bro.BasicBroParser"))
             .andExpect(jsonPath("$.sensorTopic").value("broTest"))
             .andExpect(jsonPath("$.readMetadata").value("true"))

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/SensorParserConfig.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/SensorParserConfig.java
@@ -47,6 +47,10 @@ public class SensorParserConfig implements Serializable {
   private String securityProtocol = null;
   private Map<String, Object> stormConfig = new HashMap<>();
 
+  /**
+   * Return the spout parallelism.  This property will be used for the parser unless overridden on the CLI.
+   * @return
+   */
   public Integer getSpoutParallelism() {
     return spoutParallelism;
   }
@@ -55,6 +59,10 @@ public class SensorParserConfig implements Serializable {
     this.spoutParallelism = spoutParallelism;
   }
 
+  /**
+   * Return the spout num tasks.  This property will be used for the parser unless overridden on the CLI.
+   * @return
+   */
   public Integer getSpoutNumTasks() {
     return spoutNumTasks;
   }
@@ -63,6 +71,10 @@ public class SensorParserConfig implements Serializable {
     this.spoutNumTasks = spoutNumTasks;
   }
 
+  /**
+   * Return the parser parallelism.  This property will be used for the parser unless overridden on the CLI.
+   * @return
+   */
   public Integer getParserParallelism() {
     return parserParallelism;
   }
@@ -71,6 +83,10 @@ public class SensorParserConfig implements Serializable {
     this.parserParallelism = parserParallelism;
   }
 
+  /**
+   * Return the parser number of tasks.  This property will be used for the parser unless overridden on the CLI.
+   * @return
+   */
   public Integer getParserNumTasks() {
     return parserNumTasks;
   }
@@ -79,6 +95,10 @@ public class SensorParserConfig implements Serializable {
     this.parserNumTasks = parserNumTasks;
   }
 
+  /**
+   * Return the error writer bolt parallelism.  This property will be used for the parser unless overridden on the CLI.
+   * @return
+   */
   public Integer getErrorWriterParallelism() {
     return errorWriterParallelism;
   }
@@ -87,6 +107,10 @@ public class SensorParserConfig implements Serializable {
     this.errorWriterParallelism = errorWriterParallelism;
   }
 
+  /**
+   * Return the error writer bolt number of tasks.  This property will be used for the parser unless overridden on the CLI.
+   * @return
+   */
   public Integer getErrorWriterNumTasks() {
     return errorWriterNumTasks;
   }
@@ -95,6 +119,10 @@ public class SensorParserConfig implements Serializable {
     this.errorWriterNumTasks = errorWriterNumTasks;
   }
 
+  /**
+   * Return the spout config.  This includes kafka properties.  This property will be used for the parser unless overridden on the CLI.
+   * @return
+   */
   public Map<String, Object> getSpoutConfig() {
     return spoutConfig;
   }
@@ -103,6 +131,11 @@ public class SensorParserConfig implements Serializable {
     this.spoutConfig = spoutConfig;
   }
 
+  /**
+   * Return security protocol to use.  This property will be used for the parser unless overridden on the CLI.
+   * The order of precedence is CLI > spout config > config in the sensor parser config.
+   * @return
+   */
   public String getSecurityProtocol() {
     return securityProtocol;
   }
@@ -111,6 +144,10 @@ public class SensorParserConfig implements Serializable {
     this.securityProtocol = securityProtocol;
   }
 
+  /**
+   * Return Storm topologyconfig.  This property will be used for the parser unless overridden on the CLI.
+   * @return
+   */
   public Map<String, Object> getStormConfig() {
     return stormConfig;
   }
@@ -119,6 +156,10 @@ public class SensorParserConfig implements Serializable {
     this.stormConfig = stormConfig;
   }
 
+  /**
+   * Return whether or not to merge metadata sent into the message.  If true, then metadata become proper fields.
+   * @return
+   */
   public Boolean getMergeMetadata() {
     return mergeMetadata;
   }
@@ -127,6 +168,10 @@ public class SensorParserConfig implements Serializable {
     this.mergeMetadata = mergeMetadata;
   }
 
+  /**
+   * Return whether or not to read metadata at all.
+   * @return
+   */
   public Boolean getReadMetadata() {
     return readMetadata;
   }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/SensorParserConfig.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/SensorParserConfig.java
@@ -37,6 +37,87 @@ public class SensorParserConfig implements Serializable {
   private String invalidWriterClassName;
   private Boolean readMetadata = false;
   private Boolean mergeMetadata = false;
+  private Integer spoutParallelism = 1;
+  private Integer spoutNumTasks = 1;
+  private Integer parserParallelism = 1;
+  private Integer parserNumTasks = 1;
+  private Integer errorWriterParallelism = 1;
+  private Integer errorWriterNumTasks = 1;
+  private Map<String, Object> spoutConfig = new HashMap<>();
+  private String securityProtocol = null;
+  private Map<String, Object> stormConfig = new HashMap<>();
+
+  public Integer getSpoutParallelism() {
+    return spoutParallelism;
+  }
+
+  public void setSpoutParallelism(Integer spoutParallelism) {
+    this.spoutParallelism = spoutParallelism;
+  }
+
+  public Integer getSpoutNumTasks() {
+    return spoutNumTasks;
+  }
+
+  public void setSpoutNumTasks(Integer spoutNumTasks) {
+    this.spoutNumTasks = spoutNumTasks;
+  }
+
+  public Integer getParserParallelism() {
+    return parserParallelism;
+  }
+
+  public void setParserParallelism(Integer parserParallelism) {
+    this.parserParallelism = parserParallelism;
+  }
+
+  public Integer getParserNumTasks() {
+    return parserNumTasks;
+  }
+
+  public void setParserNumTasks(Integer parserNumTasks) {
+    this.parserNumTasks = parserNumTasks;
+  }
+
+  public Integer getErrorWriterParallelism() {
+    return errorWriterParallelism;
+  }
+
+  public void setErrorWriterParallelism(Integer errorWriterParallelism) {
+    this.errorWriterParallelism = errorWriterParallelism;
+  }
+
+  public Integer getErrorWriterNumTasks() {
+    return errorWriterNumTasks;
+  }
+
+  public void setErrorWriterNumTasks(Integer errorWriterNumTasks) {
+    this.errorWriterNumTasks = errorWriterNumTasks;
+  }
+
+  public Map<String, Object> getSpoutConfig() {
+    return spoutConfig;
+  }
+
+  public void setSpoutConfig(Map<String, Object> spoutConfig) {
+    this.spoutConfig = spoutConfig;
+  }
+
+  public String getSecurityProtocol() {
+    return securityProtocol;
+  }
+
+  public void setSecurityProtocol(String securityProtocol) {
+    this.securityProtocol = securityProtocol;
+  }
+
+  public Map<String, Object> getStormConfig() {
+    return stormConfig;
+  }
+
+  public void setStormConfig(Map<String, Object> stormConfig) {
+    this.stormConfig = stormConfig;
+  }
 
   public Boolean getMergeMetadata() {
     return mergeMetadata;
@@ -145,10 +226,19 @@ public class SensorParserConfig implements Serializable {
             ", writerClassName='" + writerClassName + '\'' +
             ", errorWriterClassName='" + errorWriterClassName + '\'' +
             ", invalidWriterClassName='" + invalidWriterClassName + '\'' +
-            ", parserConfig=" + parserConfig +
-            ", fieldTransformations=" + fieldTransformations +
             ", readMetadata=" + readMetadata +
             ", mergeMetadata=" + mergeMetadata +
+            ", spoutParallelism=" + spoutParallelism +
+            ", spoutNumTasks=" + spoutNumTasks +
+            ", parserParallelism=" + parserParallelism +
+            ", parserNumTasks=" + parserNumTasks +
+            ", errorWriterParallelism=" + errorWriterParallelism +
+            ", errorWriterNumTasks=" + errorWriterNumTasks +
+            ", spoutConfig=" + spoutConfig +
+            ", securityProtocol='" + securityProtocol + '\'' +
+            ", stormConfig=" + stormConfig +
+            ", parserConfig=" + parserConfig +
+            ", fieldTransformations=" + fieldTransformations +
             '}';
   }
 
@@ -171,11 +261,29 @@ public class SensorParserConfig implements Serializable {
       return false;
     if (getInvalidWriterClassName() != null ? !getInvalidWriterClassName().equals(that.getInvalidWriterClassName()) : that.getInvalidWriterClassName() != null)
       return false;
-    if (getParserConfig() != null ? !getParserConfig().equals(that.getParserConfig()) : that.getParserConfig() != null)
-      return false;
     if (getReadMetadata() != null ? !getReadMetadata().equals(that.getReadMetadata()) : that.getReadMetadata() != null)
       return false;
     if (getMergeMetadata() != null ? !getMergeMetadata().equals(that.getMergeMetadata()) : that.getMergeMetadata() != null)
+      return false;
+    if (getSpoutParallelism() != null ? !getSpoutParallelism().equals(that.getSpoutParallelism()) : that.getSpoutParallelism() != null)
+      return false;
+    if (getSpoutNumTasks() != null ? !getSpoutNumTasks().equals(that.getSpoutNumTasks()) : that.getSpoutNumTasks() != null)
+      return false;
+    if (getParserParallelism() != null ? !getParserParallelism().equals(that.getParserParallelism()) : that.getParserParallelism() != null)
+      return false;
+    if (getParserNumTasks() != null ? !getParserNumTasks().equals(that.getParserNumTasks()) : that.getParserNumTasks() != null)
+      return false;
+    if (getErrorWriterParallelism() != null ? !getErrorWriterParallelism().equals(that.getErrorWriterParallelism()) : that.getErrorWriterParallelism() != null)
+      return false;
+    if (getErrorWriterNumTasks() != null ? !getErrorWriterNumTasks().equals(that.getErrorWriterNumTasks()) : that.getErrorWriterNumTasks() != null)
+      return false;
+    if (getSpoutConfig() != null ? !getSpoutConfig().equals(that.getSpoutConfig()) : that.getSpoutConfig() != null)
+      return false;
+    if (getSecurityProtocol() != null ? !getSecurityProtocol().equals(that.getSecurityProtocol()) : that.getSecurityProtocol() != null)
+      return false;
+    if (getStormConfig() != null ? !getStormConfig().equals(that.getStormConfig()) : that.getStormConfig() != null)
+      return false;
+    if (getParserConfig() != null ? !getParserConfig().equals(that.getParserConfig()) : that.getParserConfig() != null)
       return false;
     return getFieldTransformations() != null ? getFieldTransformations().equals(that.getFieldTransformations()) : that.getFieldTransformations() == null;
 
@@ -189,10 +297,19 @@ public class SensorParserConfig implements Serializable {
     result = 31 * result + (getWriterClassName() != null ? getWriterClassName().hashCode() : 0);
     result = 31 * result + (getErrorWriterClassName() != null ? getErrorWriterClassName().hashCode() : 0);
     result = 31 * result + (getInvalidWriterClassName() != null ? getInvalidWriterClassName().hashCode() : 0);
-    result = 31 * result + (getParserConfig() != null ? getParserConfig().hashCode() : 0);
-    result = 31 * result + (getFieldTransformations() != null ? getFieldTransformations().hashCode() : 0);
     result = 31 * result + (getReadMetadata() != null ? getReadMetadata().hashCode() : 0);
     result = 31 * result + (getMergeMetadata() != null ? getMergeMetadata().hashCode() : 0);
+    result = 31 * result + (getSpoutParallelism() != null ? getSpoutParallelism().hashCode() : 0);
+    result = 31 * result + (getSpoutNumTasks() != null ? getSpoutNumTasks().hashCode() : 0);
+    result = 31 * result + (getParserParallelism() != null ? getParserParallelism().hashCode() : 0);
+    result = 31 * result + (getParserNumTasks() != null ? getParserNumTasks().hashCode() : 0);
+    result = 31 * result + (getErrorWriterParallelism() != null ? getErrorWriterParallelism().hashCode() : 0);
+    result = 31 * result + (getErrorWriterNumTasks() != null ? getErrorWriterNumTasks().hashCode() : 0);
+    result = 31 * result + (getSpoutConfig() != null ? getSpoutConfig().hashCode() : 0);
+    result = 31 * result + (getSecurityProtocol() != null ? getSecurityProtocol().hashCode() : 0);
+    result = 31 * result + (getStormConfig() != null ? getStormConfig().hashCode() : 0);
+    result = 31 * result + (getParserConfig() != null ? getParserConfig().hashCode() : 0);
+    result = 31 * result + (getFieldTransformations() != null ? getFieldTransformations().hashCode() : 0);
     return result;
   }
 }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/SensorParserConfig.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/SensorParserConfig.java
@@ -37,6 +37,8 @@ public class SensorParserConfig implements Serializable {
   private String invalidWriterClassName;
   private Boolean readMetadata = false;
   private Boolean mergeMetadata = false;
+  private Integer numWorkers = null;
+  private Integer numAckers= null;
   private Integer spoutParallelism = 1;
   private Integer spoutNumTasks = 1;
   private Integer parserParallelism = 1;
@@ -46,6 +48,30 @@ public class SensorParserConfig implements Serializable {
   private Map<String, Object> spoutConfig = new HashMap<>();
   private String securityProtocol = null;
   private Map<String, Object> stormConfig = new HashMap<>();
+
+  /**
+   * Return the number of workers for the topology.  This property will be used for the parser unless overridden on the CLI.
+   * @return
+   */
+  public Integer getNumWorkers() {
+    return numWorkers;
+  }
+
+  public void setNumWorkers(Integer numWorkers) {
+    this.numWorkers = numWorkers;
+  }
+
+  /**
+   * Return the number of ackers for the topology.  This property will be used for the parser unless overridden on the CLI.
+   * @return
+   */
+  public Integer getNumAckers() {
+    return numAckers;
+  }
+
+  public void setNumAckers(Integer numAckers) {
+    this.numAckers = numAckers;
+  }
 
   /**
    * Return the spout parallelism.  This property will be used for the parser unless overridden on the CLI.
@@ -273,6 +299,8 @@ public class SensorParserConfig implements Serializable {
             ", invalidWriterClassName='" + invalidWriterClassName + '\'' +
             ", readMetadata=" + readMetadata +
             ", mergeMetadata=" + mergeMetadata +
+            ", numWorkers=" + numWorkers +
+            ", numAckers=" + numAckers +
             ", spoutParallelism=" + spoutParallelism +
             ", spoutNumTasks=" + spoutNumTasks +
             ", parserParallelism=" + parserParallelism +
@@ -310,6 +338,10 @@ public class SensorParserConfig implements Serializable {
       return false;
     if (getMergeMetadata() != null ? !getMergeMetadata().equals(that.getMergeMetadata()) : that.getMergeMetadata() != null)
       return false;
+    if (getNumWorkers() != null ? !getNumWorkers().equals(that.getNumWorkers()) : that.getNumWorkers() != null)
+      return false;
+    if (getNumAckers() != null ? !getNumAckers().equals(that.getNumAckers()) : that.getNumAckers() != null)
+      return false;
     if (getSpoutParallelism() != null ? !getSpoutParallelism().equals(that.getSpoutParallelism()) : that.getSpoutParallelism() != null)
       return false;
     if (getSpoutNumTasks() != null ? !getSpoutNumTasks().equals(that.getSpoutNumTasks()) : that.getSpoutNumTasks() != null)
@@ -344,6 +376,8 @@ public class SensorParserConfig implements Serializable {
     result = 31 * result + (getInvalidWriterClassName() != null ? getInvalidWriterClassName().hashCode() : 0);
     result = 31 * result + (getReadMetadata() != null ? getReadMetadata().hashCode() : 0);
     result = 31 * result + (getMergeMetadata() != null ? getMergeMetadata().hashCode() : 0);
+    result = 31 * result + (getNumWorkers() != null ? getNumWorkers().hashCode() : 0);
+    result = 31 * result + (getNumAckers() != null ? getNumAckers().hashCode() : 0);
     result = 31 * result + (getSpoutParallelism() != null ? getSpoutParallelism().hashCode() : 0);
     result = 31 * result + (getSpoutNumTasks() != null ? getSpoutNumTasks().hashCode() : 0);
     result = 31 * result + (getParserParallelism() != null ? getParserParallelism().hashCode() : 0);

--- a/metron-platform/metron-management/src/test/java/org/apache/metron/management/ConfigurationFunctionsTest.java
+++ b/metron-platform/metron-management/src/test/java/org/apache/metron/management/ConfigurationFunctionsTest.java
@@ -81,7 +81,15 @@ public class ConfigurationFunctionsTest {
       "parserConfig" : { },
       "fieldTransformations" : [ ],
       "readMetadata":false,
-      "mergeMetadata":false
+      "mergeMetadata":false,
+      "parserParallelism" : 1,
+      "errorWriterParallelism" : 1,
+      "spoutNumTasks" : 1,
+      "stormConfig" : {},
+      "errorWriterNumTasks":1,
+      "spoutConfig":{},
+      "parserNumTasks":1,
+      "spoutParallelism":1
     }
    */
   @Multiline

--- a/metron-platform/metron-parsers/README.md
+++ b/metron-platform/metron-parsers/README.md
@@ -103,6 +103,15 @@ then it is assumed to be a regex and will match any topic matching the pattern (
 * `mergeMetadata` : Boolean indicating whether to merge metadata with the message or not (`false` by default).  See below for a discussion about metadata.
 * `parserConfig` : A JSON Map representing the parser implementation specific configuration.
 * `fieldTransformations` : An array of complex objects representing the transformations to be done on the message generated from the parser before writing out to the kafka topic.
+* `spoutParallelism` : The kafka spout parallelism (default to `1`).  This can be overridden on the command line.
+* `spoutNumTasks` : The number of tasks for the spout (default to `1`). This can be overridden on the command line.
+* `parserParallelism` : The parser bolt parallelism (default to `1`). This can be overridden on the command line.
+* `parserNumTasks` : The number of tasks for the parser bolt (default to `1`). This can be overridden on the command line.
+* `errorWriterParallelism` : The error writer bolt parallelism (default to `1`). This can be overridden on the command line.
+* `errorWriterNumTasks` : The number of tasks for the error writer bolt (default to `1`). This can be overridden on the command line.
+* `spoutConfig` : A map representing a custom spout config. This can be overridden on the command line.
+* `securityProtocol` : The security protocol to use for reading from kafka.  This can be overridden on the command line and also specified in the spout config via the `security.protocol` key.  If both are specified, then they are merged and the CLI will take precedence.
+* `stormConfig` : The storm config to use.  This can be overridden on the command line.  If both are specified, they are merged with CLI properties taking precedence.
 
 The `fieldTransformations` is a complex object which defines a
 transformation which can be done to a message.  This transformation can 

--- a/metron-platform/metron-parsers/README.md
+++ b/metron-platform/metron-parsers/README.md
@@ -109,6 +109,8 @@ then it is assumed to be a regex and will match any topic matching the pattern (
 * `parserNumTasks` : The number of tasks for the parser bolt (default to `1`). This can be overridden on the command line.
 * `errorWriterParallelism` : The error writer bolt parallelism (default to `1`). This can be overridden on the command line.
 * `errorWriterNumTasks` : The number of tasks for the error writer bolt (default to `1`). This can be overridden on the command line.
+* `numWorkers` : The number of workers to use in the topology (default is the storm default of `1`).
+* `numAckers` : The number of acker executors to use in the topology (default is the storm default of `1`).
 * `spoutConfig` : A map representing a custom spout config (this is a map). This can be overridden on the command line.
 * `securityProtocol` : The security protocol to use for reading from kafka (this is a string).  This can be overridden on the command line and also specified in the spout config via the `security.protocol` key.  If both are specified, then they are merged and the CLI will take precedence.
 * `stormConfig` : The storm config to use (this is a map).  This can be overridden on the command line.  If both are specified, they are merged with CLI properties taking precedence.

--- a/metron-platform/metron-parsers/README.md
+++ b/metron-platform/metron-parsers/README.md
@@ -109,9 +109,9 @@ then it is assumed to be a regex and will match any topic matching the pattern (
 * `parserNumTasks` : The number of tasks for the parser bolt (default to `1`). This can be overridden on the command line.
 * `errorWriterParallelism` : The error writer bolt parallelism (default to `1`). This can be overridden on the command line.
 * `errorWriterNumTasks` : The number of tasks for the error writer bolt (default to `1`). This can be overridden on the command line.
-* `spoutConfig` : A map representing a custom spout config. This can be overridden on the command line.
-* `securityProtocol` : The security protocol to use for reading from kafka.  This can be overridden on the command line and also specified in the spout config via the `security.protocol` key.  If both are specified, then they are merged and the CLI will take precedence.
-* `stormConfig` : The storm config to use.  This can be overridden on the command line.  If both are specified, they are merged with CLI properties taking precedence.
+* `spoutConfig` : A map representing a custom spout config (this is a map). This can be overridden on the command line.
+* `securityProtocol` : The security protocol to use for reading from kafka (this is a string).  This can be overridden on the command line and also specified in the spout config via the `security.protocol` key.  If both are specified, then they are merged and the CLI will take precedence.
+* `stormConfig` : The storm config to use (this is a map).  This can be overridden on the command line.  If both are specified, they are merged with CLI properties taking precedence.
 
 The `fieldTransformations` is a complex object which defines a
 transformation which can be done to a message.  This transformation can 

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyBuilder.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyBuilder.java
@@ -75,13 +75,16 @@ public class ParserTopologyBuilder {
    * @param zookeeperUrl             Zookeeper URL
    * @param brokerUrl                Kafka Broker URL
    * @param sensorType               Type of sensor
-   * @param spoutParallelismSupplier         Parallelism hint for the spout
-   * @param spoutNumTasksSupplier            Number of tasks for the spout
-   * @param parserParallelismSupplier        Parallelism hint for the parser bolt
-   * @param parserNumTasksSupplier           Number of tasks for the parser bolt
-   * @param errorWriterParallelismSupplier   Parallelism hint for the bolt that handles errors
-   * @param errorWriterNumTasksSupplier      Number of tasks for the bolt that handles errors
-   * @param kafkaSpoutConfigSupplier         Configuration options for the kafka spout
+   * @param spoutParallelismSupplier         Supplier for the parallelism hint for the spout
+   * @param spoutNumTasksSupplier            Supplier for the number of tasks for the spout
+   * @param parserParallelismSupplier        Supplier for the parallelism hint for the parser bolt
+   * @param parserNumTasksSupplier           Supplier for the number of tasks for the parser bolt
+   * @param errorWriterParallelismSupplier   Supplier for the parallelism hint for the bolt that handles errors
+   * @param errorWriterNumTasksSupplier      Supplier for the number of tasks for the bolt that handles errors
+   * @param kafkaSpoutConfigSupplier         Supplier for the configuration options for the kafka spout
+   * @param securityProtocolSupplier         Supplier for the security protocol
+   * @param outputTopic                      The output kafka topic
+   * @param stormConfigSupplier              Supplier for the storm config
    * @return A Storm topology that parses telemetry data received from an external sensor
    * @throws Exception
    */

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyBuilder.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyBuilder.java
@@ -18,9 +18,11 @@
 package org.apache.metron.parsers.topology;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.metron.parsers.topology.config.ValueSupplier;
 import org.apache.metron.storm.kafka.flux.SimpleStormKafkaBuilder;
 import org.apache.metron.storm.kafka.flux.SpoutConfiguration;
 import org.apache.metron.storm.kafka.flux.StormKafkaSpout;
+import org.apache.storm.Config;
 import org.apache.storm.kafka.spout.KafkaSpout;
 import org.apache.storm.kafka.spout.KafkaSpoutConfig;
 import org.apache.storm.topology.TopologyBuilder;
@@ -48,39 +50,67 @@ import java.util.*;
  */
 public class ParserTopologyBuilder {
 
+  public static class ParserTopology {
+    private TopologyBuilder builder;
+    private Config topologyConfig;
+
+    private ParserTopology(TopologyBuilder builder, Config topologyConfig) {
+      this.builder = builder;
+      this.topologyConfig = topologyConfig;
+    }
+
+
+    public TopologyBuilder getBuilder() {
+      return builder;
+    }
+
+    public Config getTopologyConfig() {
+      return topologyConfig;
+    }
+  }
+
   /**
    * Builds a Storm topology that parses telemetry data received from an external sensor.
    *
    * @param zookeeperUrl             Zookeeper URL
    * @param brokerUrl                Kafka Broker URL
    * @param sensorType               Type of sensor
-   * @param spoutParallelism         Parallelism hint for the spout
-   * @param spoutNumTasks            Number of tasks for the spout
-   * @param parserParallelism        Parallelism hint for the parser bolt
-   * @param parserNumTasks           Number of tasks for the parser bolt
-   * @param errorWriterParallelism   Parallelism hint for the bolt that handles errors
-   * @param errorWriterNumTasks      Number of tasks for the bolt that handles errors
-   * @param kafkaSpoutConfig         Configuration options for the kafka spout
+   * @param spoutParallelismSupplier         Parallelism hint for the spout
+   * @param spoutNumTasksSupplier            Number of tasks for the spout
+   * @param parserParallelismSupplier        Parallelism hint for the parser bolt
+   * @param parserNumTasksSupplier           Number of tasks for the parser bolt
+   * @param errorWriterParallelismSupplier   Parallelism hint for the bolt that handles errors
+   * @param errorWriterNumTasksSupplier      Number of tasks for the bolt that handles errors
+   * @param kafkaSpoutConfigSupplier         Configuration options for the kafka spout
    * @return A Storm topology that parses telemetry data received from an external sensor
    * @throws Exception
    */
-  public static TopologyBuilder build(String zookeeperUrl,
+  public static ParserTopology build(String zookeeperUrl,
                                       Optional<String> brokerUrl,
                                       String sensorType,
-                                      int spoutParallelism,
-                                      int spoutNumTasks,
-                                      int parserParallelism,
-                                      int parserNumTasks,
-                                      int errorWriterParallelism,
-                                      int errorWriterNumTasks,
-                                      Map<String, Object> kafkaSpoutConfig,
-                                      Optional<String> securityProtocol,
-                                      Optional<String> outputTopic
+                                      ValueSupplier<Integer> spoutParallelismSupplier,
+                                      ValueSupplier<Integer> spoutNumTasksSupplier,
+                                      ValueSupplier<Integer> parserParallelismSupplier,
+                                      ValueSupplier<Integer> parserNumTasksSupplier,
+                                      ValueSupplier<Integer> errorWriterParallelismSupplier,
+                                      ValueSupplier<Integer> errorWriterNumTasksSupplier,
+                                      ValueSupplier<Map> kafkaSpoutConfigSupplier,
+                                      ValueSupplier<String> securityProtocolSupplier,
+                                      Optional<String> outputTopic,
+                                      ValueSupplier<Config> stormConfigSupplier
   ) throws Exception {
 
     // fetch configuration from zookeeper
     ParserConfigurations configs = new ParserConfigurations();
     SensorParserConfig parserConfig = getSensorParserConfig(zookeeperUrl, sensorType, configs);
+    int spoutParallelism = spoutParallelismSupplier.get(parserConfig, Integer.class);
+    int spoutNumTasks = spoutNumTasksSupplier.get(parserConfig, Integer.class);
+    int parserParallelism = parserParallelismSupplier.get(parserConfig, Integer.class);
+    int parserNumTasks = parserNumTasksSupplier.get(parserConfig, Integer.class);
+    int errorWriterParallelism = errorWriterParallelismSupplier.get(parserConfig, Integer.class);
+    int errorWriterNumTasks = errorWriterNumTasksSupplier.get(parserConfig, Integer.class);
+    Map<String, Object> kafkaSpoutConfig = kafkaSpoutConfigSupplier.get(parserConfig, Map.class);
+    Optional<String> securityProtocol = Optional.ofNullable(securityProtocolSupplier.get(parserConfig, String.class));
 
     // create the spout
     TopologyBuilder builder = new TopologyBuilder();
@@ -102,7 +132,7 @@ public class ParserTopologyBuilder {
               .shuffleGrouping("parserBolt", Constants.ERROR_STREAM);
     }
 
-    return builder;
+    return new ParserTopology(builder, stormConfigSupplier.get(parserConfig, Config.class));
   }
 
   /**
@@ -247,16 +277,16 @@ public class ParserTopologyBuilder {
    * @throws Exception
    */
   private static SensorParserConfig getSensorParserConfig(String zookeeperUrl, String sensorType, ParserConfigurations configs) throws Exception {
-    CuratorFramework client = ConfigurationsUtils.getClient(zookeeperUrl);
-    client.start();
-    ConfigurationsUtils.updateParserConfigsFromZookeeper(configs, client);
-    SensorParserConfig parserConfig = configs.getSensorParserConfig(sensorType);
-    if (parserConfig == null) {
-      throw new IllegalStateException("Cannot find the parser configuration in zookeeper for " + sensorType + "." +
-              "  Please check that it exists in zookeeper by using the 'zk_load_configs.sh -m DUMP' command.");
+    try(CuratorFramework client = ConfigurationsUtils.getClient(zookeeperUrl)) {
+      client.start();
+      ConfigurationsUtils.updateParserConfigsFromZookeeper(configs, client);
+      SensorParserConfig parserConfig = configs.getSensorParserConfig(sensorType);
+      if (parserConfig == null) {
+        throw new IllegalStateException("Cannot find the parser configuration in zookeeper for " + sensorType + "." +
+                "  Please check that it exists in zookeeper by using the 'zk_load_configs.sh -m DUMP' command.");
+      }
+      return parserConfig;
     }
-    client.close();
-    return parserConfig;
   }
 
   /**

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyCLI.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyCLI.java
@@ -365,7 +365,13 @@ public class ParserTopologyCLI {
       if(c != null && !c.isEmpty()) {
         finalConfig.putAll(c);
       }
-      return ParserOptions.getConfig(cmd, finalConfig).orElse(new Config());
+      if(parserConfig.getNumAckers() != null) {
+        Config.setNumAckers(finalConfig, parserConfig.getNumAckers());
+      }
+      if(parserConfig.getNumWorkers() != null) {
+        Config.setNumWorkers(finalConfig, parserConfig.getNumWorkers());
+      }
+      return ParserOptions.getConfig(cmd, finalConfig).orElse(finalConfig);
     };
 
     Optional<String> outputTopic = ParserOptions.OUTPUT_TOPIC.has(cmd)?Optional.of(ParserOptions.OUTPUT_TOPIC.get(cmd)):Optional.empty();

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyCLI.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyCLI.java
@@ -301,6 +301,24 @@ public class ParserTopologyCLI {
     String zookeeperUrl = ParserOptions.ZK_QUORUM.get(cmd);
     Optional<String> brokerUrl = ParserOptions.BROKER_URL.has(cmd)?Optional.of(ParserOptions.BROKER_URL.get(cmd)):Optional.empty();
     String sensorType= ParserOptions.SENSOR_TYPE.get(cmd);
+
+    /*
+    It bears mentioning why we're creating this ValueSupplier indirection here.
+    As a separation of responsibilities, the CLI class defines the order of precedence
+    for the various topological and structural properties for creating a parser.  This is
+    desirable because there are now (i.e. integration tests)
+    and may be in the future (i.e. a REST service to start parsers without using the CLI)
+    other mechanisms to construct parser topologies.  It's sensible to split those concerns..
+
+    Unfortunately, determining the structural parameters for a parser requires interacting with
+    external services (e.g. zookeeper) that are set up well within the ParserTopology class.
+    Rather than pulling the infrastructure to interact with those services out and moving it into the
+    CLI class and breaking that separation of concerns, we've created a supplier
+    indirection where are providing the logic as to how to create precedence in the CLI class
+    without owning the responsibility of constructing the infrastructure where the values are
+    necessarily supplied.
+
+     */
     ValueSupplier<Integer> spoutParallelism = (parserConfig, clazz) -> {
       if(ParserOptions.SPOUT_PARALLELISM.has(cmd)) {
         return Integer.parseInt(ParserOptions.SPOUT_PARALLELISM.get(cmd, "1"));

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/config/ValueSupplier.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/config/ValueSupplier.java
@@ -21,6 +21,10 @@ package org.apache.metron.parsers.topology.config;
 import org.apache.metron.common.configuration.SensorParserConfig;
 
 
+/**
+ * Supplies a value given a sensor config.
+ * @param <T>
+ */
 public interface ValueSupplier<T> {
   T get(SensorParserConfig config, Class<T> clazz);
 }

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/config/ValueSupplier.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/config/ValueSupplier.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.metron.parsers.topology.config;
+
+import org.apache.metron.common.configuration.SensorParserConfig;
+
+
+public interface ValueSupplier<T> {
+  T get(SensorParserConfig config, Class<T> clazz);
+}

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/integration/components/ParserTopologyComponent.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/integration/components/ParserTopologyComponent.java
@@ -87,23 +87,29 @@ public class ParserTopologyComponent implements InMemoryComponent {
   @Override
   public void start() throws UnableToStartException {
     try {
-      TopologyBuilder topologyBuilder = ParserTopologyBuilder.build(topologyProperties.getProperty(ZKServerComponent.ZOOKEEPER_PROPERTY)
+      final Map<String, Object> stormConf = new HashMap<>();
+      stormConf.put(Config.TOPOLOGY_DEBUG, true);
+      ParserTopologyBuilder.ParserTopology topologyBuilder = ParserTopologyBuilder.build(topologyProperties.getProperty(ZKServerComponent.ZOOKEEPER_PROPERTY)
                                                                    , Optional.ofNullable(brokerUrl)
                                                                    , sensorType
-                                                                   , 1
-                                                                   , 1
-                                                                   , 1
-                                                                   , 1
-                                                                   , 1
-                                                                   , 1
-                                                                   , null
-                                                                   , Optional.empty()
+                                                                   , (x,y) -> 1
+                                                                   , (x,y) -> 1
+                                                                   , (x,y) -> 1
+                                                                   , (x,y) -> 1
+                                                                   , (x,y) -> 1
+                                                                   , (x,y) -> 1
+                                                                   , (x,y) -> new HashMap<>()
+                                                                   , (x,y) -> null
                                                                    , Optional.ofNullable(outputTopic)
+                                                                   , (x,y) -> {
+                                                                      Config c = new Config();
+                                                                      c.putAll(stormConf);
+                                                                      return c;
+                                                                      }
                                                                    );
-      Map<String, Object> stormConf = new HashMap<>();
-      stormConf.put(Config.TOPOLOGY_DEBUG, true);
+
       stormCluster = new LocalCluster();
-      stormCluster.submitTopology(sensorType, stormConf, topologyBuilder.createTopology());
+      stormCluster.submitTopology(sensorType, stormConf, topologyBuilder.getBuilder().createTopology());
     } catch (Exception e) {
       throw new UnableToStartException("Unable to start parser topology for sensorType: " + sensorType, e);
     }

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/topology/ParserTopologyCLITest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/topology/ParserTopologyCLITest.java
@@ -199,4 +199,6 @@ public class ParserTopologyCLITest {
       extraFile.deleteOnExit();
     }
   }
+
+
 }

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/topology/ParserTopologyCLITest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/topology/ParserTopologyCLITest.java
@@ -18,8 +18,12 @@
 
 package org.apache.metron.parsers.topology;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.commons.cli.Parser;
 import org.apache.log4j.Level;
+import org.apache.metron.common.configuration.SensorParserConfig;
+import org.apache.metron.common.utils.JSONUtils;
+import org.apache.metron.parsers.topology.config.ValueSupplier;
 import org.apache.metron.test.utils.UnitTestHelper;
 import org.apache.storm.Config;
 import com.google.common.collect.ImmutableMap;
@@ -34,7 +38,10 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.ref.Reference;
 import java.util.*;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 public class ParserTopologyCLITest {
 
@@ -200,5 +207,377 @@ public class ParserTopologyCLITest {
     }
   }
 
+  private static class ParserInput {
+    private Integer spoutParallelism;
+    private Integer spoutNumTasks;
+    private Integer parserParallelism;
+    private Integer parserNumTasks;
+    private Integer errorParallelism;
+    private Integer errorNumTasks;
+    private Map<String, Object> spoutConfig;
+    private String securityProtocol;
+    private Config stormConf;
+
+    public ParserInput( ValueSupplier<Integer> spoutParallelism
+                      , ValueSupplier<Integer> spoutNumTasks
+                      , ValueSupplier<Integer> parserParallelism
+                      , ValueSupplier<Integer> parserNumTasks
+                      , ValueSupplier<Integer> errorParallelism
+                      , ValueSupplier<Integer> errorNumTasks
+                      , ValueSupplier<Map> spoutConfig
+                      , ValueSupplier<String> securityProtocol
+                      , ValueSupplier<Config> stormConf
+                      , SensorParserConfig config
+                      )
+    {
+      this.spoutParallelism = spoutParallelism.get(config, Integer.class);
+      this.spoutNumTasks = spoutNumTasks.get(config, Integer.class);
+      this.parserParallelism = parserParallelism.get(config, Integer.class);
+      this.parserNumTasks = parserNumTasks.get(config, Integer.class);
+      this.errorParallelism = errorParallelism.get(config, Integer.class);
+      this.errorNumTasks = errorNumTasks.get(config, Integer.class);
+      this.spoutConfig = spoutConfig.get(config, Map.class);
+      this.securityProtocol = securityProtocol.get(config, String.class);
+      this.stormConf = stormConf.get(config, Config.class);
+    }
+
+    public Integer getSpoutParallelism() {
+      return spoutParallelism;
+    }
+
+    public Integer getSpoutNumTasks() {
+      return spoutNumTasks;
+    }
+
+    public Integer getParserParallelism() {
+      return parserParallelism;
+    }
+
+    public Integer getParserNumTasks() {
+      return parserNumTasks;
+    }
+
+    public Integer getErrorParallelism() {
+      return errorParallelism;
+    }
+
+    public Integer getErrorNumTasks() {
+      return errorNumTasks;
+    }
+
+    public Map<String, Object> getSpoutConfig() {
+      return spoutConfig;
+    }
+
+    public String getSecurityProtocol() {
+      return securityProtocol;
+    }
+
+    public Config getStormConf() {
+      return stormConf;
+    }
+  }
+  /**
+{
+  "parserClassName": "org.apache.metron.parsers.GrokParser",
+  "sensorTopic": "squid",
+  "parserConfig": {
+    "grokPath": "/patterns/squid",
+    "patternLabel": "SQUID_DELIMITED",
+    "timestampField": "timestamp"
+  },
+  "fieldTransformations" : [
+    {
+      "transformation" : "STELLAR"
+    ,"output" : [ "full_hostname", "domain_without_subdomains" ]
+    ,"config" : {
+      "full_hostname" : "URL_TO_HOST(url)"
+      ,"domain_without_subdomains" : "DOMAIN_REMOVE_SUBDOMAINS(full_hostname)"
+                }
+    }
+                           ]
+}
+   */
+  @Multiline
+  public static String baseConfig;
+  private static SensorParserConfig getBaseConfig() {
+    try {
+      return JSONUtils.INSTANCE.load(baseConfig, SensorParserConfig.class);
+    } catch (IOException e) {
+      throw new IllegalStateException(e.getMessage(), e);
+    }
+  }
+
+  @Test
+  public void testSpoutParallelism() throws Exception {
+    testConfigOption(ParserTopologyCLI.ParserOptions.SPOUT_PARALLELISM
+                    , "10"
+                    , input -> input.getSpoutParallelism().equals(10)
+                    , () -> {
+                      SensorParserConfig config = getBaseConfig();
+                      config.setSpoutParallelism(20);
+                      return config;
+                    }
+                    , input -> input.getSpoutParallelism().equals(20)
+                    );
+  }
+
+  @Test
+  public void testSpoutNumTasks() throws Exception {
+    testConfigOption(ParserTopologyCLI.ParserOptions.SPOUT_NUM_TASKS
+                    , "10"
+                    , input -> input.getSpoutNumTasks().equals(10)
+                    , () -> {
+                      SensorParserConfig config = getBaseConfig();
+                      config.setSpoutNumTasks(20);
+                      return config;
+                    }
+                    , input -> input.getSpoutNumTasks().equals(20)
+                    );
+  }
+
+  @Test
+  public void testParserParallelism() throws Exception {
+    testConfigOption(ParserTopologyCLI.ParserOptions.PARSER_PARALLELISM
+                    , "10"
+                    , input -> input.getParserParallelism().equals(10)
+                    , () -> {
+                      SensorParserConfig config = getBaseConfig();
+                      config.setParserParallelism(20);
+                      return config;
+                    }
+                    , input -> input.getParserParallelism().equals(20)
+                    );
+  }
+
+  @Test
+  public void testParserNumTasks() throws Exception {
+    testConfigOption(ParserTopologyCLI.ParserOptions.PARSER_NUM_TASKS
+                    , "10"
+                    , input -> input.getParserNumTasks().equals(10)
+                    , () -> {
+                      SensorParserConfig config = getBaseConfig();
+                      config.setParserNumTasks(20);
+                      return config;
+                    }
+                    , input -> input.getParserNumTasks().equals(20)
+                    );
+  }
+
+  @Test
+  public void testErrorParallelism() throws Exception {
+    testConfigOption(ParserTopologyCLI.ParserOptions.ERROR_WRITER_PARALLELISM
+                    , "10"
+                    , input -> input.getErrorParallelism().equals(10)
+                    , () -> {
+                      SensorParserConfig config = getBaseConfig();
+                      config.setErrorWriterParallelism(20);
+                      return config;
+                    }
+                    , input -> input.getErrorParallelism().equals(20)
+                    );
+  }
+
+  @Test
+  public void testErrorNumTasks() throws Exception {
+    testConfigOption(ParserTopologyCLI.ParserOptions.ERROR_WRITER_NUM_TASKS
+                    , "10"
+                    , input -> input.getErrorNumTasks().equals(10)
+                    , () -> {
+                      SensorParserConfig config = getBaseConfig();
+                      config.setErrorWriterNumTasks(20);
+                      return config;
+                    }
+                    , input -> input.getErrorNumTasks().equals(20)
+                    );
+  }
+
+  @Test
+  public void testSecurityProtocol_fromCLI() throws Exception {
+    testConfigOption(ParserTopologyCLI.ParserOptions.SECURITY_PROTOCOL
+                    , "PLAINTEXT"
+                    , input -> input.getSecurityProtocol().equals("PLAINTEXT")
+                    , () -> {
+                      SensorParserConfig config = getBaseConfig();
+                      config.setSecurityProtocol("KERBEROS");
+                      return config;
+                    }
+                    , input -> input.getSecurityProtocol().equals("KERBEROS")
+                    );
+  }
+
+  @Test
+  public void testSecurityProtocol_fromSpout() throws Exception {
+    //Ultimately the order of precedence is CLI > spout config > parser config
+    File extraConfig = File.createTempFile("spoutConfig", "json");
+      extraConfig.deleteOnExit();
+      writeMap(extraConfig, new HashMap<String, Object>() {{
+        put("security.protocol", "PLAINTEXTSASL");
+      }});
+    {
+      //Ensure that the CLI spout config takes precedence
+
+      testConfigOption(new EnumMap<ParserTopologyCLI.ParserOptions, String>(ParserTopologyCLI.ParserOptions.class) {{
+                         put(ParserTopologyCLI.ParserOptions.SPOUT_CONFIG, extraConfig.getAbsolutePath());
+                         put(ParserTopologyCLI.ParserOptions.SECURITY_PROTOCOL, "PLAINTEXT");
+                       }}
+              , input -> input.getSecurityProtocol().equals("PLAINTEXT")
+              , () -> {
+                SensorParserConfig config = getBaseConfig();
+                config.setSecurityProtocol("PLAINTEXTSASL_FROM_ZK");
+                return config;
+              }
+              , input -> input.getSecurityProtocol().equals("PLAINTEXTSASL_FROM_ZK")
+      );
+    }
+    {
+      //Ensure that the spout config takes precedence
+      testConfigOption(new EnumMap<ParserTopologyCLI.ParserOptions, String>(ParserTopologyCLI.ParserOptions.class) {{
+                         put(ParserTopologyCLI.ParserOptions.SPOUT_CONFIG, extraConfig.getAbsolutePath());
+                       }}
+              , input -> input.getSecurityProtocol().equals("PLAINTEXTSASL")
+              , () -> {
+                SensorParserConfig config = getBaseConfig();
+                config.setSecurityProtocol("PLAINTEXTSASL_FROM_ZK");
+                return config;
+              }
+              , input -> input.getSecurityProtocol().equals("PLAINTEXTSASL_FROM_ZK")
+      );
+    }
+  }
+
+  @Test
+  public void testTopologyConfig() throws Exception {
+    File extraConfig = File.createTempFile("topologyConfig", "json");
+    extraConfig.deleteOnExit();
+    writeMap(extraConfig, new HashMap<String, Object>() {{
+      put(Config.TOPOLOGY_DEBUG, true);
+    }});
+    testConfigOption(new EnumMap<ParserTopologyCLI.ParserOptions, String>(ParserTopologyCLI.ParserOptions.class)
+                    {{
+                      put(ParserTopologyCLI.ParserOptions.NUM_WORKERS, "10");
+                      put(ParserTopologyCLI.ParserOptions.NUM_ACKERS, "20");
+                      put(ParserTopologyCLI.ParserOptions.EXTRA_OPTIONS, extraConfig.getAbsolutePath());
+                    }}
+                    , input -> {
+                        Config c = input.getStormConf();
+                        return (int)c.get(Config.TOPOLOGY_WORKERS) == 10
+                            && (int)c.get(Config.TOPOLOGY_ACKER_EXECUTORS) == 20
+                            && (boolean)c.get(Config.TOPOLOGY_DEBUG);
+                      }
+                      , () -> {
+                        SensorParserConfig config = getBaseConfig();
+                        config.setStormConfig(
+                          new HashMap<String, Object>() {{
+                            put(Config.TOPOLOGY_WORKERS, 100);
+                            put(Config.TOPOLOGY_ACKER_EXECUTORS, 200);
+                          }}
+                                             );
+                        return config;
+                              }
+                      , input -> {
+                          Config c = input.getStormConf();
+                          return (int)c.get(Config.TOPOLOGY_WORKERS) == 100
+                              && (int)c.get(Config.TOPOLOGY_ACKER_EXECUTORS) == 200
+                              && !c.containsKey(Config.TOPOLOGY_DEBUG);
+                                 }
+                    );
+  }
+
+  @Test
+  public void testSpoutConfig() throws Exception {
+    File extraConfig = File.createTempFile("spoutConfig", "json");
+    extraConfig.deleteOnExit();
+    writeMap(extraConfig, new HashMap<String, Object>() {{
+      put("extra_config", "from_file");
+    }});
+    testConfigOption(new EnumMap<ParserTopologyCLI.ParserOptions, String>(ParserTopologyCLI.ParserOptions.class)
+                    {{
+                      put(ParserTopologyCLI.ParserOptions.SPOUT_CONFIG, extraConfig.getAbsolutePath());
+                    }}
+                    , input -> input.getSpoutConfig().get("extra_config").equals("from_file")
+                      , () -> {
+                        SensorParserConfig config = getBaseConfig();
+                        config.setSpoutConfig(
+                          new HashMap<String, Object>() {{
+                            put("extra_config", "from_zk");
+                          }}
+                                             );
+                        return config;
+                              }
+                      , input -> input.getSpoutConfig().get("extra_config").equals("from_zk")
+                    );
+  }
+
+  private void writeMap(File outFile, Map<String, Object> config) throws IOException {
+    FileUtils.write(outFile, JSONUtils.INSTANCE.toJSON(config, true));
+  }
+
+  private void testConfigOption( ParserTopologyCLI.ParserOptions option
+                               , String cliOverride
+                               , Predicate<ParserInput> cliOverrideCondition
+                               , Supplier<SensorParserConfig> configSupplier
+                               , Predicate<ParserInput> configOverrideCondition
+  ) throws Exception {
+    testConfigOption(
+            new EnumMap<ParserTopologyCLI.ParserOptions, String>(ParserTopologyCLI.ParserOptions.class) {{
+              put(option, cliOverride);
+            }},
+            cliOverrideCondition,
+            configSupplier,
+            configOverrideCondition
+    );
+  }
+
+  private void testConfigOption( EnumMap<ParserTopologyCLI.ParserOptions, String> options
+                               , Predicate<ParserInput> cliOverrideCondition
+                               , Supplier<SensorParserConfig> configSupplier
+                               , Predicate<ParserInput> configOverrideCondition
+  ) throws Exception {
+    //CLI Override
+    SensorParserConfig config = configSupplier.get();
+    {
+      CLIBuilder builder = new CLIBuilder().with(ParserTopologyCLI.ParserOptions.BROKER_URL, "mybroker")
+              .with(ParserTopologyCLI.ParserOptions.ZK_QUORUM, "myzk")
+              .with(ParserTopologyCLI.ParserOptions.SENSOR_TYPE, "mysensor");
+      for(Map.Entry<ParserTopologyCLI.ParserOptions, String> entry : options.entrySet()) {
+        builder.with(entry.getKey(), entry.getValue());
+      }
+      CommandLine cmd = builder.build(true);
+      ParserInput input = getInput(cmd, config);
+      Assert.assertTrue(cliOverrideCondition.test(input));
+    }
+    // Config Override
+    {
+      CLIBuilder builder = new CLIBuilder().with(ParserTopologyCLI.ParserOptions.BROKER_URL, "mybroker")
+              .with(ParserTopologyCLI.ParserOptions.ZK_QUORUM, "myzk")
+              .with(ParserTopologyCLI.ParserOptions.SENSOR_TYPE, "mysensor");
+      CommandLine cmd = builder.build(true);
+      ParserInput input = getInput(cmd, config);
+      Assert.assertTrue(configOverrideCondition.test(input));
+    }
+  }
+
+  private static ParserInput getInput(CommandLine cmd, SensorParserConfig config ) throws Exception {
+    final ParserInput[] parserInput = new ParserInput[]{null};
+    new ParserTopologyCLI() {
+      @Override
+      protected ParserTopologyBuilder.ParserTopology getParserTopology(String zookeeperUrl, Optional<String> brokerUrl, String sensorType, ValueSupplier<Integer> spoutParallelism, ValueSupplier<Integer> spoutNumTasks, ValueSupplier<Integer> parserParallelism, ValueSupplier<Integer> parserNumTasks, ValueSupplier<Integer> errorParallelism, ValueSupplier<Integer> errorNumTasks, ValueSupplier<Map> spoutConfig, ValueSupplier<String> securityProtocol, ValueSupplier<Config> stormConf, Optional<String> outputTopic) throws Exception {
+       parserInput[0] = new ParserInput( spoutParallelism
+                                        , spoutNumTasks
+                                        , parserParallelism
+                                        , parserNumTasks
+                                        , errorParallelism
+                                        , errorNumTasks
+                                        , spoutConfig
+                                        , securityProtocol
+                                        , stormConf
+                                        , config
+                                        );
+        return null;
+      }
+    }.createParserTopology(cmd);
+    return parserInput[0];
+  }
 
 }

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/topology/ParserTopologyCLITest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/topology/ParserTopologyCLITest.java
@@ -142,7 +142,8 @@ public class ParserTopologyCLITest {
                                      .with(ParserTopologyCLI.ParserOptions.NUM_MAX_TASK_PARALLELISM, "3")
                                      .with(ParserTopologyCLI.ParserOptions.MESSAGE_TIMEOUT, "4")
                                      .build(longOpt);
-    Config config = ParserTopologyCLI.ParserOptions.getConfig(cli);
+    Optional<Config> configOptional = ParserTopologyCLI.ParserOptions.getConfig(cli);
+    Config config = configOptional.get();
     Assert.assertEquals(1, config.get(Config.TOPOLOGY_WORKERS));
     Assert.assertEquals(2, config.get(Config.TOPOLOGY_ACKER_EXECUTORS));
     Assert.assertEquals(3, config.get(Config.TOPOLOGY_MAX_TASK_PARALLELISM));
@@ -189,7 +190,8 @@ public class ParserTopologyCLITest {
               .with(ParserTopologyCLI.ParserOptions.MESSAGE_TIMEOUT, "4")
               .with(ParserTopologyCLI.ParserOptions.EXTRA_OPTIONS, extraFile.getAbsolutePath())
               .build(longOpt);
-      Config config = ParserTopologyCLI.ParserOptions.getConfig(cli);
+      Optional<Config> configOptional = ParserTopologyCLI.ParserOptions.getConfig(cli);
+      Config config = configOptional.get();
       Assert.assertEquals(4, config.get(Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS));
       Assert.assertEquals("foo", config.get("string"));
       Assert.assertEquals(1, config.get("integer"));


### PR DESCRIPTION
## Contributor Comments
It would be useful to maintain sensible defaults for various properties in the construction of parser topologies within the sensor parser config in zookeeper. This, along with a UI, would allow people to manage defaults per sensor in a single place. CLI should take precedent and override anything stored in zookeeper.

Manual testing via fulldev should focus on ensuring the following conditions hold for the properties able to be specified in the config:
* Specify the property in the config.
* Start parser and ensure that the property is preserved.
* Specify the property via the CLI param
* Start parser and ensure that the CLI param is honored

The properties able to be specified in the config are as follows: 
* `spoutParallelism` : The kafka spout parallelism (default to `1`).  This can be overridden on the command line.
* `spoutNumTasks` : The number of tasks for the spout (default to `1`). This can be overridden on the command line.
* `parserParallelism` : The parser bolt parallelism (default to `1`). This can be overridden on the command line.
* `parserNumTasks` : The number of tasks for the parser bolt (default to `1`). This can be overridden on the command line.
* `errorWriterParallelism` : The error writer bolt parallelism (default to `1`). This can be overridden on the command line.
* `errorWriterNumTasks` : The number of tasks for the error writer bolt (default to `1`). This can be overridden on the command line.
* `spoutConfig` : A map representing a custom spout config. This can be overridden on the command line.
* `securityProtocol` : The security protocol to use for reading from kafka.  This can be overridden on the command line and also specified in the spout config via the `security.protocol` key.  If both are specified, then they are merged and the CLI will take precedence.
* `stormConfig` : The storm config to use.  This can be overridden on the command line.  If both are specified, they are merged with CLI properties taking precedence.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && build_utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.

