### PR TITLE
METRON-1180:  Make Stellar Shell accept zookeeper quorum as a CSV list and not require a port

### DIFF
--- a/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/common/shell/StellarShellOptionsValidator.java
+++ b/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/common/shell/StellarShellOptionsValidator.java
@@ -26,6 +26,8 @@ import java.net.UnknownHostException;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import com.google.common.base.Splitter;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.InetAddressValidator;
@@ -73,30 +75,32 @@ public class StellarShellOptionsValidator {
   /**
    * Zookeeper argument should be in the form [HOST|IP]:PORT.
    *
-   * @param z the zookeeper url fragment
+   * @param zMulti the zookeeper url fragment
    */
-  private static void validateZookeeperOption(String z) throws IllegalArgumentException {
+  private static void validateZookeeperOption(String zMulti) throws IllegalArgumentException {
+    for(String z : Splitter.on(",").split(zMulti)) {
+      Matcher matcher = validPortPattern.matcher(z);
+      boolean hasPort = z.contains(":");
+      if (hasPort && !matcher.matches()) {
+        throw new IllegalArgumentException(String.format("Zookeeper option must have valid port: %s", z));
+      }
 
-    Matcher matcher = validPortPattern.matcher(z);
-    if (!matcher.matches()) {
-      throw new IllegalArgumentException(String.format("Zookeeper option must have port: %s", z));
-    }
+      if (hasPort && matcher.groupCount() != 2) {
+        throw new IllegalArgumentException(
+                String.format("Zookeeper Option must be in the form of [HOST|IP]:PORT  %s", z));
+      }
+      String name = hasPort?matcher.group(1):z;
+      Integer port = hasPort?Integer.parseInt(matcher.group(2)):null;
 
-    if (matcher.groupCount() != 2) {
-      throw new IllegalArgumentException(
-          String.format("Zookeeper Option must be in the form of [HOST|IP]:PORT  %s", z));
-    }
-    String name = matcher.group(1);
-    Integer port = Integer.parseInt(matcher.group(2));
+      if (!hostnameValidator.test(name) && !inetAddressValidator.isValid(name)) {
+        throw new IllegalArgumentException(
+                String.format("Zookeeper Option %s is not a valid host name or ip address  %s", name, z));
+      }
 
-    if (!hostnameValidator.test(name) && !inetAddressValidator.isValid(name)) {
-      throw new IllegalArgumentException(
-          String.format("Zookeeper Option %s is not a valid host name or ip address  %s", name, z));
-    }
-
-    if(port == 0 || port > 65535){
-      throw new IllegalArgumentException(
-          String.format("Zookeeper Option %s port is not valid",z));
+      if (hasPort && (port == 0 || port > 65535)) {
+        throw new IllegalArgumentException(
+                String.format("Zookeeper Option %s port is not valid", z));
+      }
     }
   }
 

--- a/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/common/shell/StellarShellOptionsValidatorTest.java
+++ b/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/common/shell/StellarShellOptionsValidatorTest.java
@@ -37,9 +37,10 @@ public class StellarShellOptionsValidatorTest {
   @Test
   public void validateOptions() throws Exception {
     String[] validZHostArg = new String[]{"-z", "localhost:8888"};
+    String[] validZHostArgNoPort = new String[]{"-z", "localhost"};
+    String[] validZIPArgNoPort = new String[]{"-z", "10.10.10.3"};
+    String[] validZHostArgList = new String[]{"-z", "localhost:8888,localhost:2181,localhost"};
     String[] validZIPArg = new String[]{"-z", "10.10.10.3:9999"};
-    String[] invalidZNoPortArg = new String[]{"-z", "youtube.com"};
-    String[] invalidZIPNoPortArg = new String[]{"-z", "10.10.10.3"};
     String[] invalidZNameArg = new String[]{"-z", "!!!@!!@!:8882"};
     String[] invalidZIPArg = new String[]{"-z", "11111.22222.10.3:3332"};
     String[] invalidZMissingNameArg = new String[]{"-z", ":8882"};
@@ -88,27 +89,18 @@ public class StellarShellOptionsValidatorTest {
     commandLine = parser.parse(options, validPFileArg);
     StellarShellOptionsValidator.validateOptions(commandLine);
 
+    commandLine = parser.parse(options, validZHostArgNoPort);
+    StellarShellOptionsValidator.validateOptions(commandLine);
+
+    commandLine = parser.parse(options, validZHostArgList);
+    StellarShellOptionsValidator.validateOptions(commandLine);
+
+    commandLine = parser.parse(options, validZIPArgNoPort);
+    StellarShellOptionsValidator.validateOptions(commandLine);
     // these should not
 
     boolean thrown = false;
 
-    try {
-      commandLine = parser.parse(options, invalidZNoPortArg);
-      StellarShellOptionsValidator.validateOptions(commandLine);
-    } catch (IllegalArgumentException e) {
-      thrown = true;
-    }
-    Assert.assertTrue("Did not catch failure for not providing port with host name ", thrown);
-    thrown = false;
-
-    try {
-      commandLine = parser.parse(options, invalidZIPNoPortArg);
-      StellarShellOptionsValidator.validateOptions(commandLine);
-    } catch (IllegalArgumentException e) {
-      thrown = true;
-    }
-    Assert.assertTrue("Did not catch failure for not providing port with ip address ", thrown);
-    thrown = false;
 
     try {
       commandLine = parser.parse(options, invalidZNameArg);


### PR DESCRIPTION
## Contributor Comments
ZK Quora do not require a port (it defaults to 2181) and it may be a comma separated list.  Allowing the REPL to validate the port only if provided and allowing multiple hosts.


## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && build_utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.

