### PR TITLE
METRON-1185: Stellar REPL does not work on a kerberized cluster when calling functions interacting with HBase

### DIFF
--- a/metron-platform/metron-common/src/main/scripts/stellar
+++ b/metron-platform/metron-common/src/main/scripts/stellar
@@ -32,4 +32,5 @@ export HBASE_CONFIGS=$(hbase classpath)
 export METRON_VERSION=${project.version}
 export METRON_HOME=/usr/metron/$METRON_VERSION
 export STELLAR_LIB=$(find $METRON_HOME/lib/ -name metron-enrichment*.jar)
-java $JVMFLAGS -cp "$HBASE_CONFIGS:${CONTRIB:-$METRON_HOME/contrib/*}:$STELLAR_LIB" org.apache.metron.stellar.common.shell.StellarShell "$@"
+export MANAGEMENT_LIB=$(find $METRON_HOME/lib/ -name metron-management*.jar)
+java $JVMFLAGS -cp "$HBASE_CONFIGS:${CONTRIB:-$METRON_HOME/contrib/*}:$STELLAR_LIB:$MANAGEMENT_LIB" org.apache.metron.stellar.common.shell.StellarShell "$@"

--- a/metron-platform/metron-common/src/main/scripts/stellar
+++ b/metron-platform/metron-common/src/main/scripts/stellar
@@ -31,6 +31,6 @@ fi
 export HBASE_CONFIGS=$(hbase classpath)
 export METRON_VERSION=${project.version}
 export METRON_HOME=/usr/metron/$METRON_VERSION
-export STELLAR_LIB=$(find $METRON_HOME/lib/ -name metron-enrichment*.jar)
+export STELLAR_LIB=$(find $METRON_HOME/lib/ -name metron-parsers*.jar)
 export MANAGEMENT_LIB=$(find $METRON_HOME/lib/ -name metron-management*.jar)
 java $JVMFLAGS -cp "$HBASE_CONFIGS:${CONTRIB:-$METRON_HOME/contrib/*}:$STELLAR_LIB:$MANAGEMENT_LIB" org.apache.metron.stellar.common.shell.StellarShell "$@"

--- a/metron-platform/metron-common/src/main/scripts/stellar
+++ b/metron-platform/metron-common/src/main/scripts/stellar
@@ -28,7 +28,8 @@ elif [ -e /usr/lib/bigtop-utils/bigtop-detect-javahome ]; then
   . /usr/lib/bigtop-utils/bigtop-detect-javahome
 fi
 
-export HBASE_CONFIGS=/etc/hbase/conf
+export HBASE_CONFIGS=$(hbase classpath)
 export METRON_VERSION=${project.version}
 export METRON_HOME=/usr/metron/$METRON_VERSION
-java $JVMFLAGS -cp "$HBASE_CONFIGS:$METRON_HOME/lib/*" org.apache.metron.stellar.common.shell.StellarShell "$@"
+export STELLAR_LIB=$(find $METRON_HOME/lib/ -name metron-enrichment*.jar)
+java $JVMFLAGS -cp "$HBASE_CONFIGS:${CONTRIB_LIB:-$METRON_HOME/contrib-lib}:$STELLAR_LIB" org.apache.metron.stellar.common.shell.StellarShell "$@"

--- a/metron-platform/metron-common/src/main/scripts/stellar
+++ b/metron-platform/metron-common/src/main/scripts/stellar
@@ -32,4 +32,4 @@ export HBASE_CONFIGS=$(hbase classpath)
 export METRON_VERSION=${project.version}
 export METRON_HOME=/usr/metron/$METRON_VERSION
 export STELLAR_LIB=$(find $METRON_HOME/lib/ -name metron-enrichment*.jar)
-java $JVMFLAGS -cp "$HBASE_CONFIGS:${CONTRIB_LIB:-$METRON_HOME/contrib-lib}:$STELLAR_LIB" org.apache.metron.stellar.common.shell.StellarShell "$@"
+java $JVMFLAGS -cp "$HBASE_CONFIGS:${CONTRIB:-$METRON_HOME/contrib/*}:$STELLAR_LIB" org.apache.metron.stellar.common.shell.StellarShell "$@"

--- a/metron-stellar/stellar-common/README.md
+++ b/metron-stellar/stellar-common/README.md
@@ -1121,6 +1121,12 @@ Shell-like operations are supported such as
 
 Note: Stellar classpath configuration from the global config is honored here if the REPL knows about zookeeper.
 
+### Environment Variables
+When starting the REPL via `$METRON_HOME/bin/stellar` you can specify
+certain environment variables to customize the experience:
+* `JVMFLAGS` - Arbitrary JVM flags to pass to the `java` command when starting the REPL.
+* `CONTRIB` - Directory where jars with Stellar functions can be placed.  The default is `$METRON_HOME/contrib`.
+
 ### Getting Started
 
 To run the Stellar Shell from within a deployed Metron cluster, run the following command on the host where Metron is installed.

--- a/metron-stellar/stellar-common/src/main/scripts/stellar
+++ b/metron-stellar/stellar-common/src/main/scripts/stellar
@@ -28,7 +28,8 @@ elif [ -e /usr/lib/bigtop-utils/bigtop-detect-javahome ]; then
   . /usr/lib/bigtop-utils/bigtop-detect-javahome
 fi
 
-export HBASE_CONFIGS=/etc/hbase/conf
+export HBASE_CONFIGS=$(hbase classpath)
 export METRON_VERSION=${project.version}
 export METRON_HOME=/usr/metron/$METRON_VERSION
-java $JVMFLAGS -cp "$HBASE_CONFIGS:$METRON_HOME/lib/*" org.apache.metron.stellar.stellar.shell.StellarShell "$@"
+export STELLAR_LIB=$(find $METRON_HOME/lib/ -name metron-enrichment*.jar)
+java $JVMFLAGS -cp "$HBASE_CONFIGS:${CONTRIB_LIB:-$METRON_HOME/contrib-lib}:$STELLAR_LIB" org.apache.metron.stellar.common.shell.StellarShell "$@"

--- a/metron-stellar/stellar-common/src/main/scripts/stellar
+++ b/metron-stellar/stellar-common/src/main/scripts/stellar
@@ -32,4 +32,5 @@ export HBASE_CONFIGS=$(hbase classpath)
 export METRON_VERSION=${project.version}
 export METRON_HOME=/usr/metron/$METRON_VERSION
 export STELLAR_LIB=$(find $METRON_HOME/lib/ -name metron-enrichment*.jar)
-java $JVMFLAGS -cp "$HBASE_CONFIGS:${CONTRIB:-$METRON_HOME/contrib}:$STELLAR_LIB" org.apache.metron.stellar.common.shell.StellarShell "$@"
+export MANAGEMENT_LIB=$(find $METRON_HOME/lib/ -name metron-management*.jar)
+java $JVMFLAGS -cp "$HBASE_CONFIGS:${CONTRIB:-$METRON_HOME/contrib}:$STELLAR_LIB:$MANAGEMENT_LIB" org.apache.metron.stellar.common.shell.StellarShell "$@"

--- a/metron-stellar/stellar-common/src/main/scripts/stellar
+++ b/metron-stellar/stellar-common/src/main/scripts/stellar
@@ -31,6 +31,6 @@ fi
 export HBASE_CONFIGS=$(hbase classpath)
 export METRON_VERSION=${project.version}
 export METRON_HOME=/usr/metron/$METRON_VERSION
-export STELLAR_LIB=$(find $METRON_HOME/lib/ -name metron-enrichment*.jar)
+export STELLAR_LIB=$(find $METRON_HOME/lib/ -name metron-parsers*.jar)
 export MANAGEMENT_LIB=$(find $METRON_HOME/lib/ -name metron-management*.jar)
 java $JVMFLAGS -cp "$HBASE_CONFIGS:${CONTRIB:-$METRON_HOME/contrib}:$STELLAR_LIB:$MANAGEMENT_LIB" org.apache.metron.stellar.common.shell.StellarShell "$@"

--- a/metron-stellar/stellar-common/src/main/scripts/stellar
+++ b/metron-stellar/stellar-common/src/main/scripts/stellar
@@ -32,4 +32,4 @@ export HBASE_CONFIGS=$(hbase classpath)
 export METRON_VERSION=${project.version}
 export METRON_HOME=/usr/metron/$METRON_VERSION
 export STELLAR_LIB=$(find $METRON_HOME/lib/ -name metron-enrichment*.jar)
-java $JVMFLAGS -cp "$HBASE_CONFIGS:${CONTRIB_LIB:-$METRON_HOME/contrib-lib}:$STELLAR_LIB" org.apache.metron.stellar.common.shell.StellarShell "$@"
+java $JVMFLAGS -cp "$HBASE_CONFIGS:${CONTRIB:-$METRON_HOME/contrib}:$STELLAR_LIB" org.apache.metron.stellar.common.shell.StellarShell "$@"


### PR DESCRIPTION
## Contributor Comments

Because we put all the jars on the classpath from `$METRON_HOME/lib` via a glob, if we get the wrong order, we get classpath issues around Stopwatch (i.e. more recent guava may sneak onto the classpath first). This is non-deterministic and can cause issues randomly. Instead of a glob, we should choose one of the uber jars with all the metron Stellar functions baked in and allow users to provide any extra directories we should include via an env variable. Also, we are not pulling the full hbase classpath, so in a kerberized cluster we do not get all of the configs on the classpath, so we can't find always find tgts.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && build_utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.

