### PR TITLE
METRON-1348 Metron Service Checks Use Wrong Hostname

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/alerts_ui_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/alerts_ui_commands.py
@@ -66,7 +66,7 @@ class AlertsUICommands:
         """
         Logger.info('Status check the Alerts UI')
         metron_service.check_http(
-          self.__params.hostname,
+          self.__params.metron_alerts_ui_host,
           self.__params.metron_alerts_ui_port,
           self.__params.metron_user)
 
@@ -77,7 +77,7 @@ class AlertsUICommands:
         """
         Logger.info('Checking connectivity to Alerts UI')
         metron_service.check_http(
-          self.__params.hostname,
+          self.__params.metron_alerts_ui_host,
           self.__params.metron_alerts_ui_port,
           self.__params.metron_user)
 

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/management_ui_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/management_ui_commands.py
@@ -68,7 +68,7 @@ class ManagementUICommands:
         """
         Logger.info('Status check the Management UI')
         metron_service.check_http(
-          self.__params.hostname,
+          self.__params.metron_management_ui_host,
           self.__params.metron_management_ui_port,
           self.__params.metron_user)
 
@@ -79,7 +79,7 @@ class ManagementUICommands:
         """
         Logger.info('Checking connectivity to Management UI')
         metron_service.check_http(
-          self.__params.hostname,
+          self.__params.metron_management_ui_host,
           self.__params.metron_management_ui_port,
           self.__params.metron_user)
 

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/params_linux.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/params_linux.py
@@ -49,8 +49,11 @@ metron_user = status_params.metron_user
 metron_group = config['configurations']['metron-env']['metron_group']
 metron_log_dir = config['configurations']['metron-env']['metron_log_dir']
 metron_pid_dir = config['configurations']['metron-env']['metron_pid_dir']
+
 metron_rest_port = status_params.metron_rest_port
+metron_management_ui_host = status_params.metron_management_ui_host
 metron_management_ui_port = status_params.metron_management_ui_port
+metron_alerts_ui_host = status_params.metron_alerts_ui_host
 metron_alerts_ui_port = status_params.metron_alerts_ui_port
 metron_jvm_flags = config['configurations']['metron-rest-env']['metron_jvm_flags']
 metron_spring_profiles_active = config['configurations']['metron-rest-env']['metron_spring_profiles_active']
@@ -237,7 +240,7 @@ if security_enabled:
     nimbus_seeds = config['configurations']['storm-site']['nimbus.seeds']
 
 # Management UI
-metron_rest_host = default("/clusterHostInfo/metron_rest_hosts", ['localhost'])[0]
+metron_rest_host = default("/clusterHostInfo/metron_rest_hosts", [hostname])[0]
 
 # REST
 metron_rest_pid_dir = config['configurations']['metron-rest-env']['metron_rest_pid_dir']

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/status_params.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/status_params.py
@@ -25,6 +25,7 @@ from resource_management.libraries.functions.version import format_stack_version
 
 config = Script.get_config()
 
+hostname = config['hostname']
 metron_user = config['configurations']['metron-env']['metron_user']
 metron_home = config['configurations']['metron-env']['metron_home']
 metron_zookeeper_config_dir = config['configurations']['metron-env']['metron_zookeeper_config_dir']
@@ -80,9 +81,13 @@ elasticsearch_template_installed_flag_file = metron_zookeeper_config_path + '/..
 # REST
 metron_rest_port = config['configurations']['metron-rest-env']['metron_rest_port']
 
-# UI
-metron_management_ui_port = config['configurations']['metron-management-ui-env']['metron_management_ui_port']
+# Alerts UI
+metron_alerts_ui_host = default("/clusterHostInfo/metron_alerts_ui_hosts", [hostname])[0]
 metron_alerts_ui_port = config['configurations']['metron-alerts-ui-env']['metron_alerts_ui_port']
+
+# Management UI
+metron_management_ui_host = default("/clusterHostInfo/metron_management_ui_hosts", [hostname])[0]
+metron_management_ui_port = config['configurations']['metron-management-ui-env']['metron_management_ui_port']
 
 # Storm
 storm_rest_addr = config['configurations']['metron-env']['storm_rest_addr']
@@ -93,7 +98,7 @@ zeppelin_server_url = config['configurations']['metron-env']['zeppelin_server_ur
 # Security
 stack_version_unformatted = str(config['hostLevelParams']['stack_version'])
 stack_version_formatted = format_stack_version(stack_version_unformatted)
-hostname = config['hostname']
+
 security_enabled = config['configurations']['cluster-env']['security_enabled']
 kinit_path_local = get_kinit_path(default('/configurations/kerberos-env/executable_search_paths', None))
 tmp_dir = Script.get_tmp_dir()

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/rest_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/rest_commands.py
@@ -175,7 +175,7 @@ class RestCommands:
         """
         Logger.info('Status check the REST application')
         metron_service.check_http(
-            self.__params.hostname,
+            self.__params.metron_rest_host,
             self.__params.metron_rest_port,
             self.__params.metron_user)
 
@@ -186,7 +186,7 @@ class RestCommands:
         """
         Logger.info('Checking connectivity to REST application')
         metron_service.check_http(
-            self.__params.hostname,
+            self.__params.metron_rest_host,
             self.__params.metron_rest_port,
             self.__params.metron_user)
 


### PR DESCRIPTION
The Metron service check can often use the incorrect hostname when checking the Alerts UI, Management UI, and REST services.  This results in a failed service check, even when the services are running successfully.

Ambari can run the service check on any node in the cluster, not just the node the service is actually running on.  The service check code currently uses the hostname on which the service check is running.  If the service is not actually installed on that host, the service check will incorrectly fail.

The service check code was updated to find the hostname where the service is installed and use that hostname.  

## Testing

This change was tested by deploying Metron on Full Dev and running Metron > Service Check in Ambari.  The service check should complete successfully when the cluster is healthy.  The fix has also been tested on a multi-node cluster in the same manner.

## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
