### PR TITLE
METRON-1374 Script Metron Release Validation

### DIFF
--- a/build_utils/release-utils/metron-rc-check
+++ b/build_utils/release-utils/metron-rc-check
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+shopt -s nocasematch
+
+METRON_DIST="https://dist.apache.org/repos/dist/dev/metron/"
+
+if [ "$#" -ne 3 ]; then
+    echo "error: missing arguments"
+    echo "$0 [METRON VERSION][RC#][METRON BRO PLUGIN VERSION]"
+    exit 1
+else
+    if [[ "$1" =~ ^[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2} ]]; then
+       METRON_VERSION="$1"
+    else
+       echo "[ERROR] $1 may not be a valid version number"
+       exit 1
+    fi
+    if [[ "$2" =~ ^RC[0-9]+ ]]; then
+      RC=$(echo "$2" | tr '[:upper:]' '[:lower:]')
+      UPPER_RC=$(echo "$2" | tr '[:lower:]' '[:upper:]')
+    elif [[ "$2" =~ ^[0-9]+ ]]; then
+      RC=rc"$2"
+      UPPER_RC=RC"$2"
+    else
+      echo "[ERROR] invalid RC, valid is RC# or just #"
+      exit 1
+    fi
+    if [[ "$3" =~ ^[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2} ]]; then
+       BRO_VERSION="$3"
+    else
+       echo "[ERROR] $3 may not be a valid version number"
+       exit 1
+    fi
+fi
+
+echo "Metron Version $METRON_VERSION"
+echo "Release Candidate $RC"
+
+METRON_RC_DIST="$METRON_DIST$METRON_VERSION-$UPPER_RC"
+echo "Metron RC Distribution Root is $METRON_RC_DIST"
+
+# working directory
+WORK="~/tmp/metron-$METRON_VERSION-$RC"
+
+# handle tilde expansion
+WORK="${WORK/#\~/$HOME}"
+
+# warn the user if the working directory exists
+if [ -d "$WORK" ]; then
+  echo "[ERROR] Directory $WORK exists, please rename it and start over"
+  exit 1
+fi
+
+if [ ! -d "$WORK" ]; then
+  mkdir -p "$WORK"
+fi
+echo "Working directory $WORK"
+
+KEYS="$METRON_RC_DIST/KEYS"
+METRON_ASSEMBLY="$METRON_RC_DIST/apache-metron-$METRON_VERSION-$RC.tar.gz"
+METRON_ASSEMBLY_SIG="$METRON_ASSEMBLY.asc"
+METRON_KAFKA_BRO_ASSEMBLY="$METRON_RC_DIST/apache-metron-bro-plugin-kafka_$BRO_VERSION.tar.gz"
+METRON_KAFKA_BRO_ASSEMBLY_ASC="$METRON_KAFKA_BRO_ASSEMBLY.asc"
+
+echo "Downloading $KEYS"
+if ! wget -P "$WORK" "$KEYS" ; then
+  echo "[ERROR] Failed to download $KEYS"
+  exit 1
+fi
+
+echo "Downloading $METRON_ASSEMBLY"
+if ! wget -P "$WORK" "$METRON_ASSEMBLY" ; then
+  echo "[ERROR] Failed to download $METRON_ASSEMBLY"
+  exit 1
+fi
+echo "Downloading $METRON_ASSEMBLY_SIG"
+if ! wget -P "$WORK" "$METRON_ASSEMBLY_SIG" ; then
+  echo "[ERROR] Failed to download $METRON_ASSEMBLY_SIG"
+  exit 1
+fi
+echo "Downloading $METRON_KAFKA_BRO_ASSEMBLY"
+if ! wget -P "$WORK" "$METRON_KAFKA_BRO_ASSEMBLY" ; then
+  echo "[ERROR] Failed to download $METRON_KAFKA_BRO_ASSEMBLY"
+  exit 1
+fi
+echo "Downloading $METRON_KAFKA_BRO_ASSEMBLY_ASC"
+if ! wget -P "$WORK" "$METRON_KAFKA_BRO_ASSEMBLY_ASC" ; then
+  echo "[ERROR] Failed to download $METRON_KAFKA_BRO_ASSEMBLY_ASC"
+  exit 1
+fi
+
+cd "$WORK" || exit 1
+echo "importing metron keys"
+
+if ! gpg --import KEYS ; then
+  echo "[ERROR] failed to import KEYS"
+  exit 1
+fi
+
+echo "Verifying Metron Assembly"
+if ! gpg --verify ./"apache-metron-$METRON_VERSION-$RC.tar.gz.asc" "apache-metron-$METRON_VERSION-$RC.tar.gz" ; then
+  echo "[ERROR] failed to verify Metron Assembly"
+  exit 1
+fi
+
+echo "Verifying Bro Kafka Plugin Assembly"
+if ! gpg --verify ./"apache-metron-bro-plugin-kafka_$BRO_VERSION.tar.gz.asc" "apache-metron-bro-plugin-kafka_$BRO_VERSION.tar.gz" ; then
+  echo "[ERROR] failed to verify Bro Kafka Plugin Assembly"
+  exit 1
+fi
+
+echo "Unpacking Assemblies"
+if ! tar -xzf "apache-metron-$METRON_VERSION-$RC.tar.gz" ; then
+  echo "[ERROR] failed to unpack Metron Assembly"
+  exit 1
+fi
+
+if ! tar -xzf "apache-metron-bro-plugin-kafka_$BRO_VERSION.tar.gz" ; then
+  echo "[ERROR] failed to unpack  Bro Kafka Plugin Assembly"
+  exit 1
+fi
+
+echo ""
+echo ""
+read -p "  run test suite [install, unit tests, integration tests, ui tests, licenses, rpm build]? [yN] " -n 1 -r
+echo
+DID_BUILD=0
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+  cd "apache-metron-$METRON_VERSION-$RC" || exit 1
+  if ! mvn -q -T 2C -DskipTests clean install  ; then
+    echo "[ERROR] failed to mvn install metron"
+    exit 1
+  fi
+  if ! mvn -q -T 2C surefire:test@unit-tests ; then
+    echo "[ERROR] failed unit tests"
+    exit 1
+  fi
+  if ! mvn -q surefire:test@integration-tests ; then
+    echo "[ERROR] failed integration tests"
+    exit 1
+  fi
+  if ! mvn -q test --projects metron-interface/metron-config  ; then
+    echo "[ERROR] failed metron-config tests"
+    exit 1
+  fi
+  build_utils/verify_licenses.sh | tee ../build-lic.log
+  cd metron-deployment || exit 1
+  if ! mvn -q package -DskipTests -P build-rpms ; then
+    echo "[ERROR] failed to build rpm"
+    exit 1
+  fi
+  cd .. || exit 1
+  DID_BUILD=1
+fi
+
+#ask if build test vagrant METRON
+
+# run tests?
+echo ""
+echo ""
+read -p "  run vagrant full_dev? [yN] " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+  cd "$WORK/apache-metron-$METRON_VERSION-$RC/metron-deployment/vagrant/full-dev-platform" || exit 1
+  if [[ ${DID_BUILD} -ne 1 ]]; then
+    vagrant up
+  else
+    vagrant --ansible-skip-tags="build,sensors,quick-dev" up
+  fi
+fi


### PR DESCRIPTION
This PR introduces a script that automates the documented process for validation of metron release candidates.

It will:

Download the files
Install the keys
Validate the signatures
Build and test metron + rpms
Start full dev


to test ( with RC2 )

```bash
%> cd build_utils/release-utils
%> bash ./metron-rc-check 0.4.2 RC2 0.1.0

where 0.4.2 is the release number, RC2 is the RC, 0.1.0 is the bro plugin version

When asked, enter yes (y) for testing and full dev



### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?