### PR TITLE
METRON-1319: Column Metadata REST service should use default indices on empty input

### DIFF
--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/service/impl/SearchServiceImpl.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/service/impl/SearchServiceImpl.java
@@ -96,6 +96,11 @@ public class SearchServiceImpl implements SearchService {
   @Override
   public Map<String, FieldType> getColumnMetadata(List<String> indices) throws RestException {
     try {
+      if (indices == null || indices.isEmpty()) {
+        indices = getDefaultIndices();
+        // metaalerts should be included by default in column metadata requests
+        indices.add(METAALERT_TYPE);
+      }
       return dao.getColumnMetadata(indices);
     }
     catch(IOException ioe) {

--- a/metron-interface/metron-rest/src/test/java/org/apache/metron/rest/controller/SearchControllerIntegrationTest.java
+++ b/metron-interface/metron-rest/src/test/java/org/apache/metron/rest/controller/SearchControllerIntegrationTest.java
@@ -133,6 +133,30 @@ public class SearchControllerIntegrationTest extends DaoControllerTest {
   }
 
   @Test
+  public void testDefaultColumnMetadata() throws Exception {
+    sensorIndexingConfigService.save("bro", new HashMap<String, Object>() {{
+      put("index", "bro");
+    }});
+    sensorIndexingConfigService.save("snort", new HashMap<String, Object>() {{
+      put("index", "snort");
+    }});
+
+    assertEventually(() -> this.mockMvc.perform(post(searchUrl + "/column/metadata").with(httpBasic(user, password)).with(csrf()).contentType(MediaType.parseMediaType("application/json;charset=UTF-8")).content("[]"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.parseMediaType("application/json;charset=UTF-8")))
+        .andExpect(jsonPath("$.*", hasSize(5)))
+        .andExpect(jsonPath("$.common_string_field").value("string"))
+        .andExpect(jsonPath("$.common_integer_field").value("integer"))
+        .andExpect(jsonPath("$.bro_field").value("boolean"))
+        .andExpect(jsonPath("$.snort_field").value("double"))
+        .andExpect(jsonPath("$.duplicate_field").value("other"))
+    );
+
+    sensorIndexingConfigService.delete("bro");
+    sensorIndexingConfigService.delete("snort");
+  }
+
+  @Test
   public void test() throws Exception {
 
     this.mockMvc.perform(post(searchUrl + "/search").with(httpBasic(user, password)).with(csrf()).contentType(MediaType.parseMediaType("application/json;charset=UTF-8")).content(SearchIntegrationTest.allQuery))

--- a/metron-interface/metron-rest/src/test/java/org/apache/metron/rest/service/impl/SearchServiceImplTest.java
+++ b/metron-interface/metron-rest/src/test/java/org/apache/metron/rest/service/impl/SearchServiceImplTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import org.apache.metron.indexing.dao.IndexDao;
 import org.apache.metron.indexing.dao.search.InvalidSearchException;
@@ -94,5 +95,17 @@ public class SearchServiceImplTest {
     SearchRequest searchRequest = new SearchRequest();
     searchRequest.setIndices(Arrays.asList("bro"));
     searchService.search(searchRequest);
+  }
+
+  @Test
+  public void getColumnMetadataShouldProperlyGetDefaultIndices() throws Exception {
+    when(environment.getProperty(INDEX_WRITER_NAME)).thenReturn("elasticsearch");
+    when(sensorIndexingConfigService.getAllIndices("elasticsearch")).thenReturn(Arrays.asList("bro", "snort", "error"));
+
+    searchService.getColumnMetadata(new ArrayList<>());
+
+    verify(dao).getColumnMetadata(eq(Arrays.asList("bro", "snort", "metaalert")));
+
+    verifyNoMoreInteractions(dao);
   }
 }


### PR DESCRIPTION
## Contributor Comments
This PR adjusts the Column Metadata REST service to use a list of default indices when an empty list is passed in.  This behavior is similar to the search method and keeps the Alerts UI from having to track the current list of available indices.

I added test cases and verified the relevant tests in our Alerts UI end-to-end test now pass.  Still need to spin up full dev and validate there.  Will report back once I have successfully done that but this can be reviewed in the meantime.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && build_utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.

