### PR TITLE
METRON-1333 Ensure that ansible-docker can be used to build metron ( including rpms )

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ $ mvn clean install -PHDP-2.5.0.0
 
 You can swap "install" for "package" in the commands above if you don't want to deploy the artifacts to your local .m2 repo.
 
+
 # Build Metron Reporting
 
 To build and run reporting with code coverage:
@@ -101,6 +102,11 @@ $ mvn clean install -DskipTests site site:stage-deploy site:deploy
 ```
 
 The staged site is deployed to /tmp/metron/site/index.html, and can be viewed by opening the file in a browser.
+
+## Building with Docker
+
+A Docker container with all the required software, with the proper versions, is available to be used as well.
+see [ansible-docker](metron-deployment/packaging/docker/ansible-docker)
 
 # Navigating the Architecture
 

--- a/metron-deployment/packaging/docker/ansible-docker/Dockerfile
+++ b/metron-deployment/packaging/docker/ansible-docker/Dockerfile
@@ -22,8 +22,8 @@ RUN yum install -y wget
 # base development tools required
 RUN yum groupinstall -y "Development tools"
 # newer cpp 11 support required for building node modules
-RUN wget http://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo
-RUN yum -y install devtoolset-2-gcc devtoolset-2-binutils devtoolset-2-gcc-c++
+RUN yum install -y centos-release-scl
+RUN yum install -y devtoolset-4-gcc-c++ devtoolset-4-gcc
 RUN yum install -y zlib-dev openssl-devel sqlite-devel bzip2-devel libffi-devel
 # install python 2.7.11 but do not make it the default
 RUN wget https://www.python.org/ftp/python/2.7.11/Python-2.7.11.tgz -O /usr/src/Python-2.7.11.tgz
@@ -57,7 +57,7 @@ RUN ln -s /opt/maven/bin/mvn /usr/bin/mvn
 RUN yum -y install asciidoc rpm-build rpm2cpio tar unzip xmlto zip rpmlint make && yum clean all
 # create a .bashrc for root, enabling the cpp 11 toolset
 RUN touch /root/.bashrc \
- && cat '/opt/rh/devtoolset-2/enable' >> /root/.bashrc
+ && cat '/opt/rh/devtoolset-4/enable' >> /root/.bashrc
 # install node so that the node dependencies can be packaged into the RPMs
 RUN curl --silent --location https://rpm.nodesource.com/setup_6.x | bash -
 RUN yum -y install nodejs

--- a/metron-deployment/packaging/docker/ansible-docker/Dockerfile
+++ b/metron-deployment/packaging/docker/ansible-docker/Dockerfile
@@ -14,13 +14,18 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-FROM centos:centos6
+FROM centos:centos6.9
 MAINTAINER Apache Metron
 
 RUN yum install -y tar
 RUN yum install -y wget
+# base development tools required
 RUN yum groupinstall -y "Development tools"
+# newer cpp 11 support required for building node modules
+RUN wget http://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo
+RUN yum -y install devtoolset-2-gcc devtoolset-2-binutils devtoolset-2-gcc-c++
 RUN yum install -y zlib-dev openssl-devel sqlite-devel bzip2-devel libffi-devel
+# install python 2.7.11 but do not make it the default
 RUN wget https://www.python.org/ftp/python/2.7.11/Python-2.7.11.tgz -O /usr/src/Python-2.7.11.tgz
 WORKDIR /usr/src
 RUN tar xvf Python-2.7.11.tgz
@@ -33,18 +38,28 @@ RUN tar xvf setuptools-11.3.tar.gz
 WORKDIR /usr/src/setuptools-11.3
 RUN python2.7 setup.py install
 RUN easy_install-2.7 pip
+# install ansible and set the configuration var
 RUN pip2.7 install ansible==2.0.0.2
 RUN pip2.7 install boto
 COPY ansible.cfg /root/
 ENV ANSIBLE_CONFIG /root/ansible.cfg
+# java
 RUN yum install -y java-1.8.0-openjdk java-1.8.0-openjdk-devel
 RUN yum install -y which
 RUN yum install -y nss
 WORKDIR /usr/src
+# setup maven
 RUN wget http://apache.cs.utah.edu/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz
 RUN tar xzvf apache-maven-3.3.9-bin.tar.gz
 RUN mv apache-maven-3.3.9 /opt/maven
 RUN ln -s /opt/maven/bin/mvn /usr/bin/mvn
-RUN yum -y install asciidoc rpm-build rpm2cpio tar unzip xmlto zip rpmlint && yum clean all
+# install rpm tools required to build rpms
+RUN yum -y install asciidoc rpm-build rpm2cpio tar unzip xmlto zip rpmlint make && yum clean all
+# create a .bashrc for root, enabling the cpp 11 toolset
+RUN touch /root/.bashrc \
+ && cat '/opt/rh/devtoolset-2/enable' >> /root/.bashrc
+# install node so that the node dependencies can be packaged into the RPMs
+RUN curl --silent --location https://rpm.nodesource.com/setup_6.x | bash -
+RUN yum -y install nodejs
 WORKDIR /root
 

--- a/metron-deployment/packaging/docker/ansible-docker/README.md
+++ b/metron-deployment/packaging/docker/ansible-docker/README.md
@@ -1,17 +1,34 @@
 # Overview
-The Metron ansible-docker container is provided in an effort reduce the installation burden of deploying Metron in a live envirionment.
-It is provisioned with software required to sucessfully run the deployment scripts.
+The Metron ansible-docker container is provided in an effort reduce the installation burden of building Metron.
+It may also be used to deploy Metron in a live environment.
+It is provisioned with software required to sucessfully build metron run the deployment scripts.
 
 ## Building the Container
 1. Install Docker ( https://www.docker.com/products/overview )
 2. Navigate to \<project-directory\>/metron-deployment/packaging/docker/ansible-docker
 3. Build the container `docker build -t ansible-docker:2.0.0.2 .`
 
-## Using the Container
+## Using the Container to build metron
+anytime after building the container you can run it with the following command
+
+`docker run -it -v \<project-directory\>:/root/metron ansible-docker:2.0.0.2 bash`
+
+If you are going to build metron multiple times, you may want to map the /root/.m2 maven
+repo from outside of the container so that you don't start with an empty repo every build and have to download
+the world.
+
+`docker run -it -v \<project-directory\>:/root/metron -v \<your .m2 directory\>:/root/.m2 ansible-docker:2.0.0.2 bash`
+
+After running the container:
+
+1. cd /root/metron
+2. run build commands, for example:
+  - build metron without tests : `mvn clean package -DskipTests`
+  - build metron and build the rpms as well : `mvn clean install && cd metron-deployment && mvn package -P build-rpms`
+
+## Using the Container for deployment
+
+> Note these instructions are outdated
+
 Full instructions are found on the wiki at https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=65144361
 
-tl;dr:
-
-1. docker run -it -v \<project-directory\>:/root/metron ansible-docker:2.0.0.2 bash
-2. cd /root/metron
-3. mvn clean package -DskipTests

--- a/metron-deployment/packaging/docker/ansible-docker/README.md
+++ b/metron-deployment/packaging/docker/ansible-docker/README.md
@@ -1,7 +1,7 @@
 # Overview
 The Metron ansible-docker container is provided in an effort reduce the installation burden of building Metron.
 It may also be used to deploy Metron in a live environment.
-It is provisioned with software required to sucessfully build metron run the deployment scripts.
+It is provisioned with software required to sucessfully build metron and run the deployment scripts.
 
 ## Building the Container
 1. Install Docker ( https://www.docker.com/products/overview )
@@ -25,6 +25,12 @@ After running the container:
 2. run build commands, for example:
   - build metron without tests : `mvn clean package -DskipTests`
   - build metron and build the rpms as well : `mvn clean install && cd metron-deployment && mvn package -P build-rpms`
+  
+If you wish to use this build with a vagrant instance, then after building with rpms as above, modify
+your usual vagrant up command to skip the build role, as so:
+
+`vagrant --ansible-skip-tags="build" up`
+
 
 ## Using the Container for deployment
 

--- a/metron-deployment/packaging/docker/ansible-docker/README.md
+++ b/metron-deployment/packaging/docker/ansible-docker/README.md
@@ -29,7 +29,7 @@ After running the container:
 If you wish to use this build with a vagrant instance, then after building with rpms as above, modify
 your usual vagrant up command to skip the build role, as so:
 
-`vagrant --ansible-skip-tags="build" up`
+`vagrant --ansible-skip-tags="build,quick_dev" up`
 
 
 ## Using the Container for deployment


### PR DESCRIPTION
The ansible-docker container could be used to build metron ( even the rpms ) and run the ansible scripts. This is no longer true, as the new node ui projects have native compilation that requires c++ 11 support in gcc, and rpm build requires node to be installed ( not local installed as in the mvn packaging ).
Many users are having problems building metron on centos platforms, having this container available and functioning would be a great help.

This PR addresses this by:

- installing devtoolset-4 into the container to get cpp 11
- creating a .bash_profile for root that enables the devtoolset environment
- installing node into the container since building rpms now requires node ( and not just the local node used during building in maven )
- documenting building in container, as well as mapping local .m2 repo into the container

You can now build and test metron, including building the rpms.


## Testing

Follow the steps in the read me and build metron:

`mvn clean package`
`mvn clean package -DskipTests`
`mvn clean install && cd metron-deployment && mvn package -P build-rpms`

Also, after building with the rpms, exit docker
and do full_dev with
`vagrant --ansible-skip-tags="build, quick_dev" up`  and verify that you can use vagrant with the doc built packaging and rpms.


## Pull Request Checklist

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x ] Have you run a build, test, build rpm set of builds in the container?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? 