### PR TITLE
METRON-1160 Blueprint configuration validation failed: Missing required properties

### DIFF
--- a/metron-deployment/roles/ambari_config/vars/small_cluster.yml
+++ b/metron-deployment/roles/ambari_config/vars/small_cluster.yml
@@ -100,6 +100,7 @@ required_configurations:
       storm_rest_addr: "http://{{ groups.ambari_slave[1] }}:8744"
       es_hosts: "{{ groups.web[0] }},{{ groups.search | join(',') }}"
       zeppelin_server_url: "{{ groups.zeppelin[0] }}"
+  - metron-rest-env:
       metron_jdbc_driver: "org.h2.Driver"
       metron_jdbc_url: "jdbc:h2:file:~/metrondb"
       metron_jdbc_username: "root"


### PR DESCRIPTION
Deployment to AWS using `metron-deployment/amazon-ec2` fails with the following error message. This PR addresses the problem.

```
TASK [ambari_config : Deploy cluster with Ambari; 
http://ec2-XX-XX-XXX-XXX.compute-1.amazonaws.com:8080] ***
fatal: [ec2-XX-XX-XXX-XXX.compute-1.amazonaws.com]: FAILED! => {"changed": false, "failed": true, 
"msg": "Ambari client exception occurred: Could not create blueprint: request code 400,  
request message {\n  \"status\" : 400,\n  \"message\" : \"Blueprint configuration 
validation failed: Missing required properties.  Specify a value for these properties in the 
blueprint configuration. {metron={metron-rest-env=[metron_jdbc_driver, 
metron_jdbc_username, metron_jdbc_url]}}\"\n}"}
```

I tested by performing an AWS deployment.