### PR TITLE
METRON-1432 JDK Install Fails on Ubuntu Development Environment

### DIFF
--- a/metron-deployment/ansible/roles/java_jdk/tasks/install_jdk_centos.yml
+++ b/metron-deployment/ansible/roles/java_jdk/tasks/install_jdk_centos.yml
@@ -15,10 +15,20 @@
 #  limitations under the License.
 #
 ---
-- include: install_jdk_centos.yml
-  static: no
-  when: ansible_distribution == "CentOS"
+- name: Check for java at "{{ java_home }}"
+  stat: path="{{ java_home }}"
+  register: jdk_dir
 
-- include: install_jdk_ubuntu.yml
-  static: no
-  when: ansible_distribution == "Ubuntu"
+- name: Alternatives link for java
+  alternatives: name={{ item.name }} link={{ item.link }}  path={{ item.path }}
+  with_items:
+    - { name: java, link: /usr/bin/java, path: "{{ java_home }}/bin/java" }
+    - { name: jar, link: /usr/bin/jar, path: "{{ java_home }}/bin/jar" }
+  when: jdk_dir.stat.exists
+
+- name: Install openjdk
+  yum: name={{item}}
+  with_items:
+    - java-1.8.0-openjdk
+    - java-1.8.0-openjdk-devel
+  when: not jdk_dir.stat.exists

--- a/metron-deployment/ansible/roles/java_jdk/tasks/install_jdk_ubuntu.yml
+++ b/metron-deployment/ansible/roles/java_jdk/tasks/install_jdk_ubuntu.yml
@@ -15,10 +15,17 @@
 #  limitations under the License.
 #
 ---
-- include: install_jdk_centos.yml
-  static: no
-  when: ansible_distribution == "CentOS"
+- name: Check for java at "{{ java_home }}"
+  stat: path="{{ java_home }}"
+  register: jdk_dir
 
-- include: install_jdk_ubuntu.yml
-  static: no
-  when: ansible_distribution == "Ubuntu"
+- name: Install openjdk repository
+  shell: add-apt-repository ppa:openjdk-r/ppa
+  when: not jdk_dir.stat.exists
+
+- name: Update package cache
+  apt: update_cache=yes
+
+- name: Install openjdk
+  apt: name=openjdk-8-jdk
+  when: not jdk_dir.stat.exists


### PR DESCRIPTION
The Ansible role used to install the JDK does not work correctly on Ubuntu.  This fixes the problem and ensures that the JDK can be installed on either Ubuntu or CentOS.

## Testing

1. Launch the Ubuntu development environment. 
    * Run the Metron Service Check
    * Ensure data is visible within the Alerts UI

1. Launch the CentOS development environment.
    * Run the Metron Service Check
    * Ensure data is visible within the Alerts UI

## Pull Request Checklist
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

