### PR TITLE
METRON-1260 Include Alerts UI in Ambari Service Check

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/alerts_ui_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/alerts_ui_commands.py
@@ -21,6 +21,8 @@ limitations under the License.
 from resource_management.core.logger import Logger
 from resource_management.core.resources.system import Execute, File
 
+import metron_service
+
 # Wrap major operations and functionality in this class
 class AlertsUICommands:
     __params = None
@@ -31,16 +33,52 @@ class AlertsUICommands:
         self.__params = params
 
     def start_alerts_ui(self):
+        """
+        Start the Alerts UI
+        :param env: Environment
+        """
         Logger.info('Starting Alerts UI')
         Execute("service metron-alerts-ui start")
         Logger.info('Done starting Alerts UI')
 
     def stop_alerts_ui(self):
+        """
+        Stop the Alerts UI
+        :param env: Environment
+        """
         Logger.info('Stopping Alerts UI')
         Execute("service metron-alerts-ui stop")
         Logger.info('Done stopping Alerts UI')
 
     def restart_alerts_ui(self, env):
+        """
+        Restart the Alerts UI
+        :param env: Environment
+        """
         Logger.info('Restarting the Alerts UI')
         Execute('service metron-alerts-ui restart')
         Logger.info('Done restarting the Alerts UI')
+
+    def status_alerts_ui(self, env):
+        """
+        Performs a status check for the Alerts UI
+        :param env: Environment
+        """
+        Logger.info('Status check the Alerts UI')
+        metron_service.check_http(
+          self.__params.hostname,
+          self.__params.metron_alerts_ui_port,
+          self.__params.metron_user)
+
+    def service_check(self, env):
+        """
+        Performs a service check for the Alerts UI
+        :param env: Environment
+        """
+        Logger.info('Checking connectivity to Alerts UI')
+        metron_service.check_http(
+          self.__params.hostname,
+          self.__params.metron_alerts_ui_port,
+          self.__params.metron_user)
+
+        Logger.info("Alerts UI service check completed successfully")

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/alerts_ui_master.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/alerts_ui_master.py
@@ -67,11 +67,8 @@ class AlertsUIMaster(Script):
     def status(self, env):
         from params import status_params
         env.set_params(status_params)
-        cmd = format('curl --max-time 3 {hostname}:{metron_alerts_ui_port}')
-        try:
-            get_user_call_output(cmd, user=status_params.metron_user)
-        except ExecutionFailed:
-            raise ComponentIsNotRunning()
+        commands = AlertsUICommands(status_params)
+        commands.status_alerts_ui(env)
 
     def restart(self, env):
         from params import params

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/management_ui_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/management_ui_commands.py
@@ -20,9 +20,10 @@ limitations under the License.
 
 from resource_management.core.logger import Logger
 from resource_management.core.resources.system import Execute, File
-from resource_management.core.exceptions import ComponentIsNotRunning
 from resource_management.core.exceptions import ExecutionFailed
 from resource_management.libraries.functions.get_user_call_output import get_user_call_output
+
+import metron_service
 
 # Wrap major operations and functionality in this class
 class ManagementUICommands:
@@ -34,39 +35,52 @@ class ManagementUICommands:
         self.__params = params
 
     def start_management_ui(self):
+        """
+        Starts the Management UI
+        :param env: Environment
+        """
         Logger.info('Starting Management UI')
         Execute("service metron-management-ui start")
         Logger.info('Done starting Management UI')
 
     def stop_management_ui(self):
+        """
+        Stops the Management UI
+        :param env: Environment
+        """
         Logger.info('Stopping Management UI')
         Execute("service metron-management-ui stop")
         Logger.info('Done stopping Management UI')
 
     def restart_management_ui(self, env):
+        """
+        Restarts the Management UI
+        :param env: Environment
+        """
         Logger.info('Restarting the Management UI')
         Execute('service metron-management-ui restart')
         Logger.info('Done restarting the Management UI')
 
-    def check_status(self, env):
+    def status_management_ui(self, env):
+        """
+        Performs a status check for the Management UI
+        :param env: Environment
+        """
         Logger.info('Status check the Management UI')
-        cmd = "curl --max-time 3 {0}:{1}"
-        try:
-          Execute(
-            cmd.format(self.__params.hostname, self.__params.metron_management_ui_port),
-            tries=3,
-            try_sleep=5,
-            logoutput=False,
-            user=self.__params.metron_user)
-        except:
-          raise ComponentIsNotRunning()
+        metron_service.check_http(
+          self.__params.hostname,
+          self.__params.metron_management_ui_port,
+          self.__params.metron_user)
 
     def service_check(self, env):
         """
         Performs a service check for the Management UI
         :param env: Environment
         """
-        from params import status_params
-        env.set_params(status_params)
-        self.check_status(env)
+        Logger.info('Checking connectivity to Management UI')
+        metron_service.check_http(
+          self.__params.hostname,
+          self.__params.metron_management_ui_port,
+          self.__params.metron_user)
+
         Logger.info("Management UI service check completed successfully")

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/management_ui_master.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/management_ui_master.py
@@ -73,7 +73,7 @@ class ManagementUIMaster(Script):
         from params import status_params
         env.set_params(status_params)
         commands = ManagementUICommands(status_params)
-        commands.check_status(env)
+        commands.status_management_ui(env)
 
     def restart(self, env):
         from params import params

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/rest_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/rest_commands.py
@@ -77,6 +77,9 @@ class RestCommands:
         metron_service.init_kafka_acl_groups(self.__params, groups)
 
     def start_rest_application(self):
+        """
+        Start the REST application
+        """
         Logger.info('Starting REST application')
 
         if self.__params.security_enabled:
@@ -110,6 +113,9 @@ class RestCommands:
         Logger.info('Done starting REST application')
 
     def stop_rest_application(self):
+        """
+        Stop the REST application
+        """
         Logger.info('Stopping REST application')
 
         # Get the pid associated with the service
@@ -153,21 +159,41 @@ class RestCommands:
         Logger.info('Done stopping REST application')
 
     def restart_rest_application(self, env):
+        """
+        Restart the REST application
+        :param env: Environment
+        """
         Logger.info('Restarting the REST application')
         self.stop_rest_application()
         self.start_rest_application()
         Logger.info('Done restarting the REST application')
 
-    def service_check(self, env):
+    def status_rest_application(self, env):
         """
-        Performs a service check for the Metron API.
+        Performs a status check for the REST application
         :param env: Environment
         """
+        Logger.info('Status check the REST application')
+        metron_service.check_http(
+            self.__params.hostname,
+            self.__params.metron_rest_port,
+            self.__params.metron_user)
+
+    def service_check(self, env):
+        """
+        Performs a service check for the REST application
+        :param env: Environment
+        """
+        Logger.info('Checking connectivity to REST application')
+        metron_service.check_http(
+            self.__params.hostname,
+            self.__params.metron_rest_port,
+            self.__params.metron_user)
+
         Logger.info('Checking Kafka topics for the REST application')
         metron_service.check_kafka_topics(self.__params, self.__get_topics())
 
         if self.__params.security_enabled:
-
             Logger.info('Checking Kafka topic ACL for the REST application')
             metron_service.check_kafka_acls(self.__params, self.__get_topics())
 

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/service_check.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/service_check.py
@@ -28,6 +28,7 @@ from indexing_commands import IndexingCommands
 from profiler_commands import ProfilerCommands
 from rest_commands import RestCommands
 from management_ui_commands import ManagementUICommands
+from alerts_ui_commands import AlertsUICommands
 
 class ServiceCheck(Script):
 
@@ -63,6 +64,11 @@ class ServiceCheck(Script):
         Logger.info("Performing Management UI service check")
         mgmt_cmds = ManagementUICommands(params)
         mgmt_cmds.service_check(env)
+
+        # check the alerts UI
+        Logger.info("Performing Alerts UI service check")
+        alerts_cmds = AlertsUICommands(params)
+        alerts_cmds.service_check(env)
 
         Logger.info("Metron service check completed successfully")
         exit(0)


### PR DESCRIPTION
As part of #799, I improved the Ambari Service Check for Metron.  I failed to include any checks for the Alerts UI, that being a new addition to the MPack.  This PR adds the additional checks for the Alerts UI and also some additional refactoring.

## Testing

I tested this by spinning up Full Dev and running the service check manually.  I tested both positive and negative side for the Alerts UI running.


## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
