### PR TITLE
METRON-1153 HDFS HdfsWriter never recovers from exceptions

### DIFF
--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/SourceHandler.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/SourceHandler.java
@@ -75,7 +75,8 @@ public class SourceHandler {
       try {
         out.write(bytes);
       } catch (IOException writeException) {
-        // Hope it's a transient issue, rotate our output file, and carry on.
+        // Hope it's a transient issue, rotate our output file, and try again.
+        // If it's not transient, the second attempt's exception will bubble up.
         LOG.warn("IOException while writing output. Attempting to rotate file and continue",
             writeException);
         rotateOutputFile();


### PR DESCRIPTION
## Contributor Comments
Added a try-catch around the actual write that will rotate the file and try again if there's a stream closed underneath it.  Added two unit tests, one that ensures things flow through nicely to a single file with a double write and one that ensures that things flow to two files if the channel is closed underneath for whatever reason (done by just calling `closeOutputFile()` when outside of the normal flow).

It's not a perfect solution, but it should alleviate any transient pain and let us know if the problem is deeper if it keeps showing up.

Also added a missing set to a field from the constructor which probably wasn't helping things since I happened to notice it.  It's a one line change, so it seemed excessive to create a separate PR.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && build_utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.

