### PR TITLE
METRON-1334 Add C++11 Compliance Check to 'platform-info.sh'

### DIFF
--- a/metron-deployment/scripts/platform-info.sh
+++ b/metron-deployment/scripts/platform-info.sh
@@ -75,14 +75,14 @@ npm --version
 
 # C++ compiler
 echo "--"
-echo "g++"
-g++ --version
+if [[ $(command -v g++) && $(g++ --version 2>/dev/null) ]]; then
+  g++ --version
 
-# C++11 compliant compiler
-echo "--"
-OBJFILE=/tmp/test
-CPPFILE=/tmp/test.cpp
-cat > $CPPFILE <<- EOM
+  # check C++11 compliance
+  echo "--"
+  OBJFILE=/tmp/test
+  CPPFILE=/tmp/test.cpp
+  cat > $CPPFILE <<- EOM
 #include <iostream>
 using namespace std;
 int main() {
@@ -90,13 +90,18 @@ int main() {
     return 0;
 }
 EOM
-g++ -std=c++11 $CPPFILE -o $OBJFILE
-if [ $? -eq 0 ]; then
-    echo "Compiler is C++11 compliant"
+  g++ -std=c++11 $CPPFILE -o $OBJFILE &>/dev/null
+  if [ $? -eq 0 ]; then
+      echo "Compiler is C++11 compliant"
+  else
+      echo "Warning: Compiler is NOT C++11 compliant"
+  fi
+  rm -f $CPPFILE $OBJFILE
+elif [[ $(command -v g++) ]]; then
+  echo "Warning: g++ not properly configured"
 else
-    echo "Warning: Compiler is NOT C++11 compliant"
+  echo "Warning: g++ not found"
 fi
-rm -f $CPPFILE $OBJFILE
 
 # operating system
 echo "--"

--- a/metron-deployment/scripts/platform-info.sh
+++ b/metron-deployment/scripts/platform-info.sh
@@ -73,6 +73,28 @@ echo "--"
 echo "npm"
 npm --version
 
+# C++ compiler
+echo "--"
+echo "g++"
+g++ --version
+
+# C++11 compliant compiler
+echo "--"
+CPPFILE=/tmp/test.cpp
+cat > $CPPFILE <<- EOM
+#include <iostream>
+using namespace std;
+int main() {
+    cout << "Hello World!" << endl;
+    return 0;
+}
+EOM
+g++ -std=c++11 $CPPFILE -o /tmp/test
+if [ $? -eq 0 ]; then
+    echo "Compiler is C++11 compliant"
+else
+    echo "Warning: Compiler is NOT C++11 compliant"
+fi
 
 # operating system
 echo "--"

--- a/metron-deployment/scripts/platform-info.sh
+++ b/metron-deployment/scripts/platform-info.sh
@@ -80,6 +80,7 @@ g++ --version
 
 # C++11 compliant compiler
 echo "--"
+OBJFILE=/tmp/test
 CPPFILE=/tmp/test.cpp
 cat > $CPPFILE <<- EOM
 #include <iostream>
@@ -89,12 +90,13 @@ int main() {
     return 0;
 }
 EOM
-g++ -std=c++11 $CPPFILE -o /tmp/test
+g++ -std=c++11 $CPPFILE -o $OBJFILE
 if [ $? -eq 0 ]; then
     echo "Compiler is C++11 compliant"
 else
     echo "Warning: Compiler is NOT C++11 compliant"
 fi
+rm -f $CPPFILE $OBJFILE
 
 # operating system
 echo "--"


### PR DESCRIPTION
Some of the module dependencies for the Management and Alerts UI must be built natively on the host.  This requires a C/C++ compiler.  In addition, some of the dependencies require a C++11 compliant compiler.  This is causing problems for users who attempt to build Metron on a system with an older version of GCC, like CentOS 6.

Not having a C++11 compliant compiler can cause some non-obvious error messages when the build fails.  This adds a version check for GCC and also a C++11 compliance check.  The compiler itself must be on the user's PATH, which is what the Node modules also require.

If the compiler is C++11 compliant, you will see the following.
```
--
g++
g++ (GCC) 5.3.1 20160406 (Red Hat 5.3.1-6)
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

--
Compiler is C++11 compliant
```

If the compiler is NOT C++11 compliant, you will see the following.
```
--
g++
g++ (GCC) 4.4.7 20120313 (Red Hat 4.4.7-18)
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

--
cc1plus: error: unrecognized command line option "-std=c++11"
Warning: Compiler is NOT C++11 compliant
```

This was tested manually on Mac OS X, CentOS 6, CentOS 7, and Ubuntu Trusty 64.


## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
