### PR TITLE
METRON-1396: Fix .gitignore files to not ignore themselves

### DIFF
--- a/metron-deployment/packaging/docker/deb-docker/.gitignore
+++ b/metron-deployment/packaging/docker/deb-docker/.gitignore
@@ -1,2 +1,3 @@
 .*
 target
+!/.gitignore

--- a/metron-deployment/packaging/docker/rpm-docker/.gitignore
+++ b/metron-deployment/packaging/docker/rpm-docker/.gitignore
@@ -4,3 +4,4 @@ RPMS/
 SOURCES/
 SRPMS/
 .*
+!/.gitignore


### PR DESCRIPTION
## Contributor Comments
The relevant files are already in git, it's a trivial fix to just add the reinclusion. See https://git-scm.com/docs/gitignore, under `Pattern Format`.

The files are in git already, so it's pretty benign, but I suspect weirdness could occur, and this is more correct. And also it just bothered me.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.

