### PR TITLE
METRON-1290: Only first 10 alerts are update when a MetaAlert status is changed to inactive

### DIFF
--- a/dependencies_with_url.csv
+++ b/dependencies_with_url.csv
@@ -57,6 +57,10 @@ org.jruby.joni:joni:jar:2.1.2:compile,MIT License,https://github.com/jruby/joni
 org.mitre.taxii:taxii:jar:1.1.0.1:compile,The BSD 3-Clause License,https://github.com/TAXIIProject/java-taxii
 org.mitre:stix:jar:1.2.0.2:compile,The BSD 3-Clause License,https://github.com/STIXProject/java-stix
 org.mockito:mockito-core:jar:1.10.19:compile,The MIT License,http://www.mockito.org
+org.powermock:powermock-core:jar:1.7.0:compile,Apache v2,https://github.com/powermock/powermock
+org.powermock:powermock-module-junit4-common:jar:1.7.0:compile,Apache v2,https://github.com/powermock/powermock
+org.powermock:powermock-module-junit4:jar:1.7.0:compile,Apache v2,https://github.com/powermock/powermock
+org.powermock:powermock-reflect:jar:1.7.0:compile,Apache v2,https://github.com/powermock/powermock
 org.scala-lang:scala-library:jar:2.10.6:compile,BSD-like,http://www.scala-lang.org/
 xmlenc:xmlenc:jar:0.52:compile,The BSD License,http://xmlenc.sourceforge.net
 asm:asm:jar:3.1:compile,BSD,http://asm.ow2.org/

--- a/metron-platform/metron-elasticsearch/pom.xml
+++ b/metron-platform/metron-elasticsearch/pom.xml
@@ -200,6 +200,11 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>${global_powermock_version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/metron-platform/metron-elasticsearch/src/main/java/org/apache/metron/elasticsearch/dao/ElasticsearchMetaAlertDao.java
+++ b/metron-platform/metron-elasticsearch/src/main/java/org/apache/metron/elasticsearch/dao/ElasticsearchMetaAlertDao.java
@@ -507,7 +507,7 @@ public class ElasticsearchMetaAlertDao implements MetaAlertDao {
     List<Map<String, Object>> alerts = new ArrayList<>();
     QueryBuilder query = QueryBuilders.idsQuery().ids(guids);
     SearchRequestBuilder request = elasticsearchDao.getClient().prepareSearch()
-        .setQuery(query);
+        .setQuery(query).setSize(guids.size());
     org.elasticsearch.action.search.SearchResponse response = request.get();
     for (SearchHit hit : response.getHits().getHits()) {
       alerts.add(hit.sourceAsMap());

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
         <global_java_version>1.8</global_java_version>
         <global_solr_version>5.2.1</global_solr_version>
         <global_mockito_version>1.10.19</global_mockito_version>
+        <global_powermock_version>1.7.0</global_powermock_version>
         <global_shade_version>2.4.3</global_shade_version>
         <global_jackson_version>2.7.4</global_jackson_version>
         <global_errorprone_core_version>2.0.14</global_errorprone_core_version>


### PR DESCRIPTION
## Contributor Comments
This PR fixes a small bug in the ElasticsearchMetaAlertDao that only updates the first 10 alerts in a metaalert when that metaalert status is changed to inactive.  This is due to the fact that the ElasticsearchMetaAlertDao needs to lookup up the child alerts and a search created with `elasticsearchDao.getClient().prepareSearch()` defaults to result set size to 10.  This can be reproduced in full dev:
- turn off the sensor stubs so that the number of alerts in ES is fixed
- take note of the number of alerts in the index
- create a metaalert with more than 10 alerts
- the number of alerts should decrease to: # of alerts added - 1 metaalert
- change the metaalert status to inactive 
- the number of alerts will now be less than before where the count should be the same

I also added an embarrassingly complex unit test to cover this situation.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && build_utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.

