### PR TITLE
METRON-1287 Full Dev Fails When Installing EPEL Repository

### DIFF
--- a/metron-deployment/roles/epel/tasks/main.yml
+++ b/metron-deployment/roles/epel/tasks/main.yml
@@ -15,16 +15,7 @@
 #  limitations under the License.
 #
 ---
-- name: Get epel-repo rpm
-  get_url:
-    dest: /tmp/epel-release.rpm
-    url: http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+- name: Install EPEL repository
+  yum: name=epel-release update_cache=yes
 
-- name: Install epel-repo rpm
-  yum:
-    pkg: /tmp/epel-release.rpm
-    state: installed
-  register: result
-  until: result.rc == 0
-  retries: 5
-  delay: 10
+


### PR DESCRIPTION
This fixes a change in the EPEL repository that is causing deployments of Full Dev to fail.

```
TASK [epel : Get epel-repo rpm] ************************************************
fatal: [node1]: FAILED! => {"changed": false, "dest": "/tmp/epel-release.rpm", "failed": true, "msg": "Request failed", "response": "HTTP Error 404: Not Found", "state": "absent", "status_code": 404, "url": "http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm"}
	to retry, use: --limit @/Users/nallen/Development/metron/metron-deployment/playbooks/metron_full_install.retry
```

This has fixed the immediate issue for me, but I still want to run a full deployment before this gets merged.

## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron 
- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

