### PR TITLE
METRON-1451: On Centos full dev, Metron Indexing shows up as stopped

### DIFF
--- a/metron-deployment/ansible/roles/ambari_config/tasks/dependencies.yml
+++ b/metron-deployment/ansible/roles/ambari_config/tasks/dependencies.yml
@@ -15,10 +15,7 @@
 #  limitations under the License.
 #
 ---
-- name: Install python-requests on CentOS
-  yum: name=python-requests
-  when: ansible_distribution == "CentOS"
-
-- name: Install python-requests on Ubuntu
-  apt: name=python-requests force=yes
-  when: ansible_distribution == "Ubuntu"
+- name: Install python-requests module
+  pip:
+    name: requests
+    version: 2.6.1


### PR DESCRIPTION
## Contributor Comments

**Root Cause**
The python-requests module introduced a VendorAlias import machinery in v2.5.2 and caused the sys.modules to break. This issue was later fixed in v2.6.1 of python-requests (see [here](https://pypi.python.org/pypi/requests)). 

The solution is to use this version of python-requests, which fixed the issue.

**Testing Done**

On CentOS 6 full dev
- Validated python-requests v2.6.1 is installed 
- Checked for the Metron Indexing service state to be up. 
- Checked ambari-agent.log and the error was not seen.

On Ubuntu 14 full dev
- Repeated the same steps as on CentOS 6 

**Verification Steps**
- Spin up full dev. 
- Verify Metron Indexing service is shown as up and running.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [ ] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
