### PR TITLE
METRON-1187 Indexing/Profiler Kafka ACL Groups Not Setup Correctly

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/enrichment_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/enrichment_commands.py
@@ -53,14 +53,14 @@ class EnrichmentCommands:
         return self.__kafka_acl_configured
 
     def set_kafka_configured(self):
-        Logger.info("Setting Kafka Configured to True")
+        Logger.info("Setting Kafka Configured to True for enrichment")
         File(self.__params.enrichment_kafka_configured_flag_file,
              content="",
              owner=self.__params.metron_user,
              mode=0755)
 
     def set_kafka_acl_configured(self):
-        Logger.info("Setting Kafka ACL Configured to True")
+        Logger.info("Setting Kafka ACL Configured to True for enrichment")
         File(self.__params.enrichment_kafka_acl_configured_flag_file,
              content="",
              owner=self.__params.metron_user,
@@ -73,14 +73,14 @@ class EnrichmentCommands:
         return self.__hbase_acl_configured
 
     def set_hbase_configured(self):
-        Logger.info("Setting HBase Configured to True")
+        Logger.info("Setting HBase Configured to True for enrichment")
         File(self.__params.enrichment_hbase_configured_flag_file,
              content="",
              owner=self.__params.metron_user,
              mode=0755)
 
     def set_hbase_acl_configured(self):
-        Logger.info("Setting HBase ACL Configured to True")
+        Logger.info("Setting HBase ACL Configured to True for enrichment")
         File(self.__params.enrichment_hbase_acl_configured_flag_file,
              content="",
              owner=self.__params.metron_user,
@@ -90,7 +90,7 @@ class EnrichmentCommands:
         return self.__geo_configured
 
     def set_geo_configured(self):
-        Logger.info("Setting GEO Configured to True")
+        Logger.info("Setting GEO Configured to True for enrichment")
         File(self.__params.enrichment_geo_configured_flag_file,
              content="",
              owner=self.__params.metron_user,
@@ -144,10 +144,10 @@ class EnrichmentCommands:
                                         -s {1} \
                                         -z {2}"""
             Logger.info('Starting ' + self.__enrichment_topology)
-            Execute(start_cmd_template.format(self.__params.metron_home,
-                                              self.__enrichment_topology,
-                                              self.__params.zookeeper_quorum),
-                    user=self.__params.metron_user)
+            start_cmd = start_cmd_template.format(self.__params.metron_home,
+                                                  self.__enrichment_topology,
+                                                  self.__params.zookeeper_quorum)
+            Execute(start_cmd, user=self.__params.metron_user, tries=3, try_sleep=5, logoutput=True)
         else:
             Logger.info('Enrichment topology already running')
 
@@ -158,7 +158,7 @@ class EnrichmentCommands:
 
         if self.is_topology_active(env):
             stop_cmd = 'storm kill ' + self.__enrichment_topology
-            Execute(stop_cmd, user=self.__params.metron_user)
+            Execute(stop_cmd, user=self.__params.metron_user, tries=3, try_sleep=5, logoutput=True)
         else:
             Logger.info("Enrichment topology already stopped")
 

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/enrichment_master.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/enrichment_master.py
@@ -98,7 +98,6 @@ class Enrichment(Script):
                                   status_params.metron_principal_name,
                                   execute_user=status_params.metron_user)
 
-
         if not commands.is_topology_active(env):
             raise ComponentIsNotRunning()
 

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/indexing_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/indexing_commands.py
@@ -169,12 +169,13 @@ class IndexingCommands:
                                       self.__params.metron_keytab_path,
                                       self.__params.metron_principal_name,
                                       execute_user=self.__params.metron_user)
+
             start_cmd_template = """{0}/bin/start_elasticsearch_topology.sh \
-                                    -s {1} \
-                                    -z {2}"""
+                                        -s {1} \
+                                        -z {2}"""
             start_cmd = start_cmd_template.format(self.__params.metron_home,
                                                   self.__indexing_topology,
-                                                  self.__params.zookeeper_quorum),
+                                                  self.__params.zookeeper_quorum)
             Execute(start_cmd, user=self.__params.metron_user, tries=3, try_sleep=5, logoutput=True)
 
         else:

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/indexing_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/indexing_commands.py
@@ -46,6 +46,7 @@ class IndexingCommands:
         self.__acl_configured = os.path.isfile(self.__params.indexing_acl_configured_flag_file)
         self.__hbase_configured = os.path.isfile(self.__params.indexing_hbase_configured_flag_file)
         self.__hbase_acl_configured = os.path.isfile(self.__params.indexing_hbase_acl_configured_flag_file)
+        self.__hdfs_perm_configured = os.path.isfile(self.__params.indexing_hdfs_perm_configured_flag_file)
 
     def is_configured(self):
         return self.__configured
@@ -69,21 +70,21 @@ class IndexingCommands:
         return self.__hbase_acl_configured
 
     def set_hbase_configured(self):
-        Logger.info("Setting HBase Configured to True")
+        Logger.info("Setting HBase Configured to True for indexing")
         File(self.__params.indexing_hbase_configured_flag_file,
              content="",
              owner=self.__params.metron_user,
              mode=0755)
 
     def set_hbase_acl_configured(self):
-        Logger.info("Setting HBase ACL Configured to True")
+        Logger.info("Setting HBase ACL Configured to True for indexing")
         File(self.__params.indexing_hbase_acl_configured_flag_file,
              content="",
              owner=self.__params.metron_user,
              mode=0755)
 
     def create_hbase_tables(self):
-        Logger.info("Creating HBase Tables")
+        Logger.info("Creating HBase Tables for indexing")
         if self.__params.security_enabled:
             metron_security.kinit(self.__params.kinit_path_local,
                   self.__params.hbase_keytab_path,
@@ -99,11 +100,11 @@ class IndexingCommands:
                 user=self.__params.hbase_user
                 )
 
-        Logger.info("Done creating HBase Tables")
+        Logger.info("Done creating HBase Tables for indexing")
         self.set_hbase_configured()
 
     def set_hbase_acls(self):
-        Logger.info("Setting HBase ACLs")
+        Logger.info("Setting HBase ACLs for indexing")
         if self.__params.security_enabled:
             metron_security.kinit(self.__params.kinit_path_local,
                   self.__params.hbase_keytab_path,
@@ -119,7 +120,7 @@ class IndexingCommands:
                 user=self.__params.hbase_user
                 )
 
-        Logger.info("Done setting HBase ACLs")
+        Logger.info("Done setting HBase ACLs for indexing")
         self.set_hbase_acl_configured()
 
     def set_acl_configured(self):
@@ -139,7 +140,7 @@ class IndexingCommands:
         metron_service.init_kafka_topics(self.__params, [self.__indexing_topic])
 
     def init_kafka_acls(self):
-        Logger.info('Creating Kafka ACLs')
+        Logger.info('Creating Kafka ACLs for indexing')
         # Indexed topic names matches the group
         metron_service.init_kafka_acls(self.__params, [self.__indexing_topic], [self.__indexing_topic])
 
@@ -171,10 +172,10 @@ class IndexingCommands:
             start_cmd_template = """{0}/bin/start_elasticsearch_topology.sh \
                                     -s {1} \
                                     -z {2}"""
-            Execute(start_cmd_template.format(self.__params.metron_home,
-                                              self.__indexing_topology,
-                                              self.__params.zookeeper_quorum),
-                    user=self.__params.metron_user)
+            start_cmd = start_cmd_template.format(self.__params.metron_home,
+                                                  self.__indexing_topology,
+                                                  self.__params.zookeeper_quorum),
+            Execute(start_cmd, user=self.__params.metron_user, tries=3, try_sleep=5, logoutput=True)
 
         else:
             Logger.info('Indexing topology already running')
@@ -191,7 +192,7 @@ class IndexingCommands:
                                       self.__params.metron_principal_name,
                                       execute_user=self.__params.metron_user)
             stop_cmd = 'storm kill ' + self.__indexing_topology
-            Execute(stop_cmd, user=self.__params.metron_user)
+            Execute(stop_cmd, user=self.__params.metron_user, tries=3, try_sleep=5, logoutput=True)
 
         else:
             Logger.info("Indexing topology already stopped")

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/metron_service.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/metron_service.py
@@ -122,7 +122,7 @@ def init_kafka_topics(params, topics):
                                     num_partitions,
                                     replication_factor,
                                     retention_bytes),
-            user=params.kafka_user)
+            user=params.kafka_user, tries=3, try_sleep=5, logoutput=True)
   Logger.info("Done creating Kafka topics")
 
 
@@ -142,7 +142,7 @@ def init_kafka_acls(params, topics, groups):
                                 params.zookeeper_quorum,
                                 params.metron_user,
                                 topic),
-            user=params.kafka_user)
+            user=params.kafka_user, tries=3, try_sleep=5, logoutput=True)
 
   acl_template = """{0}/kafka-acls.sh \
                                   --authorizer kafka.security.auth.SimpleAclAuthorizer \
@@ -157,5 +157,5 @@ def init_kafka_acls(params, topics, groups):
                                 params.zookeeper_quorum,
                                 params.metron_user,
                                 group),
-            user=params.kafka_user)
+            user=params.kafka_user, tries=3, try_sleep=5, logoutput=True)
   Logger.info("Done creating Kafka ACLs")

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/params_linux.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/params_linux.py
@@ -258,7 +258,6 @@ threat_intel_join_parallelism = config['configurations']['metron-enrichment-env'
 kafka_writer_parallelism = config['configurations']['metron-enrichment-env']['kafka_writer_parallelism']
 
 # Profiler
-
 metron_profiler_topology = 'profiler'
 profiler_input_topic = config['configurations']['metron-enrichment-env']['enrichment_output_topic']
 profiler_kafka_start = config['configurations']['metron-profiler-env']['profiler_kafka_start']
@@ -273,7 +272,7 @@ profiler_acker_executors = config['configurations']['metron-profiler-env']['prof
 profiler_hbase_table = config['configurations']['metron-profiler-env']['profiler_hbase_table']
 profiler_hbase_cf = config['configurations']['metron-profiler-env']['profiler_hbase_cf']
 profiler_configured_flag_file = status_params.profiler_configured_flag_file
-profiler_acl_configured_flag_file = status_params.indexing_acl_configured_flag_file
+profiler_acl_configured_flag_file = status_params.profiler_acl_configured_flag_file
 profiler_hbase_configured_flag_file = status_params.profiler_hbase_configured_flag_file
 profiler_hbase_acl_configured_flag_file = status_params.profiler_hbase_acl_configured_flag_file
 if not len(profiler_topology_worker_childopts) == 0:
@@ -303,4 +302,3 @@ metron_apps_indexed_hdfs_dir = format(format(config['configurations']['metron-in
 bolt_hdfs_rotation_policy = config['configurations']['metron-indexing-env']['bolt_hdfs_rotation_policy']
 bolt_hdfs_rotation_policy_units = config['configurations']['metron-indexing-env']['bolt_hdfs_rotation_policy_units']
 bolt_hdfs_rotation_policy_count = config['configurations']['metron-indexing-env']['bolt_hdfs_rotation_policy_count']
-

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/parser_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/parser_commands.py
@@ -124,12 +124,12 @@ class ParserCommands:
 
         for parser in stopped_parsers:
             Logger.info('Starting ' + parser)
-            Execute(start_cmd_template.format(self.__params.metron_home,
-                                              self.__params.kafka_brokers,
-                                              self.__params.zookeeper_quorum,
-                                              parser,
-                                              self.__params.kafka_security_protocol),
-                    user=self.__params.metron_user)
+            start_cmd = start_cmd_template.format(self.__params.metron_home,
+                                                  self.__params.kafka_brokers,
+                                                  self.__params.zookeeper_quorum,
+                                                  parser,
+                                                  self.__params.kafka_security_protocol)
+            Execute(start_cmd, user=self.__params.metron_user, tries=3, try_sleep=5, logoutput=True)
 
         Logger.info('Finished starting parser topologies')
 
@@ -147,7 +147,7 @@ class ParserCommands:
                                       self.__params.metron_keytab_path,
                                       self.__params.metron_principal_name,
                                       execute_user=self.__params.metron_user)
-            Execute(stop_cmd, user=self.__params.metron_user)
+            Execute(stop_cmd, user=self.__params.metron_user, tries=3, try_sleep=5, logoutput=True)
         Logger.info('Done stopping parser topologies')
 
     def restart_parser_topologies(self, env):

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/profiler_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/profiler_commands.py
@@ -132,7 +132,11 @@ class ProfilerCommands:
         Logger.info('Starting ' + self.__profiler_topology)
 
         if not self.is_topology_active(env):
-            self.authenticate(self.__params.metron_user)
+            if self.__params.security_enabled:
+                metron_security.kinit(self.__params.kinit_path_local,
+                      self.__params.hbase_keytab_path,
+                      self.__params.hbase_principal_name,
+                      execute_user=self.__params.metron_user)
             start_cmd_template = """{0}/bin/start_profiler_topology.sh \
                                     -s {1} \
                                     -z {2}"""

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/profiler_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/profiler_commands.py
@@ -134,9 +134,9 @@ class ProfilerCommands:
         if not self.is_topology_active(env):
             if self.__params.security_enabled:
                 metron_security.kinit(self.__params.kinit_path_local,
-                      self.__params.hbase_keytab_path,
-                      self.__params.hbase_principal_name,
-                      execute_user=self.__params.metron_user)
+                                      self.__params.metron_keytab_path,
+                                      self.__params.metron_principal_name,
+                                      execute_user=self.__params.metron_user)
             start_cmd_template = """{0}/bin/start_profiler_topology.sh \
                                     -s {1} \
                                     -z {2}"""


### PR DESCRIPTION
The Profiler MPack mistakenly uses the wrong flag/guard file to indicate that the Kafka ACL group has been setup.  Whichever component (either Profiler or Indexing) that is executed first will complete successfully.  The component to run next will not perform this setup task because the duplicated flag/guard file indicates that the setup was already completed successfully.

Most of the changes in this PR enhance the existing logging to help in the future when tracking down an issue like this.  The actual fix is a one line.

### Testing
To test this change, you need to kerberize and environment and then ensure that both the Profiler and Indexing topologies are successfully running and consuming data after kerberization.  

- [x] Tested in Full Dev
- [x] Tested in multi-node cluster 
