### PR TITLE
METRON-1433: Only emit debugging timing fields in enrichment when debugging is turned on

### DIFF
--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/EnrichmentJoinBolt.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/EnrichmentJoinBolt.java
@@ -86,7 +86,9 @@ public class EnrichmentJoinBolt extends JoinBolt<JSONObject> {
     for(Object o : emptyKeys) {
       message.remove(o);
     }
-    message.put(getClass().getSimpleName().toLowerCase() + ".joiner.ts", "" + System.currentTimeMillis());
+    if(LOG.isDebugEnabled()) {
+      message.put(getClass().getSimpleName().toLowerCase() + ".joiner.ts", "" + System.currentTimeMillis());
+    }
     return  message;
   }
 

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/EnrichmentSplitterBolt.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/EnrichmentSplitterBolt.java
@@ -93,13 +93,17 @@ public class EnrichmentSplitterBolt extends SplitBolt<JSONObject> {
       byte[] data = tuple.getBinary(0);
       try {
         message = (JSONObject) parser.parse(new String(data, "UTF8"));
-        message.put(getClass().getSimpleName().toLowerCase() + ".splitter.begin.ts", "" + System.currentTimeMillis());
+        if(LOG.isDebugEnabled()) {
+          message.put(getClass().getSimpleName().toLowerCase() + ".splitter.begin.ts", "" + System.currentTimeMillis());
+        }
       } catch (ParseException | UnsupportedEncodingException e) {
         e.printStackTrace();
       }
     } else {
       message = (JSONObject) tuple.getValueByField(messageFieldName);
-      message.put(getClass().getSimpleName().toLowerCase() + ".splitter.begin.ts", "" + System.currentTimeMillis());
+      if(LOG.isDebugEnabled()) {
+        message.put(getClass().getSimpleName().toLowerCase() + ".splitter.begin.ts", "" + System.currentTimeMillis());
+      }
     }
     return message;
   }
@@ -137,7 +141,9 @@ public class EnrichmentSplitterBolt extends SplitBolt<JSONObject> {
       }
       streamMessageMap.put(enrichmentType, enrichmentObject);
     }
-    message.put(getClass().getSimpleName().toLowerCase() + ".splitter.end.ts", "" + System.currentTimeMillis());
+    if(LOG.isDebugEnabled()) {
+      message.put(getClass().getSimpleName().toLowerCase() + ".splitter.end.ts", "" + System.currentTimeMillis());
+    }
     return streamMessageMap;
   }
 

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/GenericEnrichmentBolt.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/GenericEnrichmentBolt.java
@@ -187,7 +187,9 @@ public class GenericEnrichmentBolt extends ConfiguredEnrichmentBolt {
     String subGroup = "";
 
     JSONObject enrichedMessage = new JSONObject();
-    enrichedMessage.put("adapter." + adapter.getClass().getSimpleName().toLowerCase() + ".begin.ts", "" + System.currentTimeMillis());
+    if(LOG.isDebugEnabled()) {
+      enrichedMessage.put("adapter." + adapter.getClass().getSimpleName().toLowerCase() + ".begin.ts", "" + System.currentTimeMillis());
+    }
     try {
       if (rawMessage == null || rawMessage.isEmpty())
         throw new Exception("Could not parse binary stream to JSON");
@@ -257,8 +259,9 @@ public class GenericEnrichmentBolt extends ConfiguredEnrichmentBolt {
           }
         }
       }
-
-      enrichedMessage.put("adapter." + adapter.getClass().getSimpleName().toLowerCase() + ".end.ts", "" + System.currentTimeMillis());
+      if(LOG.isDebugEnabled()) {
+        enrichedMessage.put("adapter." + adapter.getClass().getSimpleName().toLowerCase() + ".end.ts", "" + System.currentTimeMillis());
+      }
       if (!enrichedMessage.isEmpty()) {
         collector.emit(enrichmentType, new Values(key, enrichedMessage, subGroup));
       }


### PR DESCRIPTION
## Contributor Comments
Right now we always emit performance debugging fields in the split/join bolts.  We should only do that when debug logging is turned on for `org.apache.metron.enrichment.bolt`

Test:
Spin up full-dev and ensure that `adapter.*.begin.ts` and `adapter.*.end.ts` fields do not show up unless you set debug logging for `org.apache.metron.enrichment.bolt`


## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
