### PR TITLE
METRON-1296 Full Dev Fails to Deploy Index Templates

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/indexing_master.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/indexing_master.py
@@ -80,14 +80,19 @@ class Indexing(Script):
         from params import params
         env.set_params(params)
         self.configure(env)
+        commands = IndexingCommands(params)
+
         # Install elasticsearch templates
         try:
             if not commands.is_elasticsearch_template_installed():
                 self.elasticsearch_template_install(env)
                 commands.set_elasticsearch_template_installed()
-        except:
-            Logger.warning("WARNING: Elasticsearch templates could not be installed. The Elasticsearch service is probably down.")
-        commands = IndexingCommands(params)
+
+        except Exception as e:
+            msg = "WARNING: Elasticsearch index templates could not be installed.  " \
+                  "Is Elasticsearch running?  Will reattempt install on next start.  error={0}"
+            Logger.warning(msg.format(e))
+
         commands.start_indexing_topology(env)
 
     def stop(self, env, upgrade_type=None):


### PR DESCRIPTION
Fixed a bug that prevents the index templates from being installed.  This also ensures that the cause of an exception is logged.

Oops.  This should not have passed testing.   I reviewed the original PR and should have caught this.  I think a late change in the review process mucked things up.

To test this, spin up Full Dev and make sure that the index templates are installed.  Open up the Alerts UI and ensure that you can see alerts in the system.

## Pull Request Checklist
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
