### PR TITLE
METRON-1228: Configuration Management PUSH immediately does DUMP after

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/cli/ConfigurationManager.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/cli/ConfigurationManager.java
@@ -261,6 +261,7 @@ public class ConfigurationManager {
         } else {
           push(inputDirStr, client);
         }
+        break;
 
       case "dump":
         if (configType.isPresent()) {


### PR DESCRIPTION
Addresses https://issues.apache.org/jira/browse/METRON-1228

## Contributor Comments
Missing 'break' is causing pushes to immediately dump configs to std output.

To test, perform a zk_load_configs.sh -m PUSH command and verify that the command is not followed with a screen dump of the zk configs.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && build_utils/verify_licenses.sh 
  ```

- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

