### PR TITLE
METRON-1349 Full Dev Builds Metron Twice

### DIFF
--- a/metron-deployment/playbooks/ambari_install.yml
+++ b/metron-deployment/playbooks/ambari_install.yml
@@ -29,7 +29,6 @@
   tags:
     - packer
 
-
 - hosts: ambari_*
   become: true
   roles:
@@ -60,18 +59,3 @@
     - role: metron-rpms
   tags:
     - metron-deploy
-
-- hosts: ambari_master
-  become: true
-  roles:
-    - role: ambari_config
-  tags:
-    - hdp-install
-    - hdp-deploy
-
-- hosts: ambari_master
-  become: true
-  roles:
-    - role: load_web_templates
-  tags:
-    - load_templates

--- a/metron-deployment/playbooks/metron_build.yml
+++ b/metron-deployment/playbooks/metron_build.yml
@@ -19,3 +19,5 @@
   become: false
   roles:
     - role: metron-builder
+  tags:
+    - build

--- a/metron-deployment/playbooks/metron_install.yml
+++ b/metron-deployment/playbooks/metron_install.yml
@@ -15,13 +15,6 @@
 #  limitations under the License.
 #
 ---
-- hosts: metron
-  become: true
-  roles:
-    - { role: ambari_slave }
-    - { role: metron-builder, tags: ['build'] }
-    - { role: metron-rpms }
-
 - hosts: ec2
   become: true
   tasks:
@@ -35,6 +28,24 @@
     - include_vars: ../inventory/full-dev-platform/group_vars/all
   tags:
     - packer
+
+#
+# start installation of components in Ambari
+#
+- hosts: ambari_master
+  become: true
+  roles:
+    - role: ambari_config
+  tags:
+    - hdp-install
+    - hdp-deploy
+
+- hosts: ambari_master
+  become: true
+  roles:
+    - role: load_web_templates
+  tags:
+    - load_templates
 
 - hosts: pcap_server
   become: true

--- a/metron-deployment/roles/ambari_config/tasks/main.yml
+++ b/metron-deployment/roles/ambari_config/tasks/main.yml
@@ -26,16 +26,15 @@
   retries: 5
   delay: 10
 
-- name : check if ambari-server is up on {{ ambari_host }}:{{ambari_port}}
+- name : Wait for Ambari to start; http://{{ ambari_host }}:{{ ambari_port }}
   wait_for :
     host: "{{ ambari_host }}"
     port: "{{ ambari_port }}"
-    delay: 120
-    timeout: 300
+    timeout: 600
 
-- name: Deploy cluster with Ambari; http://{{ groups.ambari_master[0] }}:{{ ambari_port }}
+- name: Deploy cluster with Ambari; http://{{ ambari_host }}:{{ ambari_port }}
   ambari_cluster_state:
-    host: "{{ groups.ambari_master[0] }}"
+    host: "{{ ambari_host }}"
     port: "{{ ambari_port }}"
     username: "{{ ambari_user }}"
     password: "{{ ambari_password }}"
@@ -45,5 +44,3 @@
     configurations: "{{ configurations }}"
     wait_for_complete: True
     blueprint_var: "{{ blueprint }}"
-
-

--- a/metron-deployment/roles/ambari_master/tasks/main.yml
+++ b/metron-deployment/roles/ambari_master/tasks/main.yml
@@ -19,8 +19,6 @@
 - name: Install ambari server
   yum:
     name: ambari-server
-    state: present
-    update_cache: yes
   register: result
   until: result.rc == 0
   retries: 5
@@ -52,4 +50,3 @@
   service:
     name: ambari-server
     state: restarted
-

--- a/metron-deployment/roles/epel/tasks/main.yml
+++ b/metron-deployment/roles/epel/tasks/main.yml
@@ -16,6 +16,4 @@
 #
 ---
 - name: Install EPEL repository
-  yum: name=epel-release update_cache=yes
-
-
+  yum: name=epel-release


### PR DESCRIPTION
Removing the "Quick Dev" environment in #852 had an unintended side effect.  It caused Metron to be built twice during the Full Dev deployment process.  Unless you prefer a double-build for thoroughness, this can be annoying.

## Testing

Deploy Full Dev and ensure that Metron is not build twice.  Once Metron is deployed, login to Ambari and run the Metron Service Check.  If the service check passes, we've done a solid.

More detailed steps might look like this.

1. Clear out the old logs and launch Full Dev.
    ```
    cd metron-deployment/vagrant/full-dev-platform
    rm ansible.log
    vagrant up
    ```

2. Ensure that Metron was built only once.  There should be only one record each for "Build Metron" and "Build Metron RPMs".
    ```
    $ grep "Build Metron" ansible.log
    2017-12-13 10:06:56,040 p=4688 u=nallen |  TASK [metron-builder : Build Metron] *******************************************
    2017-12-13 10:12:19,838 p=4688 u=nallen |  TASK [metron-builder : Build Metron RPMs] **************************************
    ```

