### PR TITLE
METRON-1447 Heap Size Not Set Correctly by MPack for ES 5.x

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/5.6.2/configuration/elastic-jvm-options.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/5.6.2/configuration/elastic-jvm-options.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<configuration>
+    <property>
+        <name>heap_size</name>
+        <value>512m</value>
+        <description>JVM heap size</description>
+    </property>
+    <property>
+        <name>content</name>
+        <description>The jinja template for the Elasticsearch JVM options file.</description>
+        <value>
+## JVM configuration
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+-Xms{{heap_size}}
+-Xmx{{heap_size}}
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+-XX:+UseConcMarkSweepGC
+-XX:CMSInitiatingOccupancyFraction=75
+-XX:+UseCMSInitiatingOccupancyOnly
+
+## optimizations
+
+# pre-touch memory pages used by the JVM during initialization
+-XX:+AlwaysPreTouch
+
+## basic
+
+# force the server VM (remove on 32-bit client JVMs)
+-server
+
+# explicitly set the stack size (reduce to 320k on 32-bit client JVMs)
+-Xss1m
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+-Djna.nosys=true
+
+# use old-style file permissions on JDK9
+-Djdk.io.permissionsUseCanonicalPath=true
+
+# flags to configure Netty
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+-Dio.netty.recycler.maxCapacityPerThread=0
+
+# log4j 2
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+-Dlog4j.skipJansi=true
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps
+# ensure the directory exists and has sufficient space
+#-XX:HeapDumpPath=${heap.dump.path}
+
+## GC logging
+
+#-XX:+PrintGCDetails
+#-XX:+PrintGCTimeStamps
+#-XX:+PrintGCDateStamps
+#-XX:+PrintClassHistogram
+#-XX:+PrintTenuringDistribution
+#-XX:+PrintGCApplicationStoppedTime
+
+# log GC status to a file with time stamps
+# ensure the directory exists
+#-Xloggc:${loggc}
+
+# By default, the GC log file will not rotate.
+# By uncommenting the lines below, the GC log file
+# will be rotated every 128MB at most 32 times.
+#-XX:+UseGCLogFileRotation
+#-XX:NumberOfGCLogFiles=32
+#-XX:GCLogFileSize=128M
+
+# Elasticsearch 5.0.0 will throw an exception on unquoted field names in JSON.
+# If documents were already indexed with unquoted fields in a previous version
+# of Elasticsearch, some operations may throw errors.
+#
+# WARNING: This option will be removed in Elasticsearch 6.0.0 and is provided
+# only for migration purposes.
+#-Delasticsearch.json.allow_unquoted_field_names=true
+        </value>
+    </property>
+</configuration>

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/5.6.2/configuration/elastic-sysconfig.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/5.6.2/configuration/elastic-sysconfig.xml
@@ -40,11 +40,6 @@
         <description>Elasticsearch Configuration Directory</description>
     </property>
     <property>
-        <name>heap_size</name>
-        <value>512m</value>
-        <description>Heap size</description>
-    </property>
-    <property>
         <name>max_open_files</name>
         <value>65536</value>
         <description>Maximum number of open files</description>
@@ -92,11 +87,8 @@ PID_DIR={{pid_dir}}
 # JAVA_HOME must be provided here for OS that use systemd service launch
 JAVA_HOME={{java64_home}}
 
-# Additional Java OPTS
-ES_JAVA_OPTS="-verbose:gc -Xloggc:{{log_dir}}/elasticsearch_gc.log -XX:-CMSConcurrentMTEnabled \
--XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintGCTimeStamps \
--XX:ErrorFile={{log_dir}}/elasticsearch_err.log -XX:ParallelGCThreads=8 \
--Xms{{heap_size}} -Xmx{{heap_size}}"
+# Additional Java options - now preferential to use 'jvm.options' file instead
+ES_JAVA_OPTS=""
 
 # https://www.elastic.co/guide/en/elasticsearch/reference/5.6/_memory_lock_check.html
 MAX_LOCKED_MEMORY=unlimited

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/5.6.2/metainfo.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/5.6.2/metainfo.xml
@@ -83,6 +83,7 @@
                 <config-type>elastic-site</config-type>
                 <config-type>elastic-sysconfig</config-type>
                 <config-type>elastic-systemd</config-type>
+                <config-type>elastic-jvm-options</config-type>
             </configuration-dependencies>
             <restartRequiredAfterChange>true</restartRequiredAfterChange>
             <quickLinksConfigurations>

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/5.6.2/package/scripts/elastic_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/5.6.2/package/scripts/elastic_commands.py
@@ -190,6 +190,17 @@ def create_elastic_pam_limits(params):
          owner="root",
          group="root")
 
+def create_elastic_jvm_options(params):
+    """
+    Defines the jvm.options file used to specify JVM options.
+    """
+    path = "{0}/jvm.options".format(params.conf_dir)
+    Logger.info("Creating Elasticsearch JVM Options; file={0}".format(path))
+    File(path,
+         content=InlineTemplate(params.jvm_options_template),
+         owner=params.elastic_user,
+         group=params.elastic_group)
+
 def get_data_directories(params):
     """
     Returns the directories to use for storing Elasticsearch data.
@@ -225,6 +236,7 @@ def configure_master():
     create_elastic_site(params,  "elasticsearch.master.yaml.j2")
     create_elastic_config(params)
     create_elastic_pam_limits(params)
+    create_elastic_jvm_options(params)
     if is_systemd_running():
         configure_systemd(params)
 
@@ -249,5 +261,6 @@ def configure_slave():
     create_elastic_site(params, "elasticsearch.slave.yaml.j2")
     create_elastic_config(params)
     create_elastic_pam_limits(params)
+    create_elastic_jvm_options(params)
     if is_systemd_running():
         configure_systemd(params)

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/5.6.2/package/scripts/params.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/5.6.2/package/scripts/params.py
@@ -103,3 +103,6 @@ systemd_parent_dir = '/etc/systemd/system/'
 systemd_elasticsearch_dir = systemd_parent_dir + 'elasticsearch.service.d/'
 systemd_override_file = systemd_elasticsearch_dir + 'override.conf'
 systemd_override_template = config['configurations']['elastic-systemd']['content']
+
+heap_size = config['configurations']['elastic-jvm-options']['heap_size']
+jvm_options_template = config['configurations']['elastic-jvm-options']['content']


### PR DESCRIPTION
The preferred way in which the heap size and other JVM options are set changed between ES 2.x and ES 5.x.  The project upgraded to ES 5.x as part of #840 , but the way the heap size is set by the Mpack was not changed.

This resulted in the heap size for Elasticsearch to be set incorrectly.  This also allows Elasticsearch to use up to 2G of heap when launched in the development environments, which is too much for a constrained single VM.

## Changes

The user can set the heap size by populating the "heap_size" field under "Advanced elastic-jvm-options" in Ambari.  

Elasticsearch also exposes a large number of other settings in this file.  The entire content of the file was exposed in Ambari to allow users to also alter any other JVM options as needed.

![screen shot 2018-02-06 at 11 27 34 am](https://user-images.githubusercontent.com/2475409/35870877-c3d310ce-0b30-11e8-9b07-e77ae3b7074c.png)

## Testing

1. Launch a development environment; either Ubuntu or CentOS.  
    * Ensure that telemetry reaches the Alerts UI.
    * Run the Metron Service Check

1. Login to the node and ensure that only a single `-Xms` and `-Xmx` option was passed to the JVM when launching Elasticsearch.  Ensure these are both set to the default heap size of 512mb.

    ```
    root@node1:/etc/elasticsearch# ps -ef | grep Elastic
    root      1084 31038  0 16:09 pts/4    00:00:00 grep --color=auto Elastic
    elastic+ 30048     1 23 16:08 ?        00:00:17 /usr/jdk64/jdk1.8.0_112/bin/java -Xms512m -Xmx512m -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+AlwaysPreTouch -server -Xss1m -Djava.awt.headless=true -Dfile.encoding=UTF-8 -Djna.nosys=true -Djdk.io.permissionsUseCanonicalPath=true -Dio.netty.noUnsafe=true -Dio.netty.noKeySetOptimization=true -Dio.netty.recycler.maxCapacityPerThread=0 -Dlog4j.shutdownHookEnabled=false -Dlog4j2.disable.jmx=true -Dlog4j.skipJansi=true -XX:+HeapDumpOnOutOfMemoryError -Des.path.home=/usr/share/elasticsearch -cp /usr/share/elasticsearch/lib/* org.elasticsearch.bootstrap.Elasticsearch -d -p /var/run/elasticsearch/elasticsearch.pid -Edefault.path.logs=/var/log/elasticsearch -Edefault.path.data=/var/lib/elasticsearch/ -Edefault.path.conf=/etc/elasticsearch/
    ```

1. Alter the JVM options template, save the settings, restart Elasticsearch, and ensure that the changes are reflected in the `/etc/elasticsearch/jvm.options` file.

## Pull Request Checklist
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:
