### PR TITLE
METRON-1446: Fix openjdk issue with Ubuntu

### DIFF
--- a/metron-deployment/ansible/roles/java_jdk/tasks/install_jdk_ubuntu.yml
+++ b/metron-deployment/ansible/roles/java_jdk/tasks/install_jdk_ubuntu.yml
@@ -20,7 +20,7 @@
   register: jdk_dir
 
 - name: Install openjdk repository
-  shell: add-apt-repository ppa:openjdk-r/ppa
+  shell: add-apt-repository ppa:openjdk-r/ppa -y
   when: not jdk_dir.stat.exists
 
 - name: Update package cache


### PR DESCRIPTION
## Contributor Comments
https://issues.apache.org/jira/browse/METRON-1446

Spin up full dev for Ubuntu. It should run successfully all the way through, but specifically it should make it past "TASK [java_jdk : Install openjdk repository]"

**Note**, I had issues with Vagrant 1.8.1 that caused trouble with outdated Hashicorp URLs that will give you a 404. Vagrant 2.0.2 worked fine.


## Pull Request Checklist

In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
