### PR TITLE
METRON-1443 Missing Critical MPack Install Instruction for Ubuntu

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/README.md
+++ b/metron-deployment/packaging/ambari/metron-mpack/README.md
@@ -28,6 +28,20 @@ This allows you to easily install Metron using a simple, guided process.  This a
 
 * A [Node.js](https://nodejs.org/en/download/package-manager/) repository installed on the host running the Management and Alarm UI.
 
+* When installing on Ubuntu the Elasticsearch repository must be defined manually. This is NOT defined by the Mpack like it is on CentOS.  This is an open bug that needs addressed in the Mpack.  See the [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/deb.html) documentation for more specific instructions. 
+  ```
+  $ cat >/etc/apt/sources.list.d/elasticsearch.list << EOL
+  deb https://packages.elastic.co/curator/5/debian stable main
+  deb https://artifacts.elastic.co/packages/5.x/apt stable main
+  EOL
+
+  $ wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
+
+  $ apt-get update
+  ```
+
+
+
 ### Quick Start
 
 1. Build the Metron MPack. Execute the following command from the project's root directory.


### PR DESCRIPTION
When installing Elasticsearch with the MPack on Ubuntu, you must manually install the Elasticsearch repositories.  The Mpack itself does not do this, like it does on CentOS. 

When the development environment on Ubuntu is spun-up this step is performed within Ansible as a prerequisite to the Mpack install.  Until this can be fixed so that it matches what happens on CentOS, this needs to be at least documented.

I should have documented this in #903 , but did not do so.  Oops.