### PR TITLE
METRON-1251: Typo and formatting fixes for metron-rest README

### DIFF
--- a/metron-interface/metron-rest/README.md
+++ b/metron-interface/metron-rest/README.md
@@ -76,7 +76,7 @@ No optional parameter has a default.
 | METRON_PRINCIPAL_NAME                 | Kerberos principal for the metron user                            | Optional
 | METRON_SERVICE_KEYTAB                 | Path to the Kerberos keytab for the metron user                   | Optional
 
-These are set in the `/etc/sysconfig/metron` file.
+These are set in the `/etc/default/metron` file.
 
 ## Database setup
 
@@ -87,7 +87,7 @@ Spring uses Hibernate as the default ORM framework but another framework is need
 
 The REST application comes with [embedded database support](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html#boot-features-embedded-database-support) for development purposes.
 
-For example, edit these variables in `/etc/sysconfig/metron` before starting the application to configure H2:
+For example, edit these variables in `/etc/default/metron` before starting the application to configure H2:
 ```
 METRON_JDBC_DRIVER="org.h2.Driver"
 METRON_JDBC_URL="jdbc:h2:file:~/metrondb"
@@ -125,7 +125,7 @@ The following configures the application for MySQL:
     tar xf mysql-connector-java-5.1.41.tar.gz
     ```
 
-1. Edit these variables in `/etc/sysconfig/metron` to configure the REST application for MySQL:
+1. Edit these variables in `/etc/default/metron` to configure the REST application for MySQL:
     ```
     METRON_JDBC_DRIVER="com.mysql.jdbc.Driver"
     METRON_JDBC_URL="jdbc:mysql://mysql_host:3306/metronrest"
@@ -142,7 +142,7 @@ The following configures the application for MySQL:
 1. Start the REST API. Adjust the password as necessary.
     ```
     set -o allexport;
-    source /etc/sysconfig/metron;
+    source /etc/default/metron;
     set +o allexport;
     export METRON_JDBC_PASSWORD='Myp@ssw0rd';
     $METRON_HOME/bin/metron-rest.sh
@@ -166,7 +166,7 @@ insert into authorities (username, authority) values ('your_username', 'ROLE_USE
 
 ### Kerberos
 
-Metron REST can be configured for a cluster with Kerberos enabled.  A client JAAS file is required for Kafka and Zookeeper and a Kerberos keytab for the metron user principal is required for all other services.  Configure these settings in the `/etc/sysconfig/metron` file:
+Metron REST can be configured for a cluster with Kerberos enabled.  A client JAAS file is required for Kafka and Zookeeper and a Kerberos keytab for the metron user principal is required for all other services.  Configure these settings in the `/etc/default/metron` file:
 ```
 SECURITY_ENABLED=true
 METRON_JVMFLAGS="-Djava.security.auth.login.config=$METRON_HOME/client_jaas.conf"
@@ -185,7 +185,7 @@ The REST application comes with a few [Spring Profiles](http://docs.spring.io/au
 | vagrant                  | sets configuration variables to match the Metron vagrant environment    |
 | docker                   | sets configuration variables to match the Metron docker environment     |
 
-Setting active profiles is done with the METRON_SPRING_PROFILES_ACTIVE variable.  For example, set this variable in `/etc/sysconfig/metron` to configure the REST application for the Vagrant environment and add a test user:
+Setting active profiles is done with the METRON_SPRING_PROFILES_ACTIVE variable.  For example, set this variable in `/etc/default/metron` to configure the REST application for the Vagrant environment and add a test user:
 ```
 METRON_SPRING_PROFILES_ACTIVE="vagrant,dev"
 ```
@@ -810,7 +810,7 @@ mvn spring-boot:run -Drun.profiles=vagrant,dev
 
 The metron-rest application will be available at http://localhost:8080/swagger-ui.html#/.
 
-To run the application locally on the Quick Dev host (node1), follow the [Installation](#installation) instructions above.  Then set the METRON_SPRING_PROFILES_ACTIVE variable in `/etc/sysconfig/metron`:
+To run the application locally on the Quick Dev host (node1), follow the [Installation](#installation) instructions above.  Then set the METRON_SPRING_PROFILES_ACTIVE variable in `/etc/default/metron`:
 ```
 METRON_SPRING_PROFILES_ACTIVE="vagrant,dev"
 ```
@@ -820,7 +820,7 @@ and start the application:
 service metron-rest start
 ```
 
-In a cluster with Kerberos enabled, update the security settings in `/etc/sysconfig/metron`.  Security is disabled by default in the `vagrant` Spring profile so that setting must be overriden with the METRON_SPRING_OPTIONS variable:
+In a cluster with Kerberos enabled, update the security settings in `/etc/default/metron`.  Security is disabled by default in the `vagrant` Spring profile so that setting must be overriden with the METRON_SPRING_OPTIONS variable:
 ```
 METRON_SPRING_PROFILES_ACTIVE="vagrant,dev"
 METRON_JVMFLAGS="-Djava.security.auth.login.config=$METRON_HOME/client_jaas.conf"

--- a/metron-interface/metron-rest/README.md
+++ b/metron-interface/metron-rest/README.md
@@ -14,19 +14,19 @@ This module provides a RESTful API for interacting with Metron.
 ### From Source
 
 1. Package the application with Maven:
-  ```
-mvn clean package
-  ```
+    ```
+    mvn clean package
+    ```
 
 1. Untar the archive in the $METRON_HOME directory.  The directory structure will look like:
-  ```
-config
-  rest_application.yml
-bin
-  metron-rest
-lib
-  metron-rest-$METRON_VERSION.jar
-  ```
+    ```
+    config
+      rest_application.yml
+    bin
+      metron-rest
+    lib
+      metron-rest-$METRON_VERSION.jar
+    ```
 
 1. Copy the `$METRON_HOME/bin/metron-rest` script to `/etc/init.d/metron-rest`
 
@@ -35,9 +35,9 @@ lib
 1. Deploy the RPM at `/metron/metron-deployment/packaging/docker/rpm-docker/target/RPMS/noarch/metron-rest-$METRON_VERSION-*.noarch.rpm`
 
 1. Install the RPM with:
-  ```
-rpm -ih metron-rest-$METRON_VERSION-*.noarch.rpm
-  ```
+    ```
+    rpm -ih metron-rest-$METRON_VERSION-*.noarch.rpm
+    ```
 
 ## Configuration
 
@@ -112,42 +112,42 @@ The following configures the application for MySQL:
 1. Install MySQL if not already available (this example uses version 5.7, installation instructions can be found [here](https://dev.mysql.com/doc/refman/5.7/en/linux-installation-yum-repo.html))
 
 1. Create a metron user and REST database and permission the user for that database:
-  ```
-CREATE USER 'metron'@'node1' IDENTIFIED BY 'Myp@ssw0rd';
-CREATE DATABASE IF NOT EXISTS metronrest;
-GRANT ALL PRIVILEGES ON metronrest.* TO 'metron'@'node1';
-  ```
+    ```
+    CREATE USER 'metron'@'node1' IDENTIFIED BY 'Myp@ssw0rd';
+    CREATE DATABASE IF NOT EXISTS metronrest;
+    GRANT ALL PRIVILEGES ON metronrest.* TO 'metron'@'node1';
+    ```
 
 1. Install the MySQL JDBC client onto the REST application host and configurate the METRON_JDBC_CLIENT_PATH variable:
-  ```
-cd $METRON_HOME/lib
-wget https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.41.tar.gz
-tar xf mysql-connector-java-5.1.41.tar.gz
-  ```
+    ```
+    cd $METRON_HOME/lib
+    wget https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.41.tar.gz
+    tar xf mysql-connector-java-5.1.41.tar.gz
+    ```
 
 1. Edit these variables in `/etc/sysconfig/metron` to configure the REST application for MySQL:
-  ```
-METRON_JDBC_DRIVER="com.mysql.jdbc.Driver"
-METRON_JDBC_URL="jdbc:mysql://mysql_host:3306/metronrest"
-METRON_JDBC_USERNAME="metron"
-METRON_JDBC_PLATFORM="mysql"
-METRON_JDBC_CLIENT_PATH=$METRON_HOME/lib/mysql-connector-java-5.1.41/mysql-connector-java-5.1.41-bin.jar
-  ```
+    ```
+    METRON_JDBC_DRIVER="com.mysql.jdbc.Driver"
+    METRON_JDBC_URL="jdbc:mysql://mysql_host:3306/metronrest"
+    METRON_JDBC_USERNAME="metron"
+    METRON_JDBC_PLATFORM="mysql"
+    METRON_JDBC_CLIENT_PATH=$METRON_HOME/lib/mysql-connector-java-5.1.41/mysql-connector-java-5.1.41-bin.jar
+    ```
 
 1. Switch to the metron user
-  ```
-sudo su - metron
-  ```
+    ```
+    sudo su - metron
+    ```
 
 1. Start the REST API. Adjust the password as necessary.
-  ```
-set -o allexport;
-source /etc/metron/sysconfig;
-set +o allexport;
-export METRON_JDBC_PASSWORD='Myp@ssw0rd';
-$METRON_HOME/bin/metron-rest.sh
-unset METRON_JDBC_PASSWORD;
-  ```
+    ```
+    set -o allexport;
+    source /etc/metron/sysconfig;
+    set +o allexport;
+    export METRON_JDBC_PASSWORD='Myp@ssw0rd';
+    $METRON_HOME/bin/metron-rest.sh
+    unset METRON_JDBC_PASSWORD;
+    ```
 
 ## Usage
 

--- a/metron-interface/metron-rest/README.md
+++ b/metron-interface/metron-rest/README.md
@@ -142,7 +142,7 @@ The following configures the application for MySQL:
 1. Start the REST API. Adjust the password as necessary.
     ```
     set -o allexport;
-    source /etc/metron/sysconfig;
+    source /etc/sysconfig/metron;
     set +o allexport;
     export METRON_JDBC_PASSWORD='Myp@ssw0rd';
     $METRON_HOME/bin/metron-rest.sh


### PR DESCRIPTION
## Contributor Comments
This fix properly format the github md in addition to the site-book docs (previously the github formatting was broken).  It also fixes a typo regarding `/etc/sysconfig/metron`.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [X] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?

### For documentation related changes:
- [X] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.