### PR TITLE
METRON-1162 Apply Live Messages to the Profile Debugger

### DIFF
--- a/metron-analytics/metron-profiler-client/src/main/java/org/apache/metron/profiler/client/stellar/ProfilerFunctions.java
+++ b/metron-analytics/metron-profiler-client/src/main/java/org/apache/metron/profiler/client/stellar/ProfilerFunctions.java
@@ -20,6 +20,7 @@
 
 package org.apache.metron.profiler.client.stellar;
 
+import org.apache.commons.collections4.ListUtils;
 import org.apache.metron.common.configuration.profiler.ProfilerConfig;
 import org.apache.metron.common.utils.JSONUtils;
 import org.apache.metron.profiler.ProfileMeasurement;
@@ -41,6 +42,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -109,7 +111,7 @@ public class ProfilerFunctions {
           name="APPLY",
           description="Apply a message to a local profile runner.",
           params={
-                  "message(s)", "The message to apply.  A JSON list can be used to apply multiple messages.",
+                  "message(s)", "The message to apply; a JSON string or list of JSON strings.",
                   "profiler", "A local profile runner returned by PROFILER_INIT."
           },
           returns="The local profile runner."
@@ -131,50 +133,99 @@ public class ProfilerFunctions {
     @Override
     public Object apply(List<Object> args, Context context) throws ParseException {
 
-      // user must provide the message as a string
-      String arg0 = Util.getArg(0, String.class, args);
-      if(arg0 == null) {
-        throw new IllegalArgumentException(format("expected string, found null"));
-      }
-
-      // there could be one or more messages
-      List<JSONObject> messages = new ArrayList<>();
-      try {
-        Object parsedArg0 = parser.parse(arg0);
-        if(parsedArg0 instanceof JSONObject) {
-          // if there is only one message
-          messages.add((JSONObject) parsedArg0);
-
-        } else if(parsedArg0 instanceof JSONArray) {
-          // there are multiple messages
-          JSONArray jsonArray = (JSONArray) parsedArg0;
-          for(Object json: jsonArray) {
-            if(json instanceof JSONObject) {
-              messages.add((JSONObject) json);
-
-            } else {
-              throw new IllegalArgumentException(format("invalid message: found '%s', expected JSONObject",
-                              ClassUtils.getShortClassName(json, "null")));
-            }
-          }
-        }
-
-      } catch(org.json.simple.parser.ParseException e) {
-        throw new IllegalArgumentException("invalid message", e);
-      }
+      // the use can pass in one or more messages in a few different forms
+      Object arg0 = Util.getArg(0, Object.class, args);
+      List<JSONObject> messages = getMessages(arg0);
 
       // user must provide the stand alone profiler
       StandAloneProfiler profiler = Util.getArg(1, StandAloneProfiler.class, args);
       try {
-        for(JSONObject message : messages) {
+        for (JSONObject message : messages) {
           profiler.apply(message);
         }
 
-      } catch(ExecutionException e) {
+      } catch (ExecutionException e) {
         throw new IllegalArgumentException(format("Failed to apply message; error=%s", e.getMessage()), e);
       }
 
       return profiler;
+    }
+
+    /**
+     * Gets a message or messages from the function arguments.
+     *
+     * @param arg The function argument containing the message(s).
+     * @return A list of messages
+     */
+    private List<JSONObject> getMessages(Object arg) {
+      List<JSONObject> messages;
+
+      if (arg instanceof String) {
+        messages = getMessagesFromString((String) arg);
+
+      } else if (arg instanceof List) {
+        messages = getMessagesFromList((List<String>) arg);
+
+      } else if (arg instanceof JSONObject) {
+        messages = Collections.singletonList((JSONObject) arg);
+
+      } else {
+        throw new IllegalArgumentException(format("invalid message: found '%s', expected String, List, or JSONObject",
+                ClassUtils.getShortClassName(arg, "null")));
+      }
+
+      return messages;
+    }
+
+    /**
+     * Gets a message or messages from a List
+     *
+     * @param listOfStrings The function argument is a List of Strings.
+     * @return A list of messages.
+     */
+    private List<JSONObject> getMessagesFromList(List<String> listOfStrings) {
+      List<JSONObject> messages = new ArrayList<>();
+
+      // the user pass in a list of strings
+      for (String str : listOfStrings) {
+        messages.addAll(getMessagesFromString(str));
+      }
+
+      return messages;
+    }
+
+    /**
+     * Gets a message or messages from a String argument.
+     *
+     * @param arg0 The function argument is just a List.
+     * @return A list of messages.
+     */
+    private List<JSONObject> getMessagesFromString(String arg0) {
+      List<JSONObject> messages = new ArrayList<>();
+
+      try {
+        Object parsedArg0 = parser.parse(arg0);
+        if (parsedArg0 instanceof JSONObject) {
+          // if the string only contains one message
+          messages.add((JSONObject) parsedArg0);
+
+        } else if (parsedArg0 instanceof JSONArray) {
+          // if the string contains multiple messages
+          JSONArray jsonArray = (JSONArray) parsedArg0;
+          for (Object item : jsonArray) {
+            messages.addAll(getMessages(item));
+          }
+
+        } else {
+          throw new IllegalArgumentException(format("invalid message: found '%s', expected JSONObject or JSONArray",
+                  ClassUtils.getShortClassName(parsedArg0, "null")));
+        }
+
+      } catch (org.json.simple.parser.ParseException e) {
+        throw new IllegalArgumentException(format("invalid message: '%s'", e.getMessage()), e);
+      }
+
+      return messages;
     }
   }
 

--- a/metron-analytics/metron-profiler-client/src/main/java/org/apache/metron/profiler/client/stellar/ProfilerFunctions.java
+++ b/metron-analytics/metron-profiler-client/src/main/java/org/apache/metron/profiler/client/stellar/ProfilerFunctions.java
@@ -163,8 +163,8 @@ public class ProfilerFunctions {
       if (arg instanceof String) {
         messages = getMessagesFromString((String) arg);
 
-      } else if (arg instanceof List) {
-        messages = getMessagesFromList((List<String>) arg);
+      } else if (arg instanceof Iterable) {
+        messages = getMessagesFromIterable((Iterable<String>) arg);
 
       } else if (arg instanceof JSONObject) {
         messages = Collections.singletonList((JSONObject) arg);
@@ -180,14 +180,14 @@ public class ProfilerFunctions {
     /**
      * Gets a message or messages from a List
      *
-     * @param listOfStrings The function argument is a List of Strings.
+     * @param strings The function argument that is a bunch of strings.
      * @return A list of messages.
      */
-    private List<JSONObject> getMessagesFromList(List<String> listOfStrings) {
+    private List<JSONObject> getMessagesFromIterable(Iterable<String> strings) {
       List<JSONObject> messages = new ArrayList<>();
 
       // the user pass in a list of strings
-      for (String str : listOfStrings) {
+      for (String str : strings) {
         messages.addAll(getMessagesFromString(str));
       }
 

--- a/metron-deployment/roles/ambari_config/vars/small_cluster.yml
+++ b/metron-deployment/roles/ambari_config/vars/small_cluster.yml
@@ -100,6 +100,7 @@ required_configurations:
       storm_rest_addr: "http://{{ groups.ambari_slave[1] }}:8744"
       es_hosts: "{{ groups.web[0] }},{{ groups.search | join(',') }}"
       zeppelin_server_url: "{{ groups.zeppelin[0] }}"
+  - metron-rest-env:
       metron_jdbc_driver: "org.h2.Driver"
       metron_jdbc_url: "jdbc:h2:file:~/metrondb"
       metron_jdbc_username: "root"

--- a/metron-deployment/roles/ambari_config/vars/small_cluster.yml
+++ b/metron-deployment/roles/ambari_config/vars/small_cluster.yml
@@ -100,7 +100,6 @@ required_configurations:
       storm_rest_addr: "http://{{ groups.ambari_slave[1] }}:8744"
       es_hosts: "{{ groups.web[0] }},{{ groups.search | join(',') }}"
       zeppelin_server_url: "{{ groups.zeppelin[0] }}"
-  - metron-rest-env:
       metron_jdbc_driver: "org.h2.Driver"
       metron_jdbc_url: "jdbc:h2:file:~/metrondb"
       metron_jdbc_username: "root"


### PR DESCRIPTION
I want to be able to use `PROFILER_APPLY` with live messages from a Metron cluster. For example, I would like to be able to grab 10 messages from my production Metron and then apply them in my debugger. This would be tremendously helpful for iterating between the debugger and a live cluster when troubleshooting.

```
p := PROFILER_INIT(conf)
msgs := KAFKA_GET("indexing", 10)
PROFILER_APPLY(msgs, p)
PROFILER_FLUSH(p)
```

The `PROFILER_APPLY` function does not currently accept a list of messages. It accepts a String that is a JSON list, but not a Stellar list. For `PROFILER_APPLY` to play happy with `KAFKA_GET` (and other potential uses) it needs to accept a List.

This PR makes `PROFILER_APPLY` rather flexible in the types of arguments that it accepts.
 * String containing one JSON message
 * String containing an array of JSON messages
 * List containing a JSONObject
 * List containing a String of one JSON message
 * List containing a String that is an array of JSON messages

### Testing

This can be tested by launching the REPL and running the following.

Create a Profiler definition.
```
[Stellar]>>> conf := SHELL_EDIT()
[Stellar]>>> conf
{
  "profiles": [
    {
      "profile": "hello-world",
      "onlyif":  "exists(ip_src_addr)",
      "foreach": "ip_src_addr",
      "init":    { "count": "0" },
      "update":  { "count": "count + 1" },
      "result":  "count"
    }
  ]
}
```

Create a sample message.
```
[Stellar]>>> msg := SHELL_EDIT()
[Stellar]>>> msg
{
  "ip_src_addr": "10.0.0.1",
  "protocol": "HTTPS",
  "length": "10",
  "bytes_in": "234"
}
```

Initialize the Profiler.
```
[Stellar]>>> p := PROFILER_INIT(conf)
[Stellar]>>> p
Profiler{1 profile(s), 0 messages(s), 0 route(s)}
```

Apply 3 messages at a time by passing in a list.
```
[Stellar]>>> PROFILER_APPLY([msg, msg, msg], p)
Profiler{1 profile(s), 3 messages(s), 3 route(s)}
```