### PR TITLE
METRON-1138 Improve Error Message with Bad Profile Expression

### DIFF
--- a/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/DefaultProfileBuilderTest.java
+++ b/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/DefaultProfileBuilderTest.java
@@ -600,7 +600,7 @@ public class DefaultProfileBuilderTest {
    *   "init":   { "x": "0" },
    *   "update": { "x": "x + 1" },
    *   "result": "x",
-   *   "groupBy": ["2 / 0"]
+   *   "groupBy": ["nonexistant"]
    * }
    */
   @Multiline

--- a/metron-analytics/metron-profiler/README.md
+++ b/metron-analytics/metron-profiler/README.md
@@ -200,6 +200,7 @@ A common use case would be grouping by day of week.  This allows a contiguous sc
 ```
 
 The expression can reference any of these variables.
+* Any variable defined by the profile in its `init` or `update` expressions.
 * `profile` The name of the profile.
 * `entity` The name of the entity being profiled.
 * `start` The start time of the profile period in epoch milliseconds.


### PR DESCRIPTION
I have found that it can be very natural for a new Profiler user to attempt to reference a field defined in a telemetry message, in a Profile's `groupBy` expression.  Unfortunately, this does not work as the 'groupBy' expression runs during a flush where there is no telemetry message available.  Only specific fields including duration, result, profile, start, end, entity and any variables defined in the profile itself are available.  This behavior is documented in the README, but should be more accessible when an error occurs.

For example, this seems like a Profile that should work.  But unfortunately there is no `timestamp` variable defined when the `groupBy` expression is executed.
```
{
      "profile": "calender-effects",
      "onlyif":  "exists(ip_src_addr) and exists(timestamp)",
      "foreach": "ip_src_addr",
      "init":    { "count": 0 },
      "update":  { "count": "count + 1" },
      "result":  "count",
      "groupBy": ["DAY_OF_WEEK(timestamp)"]
    }
```

When this expression fails the error message looks-like the following, which is not exactly enlightening.

```
org.apache.metron.stellar.dsl.ParseException: Bad 'groupBy' expression: Unexpected type: 
expected=Object, 
actual=null, 
expression=DAY_OF_WEEK(timestamp), 
profile=calender-effects, 
entity=10.0.0.1 
```

With this change, additional information is provided when any Profile expression fails. 
* The variables that are in-scope are logged.
* The exact expression that failed is logged.  Previously, for the 'init' and 'update' expressions it wasn't clear which expression failed, if the user defined multiple.

This should make it much easier to debug for a user.  The same error looks-like the following with the code change.  Notice the new `variables-available` which defines the variables that were in-scope when the expression was executed.

```
ERROR DefaultProfileBuilder:189 - ...
org.apache.metron.stellar.dsl.ParseException: Bad 'groupBy' expression: 
error='Unexpected type: expected=Object, actual=null, expression=DAY_OF_WEEK(timestamp)', expr='DAY_OF_WEEK(timestamp)', 
profile='calendar-effects', 
entity='10.0.0.1', 
variables-available='[duration, result, profile, start, x, end, entity]'
```


