### PR TITLE
METRON-1136  Refactor for ParserExtensionConfig and Rest get all call

### DIFF
--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/controller/ParserExtensionController.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/controller/ParserExtensionController.java
@@ -22,6 +22,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import java.util.List;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.metron.common.configuration.extensions.ParserExtensionConfig;
@@ -51,7 +52,7 @@ public class ParserExtensionController {
   DeferredResult<ResponseEntity<Void>> install(@ApiParam(name = "extensionTgz", value = "Metron Parser Extension tar.gz", required = true) @RequestParam("extensionTgz") MultipartFile extensionTgz) throws RestException {
     DeferredResult<ResponseEntity<Void>> result = new DeferredResult<>();
 
-    String extensionName = extensionService.formatPackageName(extensionTgz.getOriginalFilename());
+    String extensionName = extensionService.formatExtensionIdentifier(extensionTgz.getOriginalFilename());
     try {
       if (extensionService.findOneParserExtension(extensionName) != null) {
         result.setResult(new ResponseEntity<Void>(HttpStatus.FORBIDDEN));
@@ -90,8 +91,8 @@ public class ParserExtensionController {
   @ApiOperation(value = "Retrieves all ParserExtensionConfigs from Zookeeper")
   @ApiResponse(message = "Returns all ParserExtensionConfigs", code = 200)
   @RequestMapping(method = RequestMethod.GET)
-  ResponseEntity<Map<String, ParserExtensionConfig>> findAll() throws RestException {
-    return new ResponseEntity<Map<String, ParserExtensionConfig>>(extensionService.getAllParserExtensions(), HttpStatus.OK);
+  ResponseEntity<List<ParserExtensionConfig>> findAll() throws RestException {
+    return new ResponseEntity<List<ParserExtensionConfig>>(extensionService.getAllParserExtensions(), HttpStatus.OK);
   }
 
   @ApiOperation(value = "Deletes or uninstalls a Parser Extension and all parsers from system")

--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/service/ExtensionService.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/service/ExtensionService.java
@@ -51,8 +51,9 @@ public interface ExtensionService {
   }
   void install(ExtensionType extensionType, String extensionPackageName, TarArchiveInputStream tgzStream) throws Exception;
   ParserExtensionConfig findOneParserExtension(String name) throws RestException;
-  Map<String, ParserExtensionConfig> getAllParserExtensions() throws RestException;
+  List<ParserExtensionConfig> getAllParserExtensions() throws RestException;
   List<String> getAllParserExtensionTypes() throws RestException;
   boolean deleteParserExtension(String name) throws Exception;
   String formatPackageName(String name);
+  String formatExtensionIdentifier(String name);
 }

--- a/metron-interface/metron-rest/src/test/java/org/apache/metron/rest/controller/ParserExtensionControllerIntegrationTest.java
+++ b/metron-interface/metron-rest/src/test/java/org/apache/metron/rest/controller/ParserExtensionControllerIntegrationTest.java
@@ -35,6 +35,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultHandler;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -135,21 +136,24 @@ public class ParserExtensionControllerIntegrationTest {
     this.mockMvc.perform(get(parserExtUrl + "/metron-parser-test-assembly-0_4_0").with(httpBasic(user, password)))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.parseMediaType("application/json;charset=UTF-8")))
-            .andExpect(jsonPath("$.extensionAssemblyName").value("metron-parser-test-assembly-0_4_0"))
+            .andExpect(jsonPath("$.extensionAssemblyName").value("metron-parser-test-assembly-0_4_0-archive"))
+            .andExpect(jsonPath("$.extensionIdentifier").value("metron-parser-test-assembly-0_4_0"))
             .andExpect(jsonPath("$.extensionBundleName").value("metron-parser-test-bundle-0.4.0.bundle"))
-            .andExpect(jsonPath("$.extensionsBundleID").value("metron-parser-test-bundle"))
-            .andExpect(jsonPath("$.extensionsBundleVersion").value("0.4.0"))
+            .andExpect(jsonPath("$.extensionBundleID").value("metron-parser-test-bundle"))
+            .andExpect(jsonPath("$.extensionBundleVersion").value("0.4.0"))
             .andExpect(jsonPath("$.parserExtensionParserNames[0]").value("test"));
 
     // GET ALL
     this.mockMvc.perform(get(parserExtUrl).with(httpBasic(user,password)))
             .andExpect(status().isOk())
+            .andDo((r) -> System.out.println(r.getResponse().getContentAsString()))
             .andExpect(content().contentType(MediaType.parseMediaType("application/json;charset=UTF-8")))
-            .andExpect(jsonPath("$[?(@.metron-parser-test-assembly-0_4_0.extensionAssemblyName == 'metron-parser-test-assembly-0_4_0' && " +
-                    "@.metron-parser-test-assembly-0_4_0.extensionBundleName == 'metron-parser-test-bundle-0.4.0.bundle' && " +
-                    "@.metron-parser-test-assembly-0_4_0.extensionsBundleID == 'metron-parser-test-bundle' && " +
-                    "@.metron-parser-test-assembly-0_4_0.extensionsBundleVersion == '0.4.0' && " +
-                    "@.metron-parser-test-assembly-0_4_0.parserExtensionParserNames[0] == 'test')]").exists());
+            .andExpect(jsonPath("$[?(@.extensionAssemblyName == 'metron-parser-test-assembly-0_4_0-archive' && " +
+                    "@.extensionIdentifier == 'metron-parser-test-assembly-0_4_0' && " +
+                    "@.extensionBundleName == 'metron-parser-test-bundle-0.4.0.bundle' && " +
+                    "@.extensionBundleID == 'metron-parser-test-bundle' && " +
+                    "@.extensionBundleVersion == '0.4.0' && " +
+                    "@.parserExtensionParserNames[0] == 'test')]").exists());
 
     // DELETE ASYNC
     result = this.mockMvc.perform(delete(parserExtUrl + "/metron-parser-test-assembly-0_4_0").with(httpBasic(user, password))).andReturn();

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/extensions/ParserExtensionConfig.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/extensions/ParserExtensionConfig.java
@@ -1,19 +1,16 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements.  See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the License.  You may obtain
+ * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package org.apache.metron.common.configuration.extensions;
 
@@ -28,16 +25,35 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.*;
 
-public class ParserExtensionConfig implements Serializable{
+/**
+ * Configuration class for Parser Extensions.
+ *
+ * The ParserExtensionConfig contains information about the extension itself,
+ * along with default configurations for each of the parser types exposed by the
+ * extension.
+ *
+ *
+ */
+public class ParserExtensionConfig implements Serializable {
+
+  private String extensionIdentifier;
   private String extensionAssemblyName;
   private String extensionBundleName;
-  private String extensionsBundleID;
-  private String extensionsBundleVersion;
+  private String extensionBundleID;
+  private String extensionBundleVersion;
   private Set<String> parserExtensionParserNames;
-  private Map<String,SensorParserConfig> defaultParserConfigs;
-  private Map<String,SensorEnrichmentConfig> defaultEnrichementConfigs;
-  private Map<String,Map<String,Object>> defaultIndexingConfigs;
-  private Map<String,Map<String,Object>> defaultElasticSearchTemplates;
+  private Map<String, SensorParserConfig> defaultParserConfigs;
+  private Map<String, SensorEnrichmentConfig> defaultEnrichmentConfigs;
+  private Map<String, Map<String, Object>> defaultIndexingConfigs;
+  private Map<String, Map<String, Object>> defaultElasticSearchTemplates;
+
+  public String getExtensionIdentifier() {
+    return extensionIdentifier;
+  }
+
+  public void setExtensionIdentifier(String extensionIdentifier) {
+    this.extensionIdentifier = extensionIdentifier;
+  }
 
   public String getExtensionAssemblyName() {
     return extensionAssemblyName;
@@ -55,24 +71,24 @@ public class ParserExtensionConfig implements Serializable{
     this.extensionBundleName = extensionBundleName;
   }
 
-  public String getExtensionsBundleID() {
-    return extensionsBundleID;
+  public String getExtensionBundleID() {
+    return extensionBundleID;
   }
 
-  public void setExtensionsBundleID(String extensionsBundleID) {
-    this.extensionsBundleID = extensionsBundleID;
+  public void setExtensionBundleID(String extensionBundleID) {
+    this.extensionBundleID = extensionBundleID;
   }
 
-  public String getExtensionsBundleVersion() {
-    return extensionsBundleVersion;
+  public String getExtensionBundleVersion() {
+    return extensionBundleVersion;
   }
 
-  public void setExtensionsBundleVersion(String extensionsBundleVersion) {
-    this.extensionsBundleVersion = extensionsBundleVersion;
+  public void setExtensionBundleVersion(String extensionBundleVersion) {
+    this.extensionBundleVersion = extensionBundleVersion;
   }
 
-  public Set<String>  getParserExtensionParserNames() {
-    if(this.parserExtensionParserNames != null) {
+  public Set<String> getParserExtensionParserNames() {
+    if (this.parserExtensionParserNames != null) {
       return ImmutableSet.copyOf(this.parserExtensionParserNames);
     }
     return ImmutableSet.of();
@@ -82,36 +98,37 @@ public class ParserExtensionConfig implements Serializable{
     this.parserExtensionParserNames = new HashSet(parserExtensionParserNames);
   }
 
-  public Map<String,SensorParserConfig> getDefaultParserConfigs() {
-    if(this.defaultParserConfigs != null){
+  public Map<String, SensorParserConfig> getDefaultParserConfigs() {
+    if (this.defaultParserConfigs != null) {
       return ImmutableMap.copyOf(this.defaultParserConfigs);
     }
     return ImmutableMap.of();
   }
 
-  public void setDefaultParserConfigs(Map<String,SensorParserConfig> defaultParserConfigs) {
+  public void setDefaultParserConfigs(Map<String, SensorParserConfig> defaultParserConfigs) {
     this.defaultParserConfigs = new HashMap<>(defaultParserConfigs);
   }
 
-  public Map<String,SensorEnrichmentConfig> getDefaultEnrichementConfigs() {
-    if(this.defaultEnrichementConfigs != null){
-      return ImmutableMap.copyOf(this.defaultEnrichementConfigs);
+  public Map<String, SensorEnrichmentConfig> getDefaultEnrichmentConfigs() {
+    if (this.defaultEnrichmentConfigs != null) {
+      return ImmutableMap.copyOf(this.defaultEnrichmentConfigs);
     }
     return ImmutableMap.of();
   }
 
-  public void setDefaultEnrichementConfigs(Map<String,SensorEnrichmentConfig> defaultEnrichementConfigs) {
-    this.defaultEnrichementConfigs = new HashMap<>(defaultEnrichementConfigs);
+  public void setDefaultEnrichmentConfigs(
+      Map<String, SensorEnrichmentConfig> defaultEnrichmentConfigs) {
+    this.defaultEnrichmentConfigs = new HashMap<>(defaultEnrichmentConfigs);
   }
 
-  public Map<String,Map<String, Object>> getDefaultIndexingConfigs() {
-    if(this.defaultIndexingConfigs != null){
+  public Map<String, Map<String, Object>> getDefaultIndexingConfigs() {
+    if (this.defaultIndexingConfigs != null) {
       return ImmutableMap.copyOf(this.defaultIndexingConfigs);
     }
     return ImmutableMap.of();
   }
 
-  public void setDefaultIndexingConfigs(Map<String,Map<String, Object>> defaultIndexingConfigs) {
+  public void setDefaultIndexingConfigs(Map<String, Map<String, Object>> defaultIndexingConfigs) {
     this.defaultIndexingConfigs = new HashMap<>(defaultIndexingConfigs);
   }
 
@@ -121,18 +138,20 @@ public class ParserExtensionConfig implements Serializable{
   }
 
   public Map<String, Map<String, Object>> getDefaultElasticSearchTemplates() {
-    if(this.defaultElasticSearchTemplates != null){
+    if (this.defaultElasticSearchTemplates != null) {
       return ImmutableMap.copyOf(this.defaultElasticSearchTemplates);
     }
     return ImmutableMap.of();
   }
 
-  public void setDefaultElasticSearchTemplates(Map<String, Map<String, Object>> defaultElasticSearchTemplates) {
+  public void setDefaultElasticSearchTemplates(
+      Map<String, Map<String, Object>> defaultElasticSearchTemplates) {
     this.defaultElasticSearchTemplates = new HashMap<>(defaultElasticSearchTemplates);
   }
 
   public static ParserExtensionConfig fromBytes(byte[] config) throws IOException {
-    ParserExtensionConfig ret = JSONUtils.INSTANCE.load(new String(config), ParserExtensionConfig.class);
+    ParserExtensionConfig ret = JSONUtils.INSTANCE
+        .load(new String(config), ParserExtensionConfig.class);
     return ret;
   }
 
@@ -143,50 +162,91 @@ public class ParserExtensionConfig implements Serializable{
   @Override
   public String toString() {
     return "SensorParserConfig{" +
-            "extensionAssemblyName='" + extensionAssemblyName + '\'' +
-            ", extensionBundleName='" + extensionBundleName + '\'' +
-            ", extensionsBundleID='" + extensionsBundleID + '\'' +
-            ", parserExtensionParserNames='" + String.join(",",this.parserExtensionParserNames) + '\'' +
-            '}';
+        "extensionIdentifier='" + extensionIdentifier + '\'' +
+        "extensionAssemblyName='" + extensionAssemblyName + '\'' +
+        ", extensionBundleName='" + extensionBundleName + '\'' +
+        ", extensionBundleID='" + extensionBundleID + '\'' +
+        ", parserExtensionParserNames='" + String.join(",", this.parserExtensionParserNames) + '\''
+        +
+        '}';
   }
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
 
     ParserExtensionConfig that = (ParserExtensionConfig) o;
 
-    if (getExtensionAssemblyName() != null ? !getExtensionAssemblyName().equals(that.getExtensionAssemblyName()) : that.getExtensionAssemblyName() != null)
+    if (getExtensionIdentifier() != null ? !getExtensionIdentifier()
+        .equals(that.getExtensionIdentifier()) : that.getExtensionIdentifier() != null) {
       return false;
-    if (getExtensionBundleName() != null ? !getExtensionBundleName().equals(that.getExtensionBundleName()) : that.getExtensionBundleName() != null)
+    }
+    if (getExtensionAssemblyName() != null ? !getExtensionAssemblyName()
+        .equals(that.getExtensionAssemblyName()) : that.getExtensionAssemblyName() != null) {
       return false;
-    if (getExtensionsBundleID() != null ? !getExtensionsBundleID().equals(that.getExtensionsBundleID()) : that.getExtensionsBundleID() != null)
+    }
+    if (getExtensionBundleName() != null ? !getExtensionBundleName()
+        .equals(that.getExtensionBundleName()) : that.getExtensionBundleName() != null) {
       return false;
-    if (getExtensionsBundleVersion() != null ? !getExtensionsBundleVersion().equals(that.getExtensionsBundleVersion()) : that.getExtensionsBundleVersion() != null)
+    }
+    if (getExtensionBundleID() != null ? !getExtensionBundleID().equals(that.getExtensionBundleID())
+        : that.getExtensionBundleID() != null) {
       return false;
-    if (getDefaultParserConfigs() != null ? !getDefaultParserConfigs().equals(that.getDefaultParserConfigs()) : that.getDefaultParserConfigs() != null)
+    }
+    if (getExtensionBundleVersion() != null ? !getExtensionBundleVersion()
+        .equals(that.getExtensionBundleVersion()) : that.getExtensionBundleVersion() != null) {
       return false;
-    if (getDefaultEnrichementConfigs() != null ? !getDefaultEnrichementConfigs().equals(that.getDefaultEnrichementConfigs()) : that.getDefaultEnrichementConfigs() != null)
+    }
+    if (getDefaultParserConfigs() != null ? !getDefaultParserConfigs()
+        .equals(that.getDefaultParserConfigs()) : that.getDefaultParserConfigs() != null) {
       return false;
-    if (getDefaultIndexingConfigs() != null ? !getDefaultIndexingConfigs().equals(that.getDefaultIndexingConfigs()) : that.getDefaultIndexingConfigs() != null)
+    }
+    if (getDefaultEnrichmentConfigs() != null ? !getDefaultEnrichmentConfigs()
+        .equals(that.getDefaultEnrichmentConfigs()) : that.getDefaultEnrichmentConfigs() != null) {
       return false;
-    if (getDefaultElasticSearchTemplates() != null ? !getDefaultElasticSearchTemplates().equals(that.getDefaultElasticSearchTemplates()) : that.getDefaultElasticSearchTemplates() != null)
+    }
+    if (getDefaultIndexingConfigs() != null ? !getDefaultIndexingConfigs()
+        .equals(that.getDefaultIndexingConfigs()) : that.getDefaultIndexingConfigs() != null) {
       return false;
-    return getParserExtensionParserNames() != null ? getParserExtensionParserNames().equals(that.getParserExtensionParserNames()) : that.getParserExtensionParserNames() == null;
+    }
+    if (getDefaultElasticSearchTemplates() != null ? !getDefaultElasticSearchTemplates()
+        .equals(that.getDefaultElasticSearchTemplates())
+        : that.getDefaultElasticSearchTemplates() != null) {
+      return false;
+    }
+    return getParserExtensionParserNames() != null ? getParserExtensionParserNames()
+        .equals(that.getParserExtensionParserNames())
+        : that.getParserExtensionParserNames() == null;
   }
 
   @Override
   public int hashCode() {
     int result = getExtensionAssemblyName() != null ? getExtensionAssemblyName().hashCode() : 0;
-    result = 31 * result + (getExtensionBundleName() != null ? getExtensionBundleName().hashCode() : 0);
-    result = 31 * result + (getExtensionsBundleID() != null ? getExtensionsBundleID().hashCode() : 0);
-    result = 31 * result + (getExtensionsBundleVersion() != null ? getExtensionsBundleVersion().hashCode() : 0);
-    result = 31 * result + (getDefaultParserConfigs() != null ? getDefaultParserConfigs().hashCode() : 0);
-    result = 31 * result + (getDefaultEnrichementConfigs() != null ? getDefaultEnrichementConfigs().hashCode() : 0);
-    result = 31 * result + (getDefaultIndexingConfigs() != null ? getDefaultIndexingConfigs().hashCode() : 0);
-    result = 31 * result + (getDefaultElasticSearchTemplates() != null ? getDefaultElasticSearchTemplates().hashCode() : 0);
-    result = 31 * result + (getParserExtensionParserNames() != null ? getParserExtensionParserNames().hashCode() : 0);
+    result =
+        31 * result + (getExtensionIdentifier() != null ? getExtensionIdentifier().hashCode() : 0);
+    result =
+        31 * result + (getExtensionBundleName() != null ? getExtensionBundleName().hashCode() : 0);
+    result = 31 * result + (getExtensionBundleID() != null ? getExtensionBundleID().hashCode() : 0);
+    result =
+        31 * result + (getExtensionBundleVersion() != null ? getExtensionBundleVersion().hashCode()
+            : 0);
+    result = 31 * result + (getDefaultParserConfigs() != null ? getDefaultParserConfigs().hashCode()
+        : 0);
+    result = 31 * result + (getDefaultEnrichmentConfigs() != null ? getDefaultEnrichmentConfigs()
+        .hashCode() : 0);
+    result =
+        31 * result + (getDefaultIndexingConfigs() != null ? getDefaultIndexingConfigs().hashCode()
+            : 0);
+    result = 31 * result + (getDefaultElasticSearchTemplates() != null
+        ? getDefaultElasticSearchTemplates().hashCode() : 0);
+    result =
+        31 * result + (getParserExtensionParserNames() != null ? getParserExtensionParserNames()
+            .hashCode() : 0);
     return result;
   }
 }

--- a/metron-platform/metron-integration-test/src/main/config/zookeeper/extensions/parsers/metron-test-parsers.json
+++ b/metron-platform/metron-integration-test/src/main/config/zookeeper/extensions/parsers/metron-test-parsers.json
@@ -1,7 +1,8 @@
 {
-  "extensionAssemblyName" : "test.fool-1.0.tar.gz",
+  "extensionIdentifier" : "test.fool-1.0",
+  "extensionAssemblyName" : "test.fool-1.0-assembly",
   "extensionBundleName" : "metron-test-parsers-1.0.bundle",
-  "extensionsBundleID" : "metron-test-parsers",
-  "extensionsBundleVersion" : "1.0.0",
+  "extensionBundleID" : "metron-test-parsers",
+  "extensionBundleVersion" : "1.0.0",
   "parserExtensionParserName" : [ "test2", "test" ]
 }

--- a/metron-platform/metron-management/src/test/java/org/apache/metron/management/ConfigurationFunctionsTest.java
+++ b/metron-platform/metron-management/src/test/java/org/apache/metron/management/ConfigurationFunctionsTest.java
@@ -125,10 +125,11 @@ public class ConfigurationFunctionsTest {
 
   /**
     {
-   "extensionAssemblyName" : "test.fool-1.0.tar.gz",
+   "extensionIdentifier" : "test.fool-1.0",
+   "extensionAssemblyName" : "test.fool-1.0-assembly",
    "extensionBundleName" : "metron-test-parsers-1.0.bundle",
-   "extensionsBundleID" : "metron-test-parsers",
-   "extensionsBundleVersion" : "1.0.0",
+   "extensionBundleID" : "metron-test-parsers",
+   "extensionBundleVersion" : "1.0.0",
    "parserExtensionParserName" : [ "test2", "test" ]
    }
    */


### PR DESCRIPTION
This a PR for some cleanup on the 1136 Feature Branch

- return a list from GET ( getAllParsers ) and not a map.
- fix names in Parser Extension Configs to be consistant with extension/extensions
- add a field just called identifier, to be used instead of assembly name
- differentiate identifier/assemblyname

## 
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron 
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
