### PR TITLE
METRON-1299 In MetronError tests, don't test for HostName if getHostName wouldn't work

### DIFF
--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/error/MetronErrorTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/error/MetronErrorTest.java
@@ -18,15 +18,14 @@
 package org.apache.metron.common.error;
 
 import com.google.common.collect.Sets;
-import com.google.common.primitives.Bytes;
 import org.apache.metron.common.Constants;
 import org.json.simple.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.net.InetAddress;
 import java.util.Arrays;
 
-import static org.apache.metron.common.Constants.ErrorFields.RAW_MESSAGE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -53,7 +52,14 @@ public class MetronErrorTest {
     assertEquals(Constants.ErrorType.PARSER_ERROR.getType(), errorJSON.get(Constants.ErrorFields.ERROR_TYPE.getName()));
     assertEquals("error", errorJSON.get(Constants.SENSOR_TYPE));
     assertEquals("sensorType", errorJSON.get(Constants.ErrorFields.FAILED_SENSOR_TYPE.getName()));
-    assertTrue(((String) errorJSON.get(Constants.ErrorFields.HOSTNAME.getName())).length() > 0);
+
+    try {
+      String hostName = InetAddress.getLocalHost().getHostName();
+      assertTrue(((String) errorJSON.get(Constants.ErrorFields.HOSTNAME.getName())).length() > 0);
+      assertEquals(hostName, (String) errorJSON.get(Constants.ErrorFields.HOSTNAME.getName()));
+    } catch (Exception e) {
+      // something wrong with getting hosthame on this machine
+    }
     assertTrue(((long) errorJSON.get(Constants.ErrorFields.TIMESTAMP.getName())) > 0);
   }
 

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/error/MetronErrorTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/error/MetronErrorTest.java
@@ -18,12 +18,14 @@
 package org.apache.metron.common.error;
 
 import com.google.common.collect.Sets;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.metron.common.Constants;
 import org.json.simple.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
@@ -53,12 +55,16 @@ public class MetronErrorTest {
     assertEquals("error", errorJSON.get(Constants.SENSOR_TYPE));
     assertEquals("sensorType", errorJSON.get(Constants.ErrorFields.FAILED_SENSOR_TYPE.getName()));
 
+    String hostName = null;
     try {
-      String hostName = InetAddress.getLocalHost().getHostName();
+      hostName = InetAddress.getLocalHost().getHostName();
+    } catch (UnknownHostException uhe) {
+      // unable to get the hostname on this machine, don't test it
+    }
+
+    if (!StringUtils.isEmpty(hostName)) {
       assertTrue(((String) errorJSON.get(Constants.ErrorFields.HOSTNAME.getName())).length() > 0);
       assertEquals(hostName, (String) errorJSON.get(Constants.ErrorFields.HOSTNAME.getName()));
-    } catch (Exception e) {
-      // something wrong with getting hosthame on this machine
     }
     assertTrue(((long) errorJSON.get(Constants.ErrorFields.TIMESTAMP.getName())) > 0);
   }


### PR DESCRIPTION
MetronError ignores exceptions from InetAddress.getLocalHost().getHostName() and leaves the field unset.

The unit test however assumes it would be set, and someone has logged a jira on this, since it makes the build fail.

Changed the test so that it only verifies the hostName if it would have worked.

### Testing
- Code review
- Tests Pass

> no non-test changes in pr

```java
 private void addHostname(JSONObject errorMessage) {
    try {
      errorMessage.put(ErrorFields.HOSTNAME.getName(), InetAddress.getLocalHost().getHostName());
    } catch (UnknownHostException ex) {
      // Leave the hostname field off if it cannot be found
    }
  }
```

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
