### PR TITLE
METRON-1278 Strip "Build Status" widget from root README.md in site-book build

### DIFF
--- a/site-book/bin/generate-md.sh
+++ b/site-book/bin/generate-md.sh
@@ -72,7 +72,9 @@ RESOURCE_LIST=(
 ## This is a list of duples, flattened into a bash array.  Even fields are relative paths to a .md file
 ## that needs an href re-written to match a resource in the images/ directory.  Odd fields are the corresponding
 ## one-line sed script, in single quotes, that does the rewrite.  See below for examples.
+## The first line is a special, to remove the "Build Status" variable icon widget.
 HREF_REWRITE_LIST=(
+    README.md '/!\[Build Status\](https:\/\/travis-ci.org/d'
     metron-deployment/Kerberos-manual-setup.md 's#(readme-images/ambari-storm-site-properties.png)#(../images/ambari-storm-site-properties.png)#g'
     metron-deployment/Kerberos-manual-setup.md 's#(readme-images/ambari-storm-site.png)#(../images/ambari-storm-site.png)#g'
     metron-deployment/Kerberos-manual-setup.md 's#(readme-images/custom-storm-site-final.png)#(../images/custom-storm-site-final.png)#g'


### PR DESCRIPTION
## Contributor Comments
See https://issues.apache.org/jira/browse/METRON-1278

## Pull Request Checklist

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes: 
N/A

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? 
