### PR TITLE
METRON-1452 Rebase Dev Environment on Latest CentOS 6

### DIFF
--- a/metron-deployment/development/centos6/Vagrantfile
+++ b/metron-deployment/development/centos6/Vagrantfile
@@ -25,7 +25,7 @@ begin
      [ '--ansible-skip-tags', GetoptLong::OPTIONAL_ARGUMENT ]
    )
 
-   opts.quiet = TRUE
+   opts.quiet = true
 
    opts.each do |opt, arg|
      case opt
@@ -52,8 +52,8 @@ hosts = [{
 
 Vagrant.configure(2) do |config|
 
-  # all hosts built on centos 6
-  config.vm.box = "metron/centos_base"
+  # host built on centos 6
+  config.vm.box = "centos/6"
   config.ssh.insert_key = true
 
   # enable the hostmanager plugin
@@ -84,9 +84,10 @@ Vagrant.configure(2) do |config|
   # provision the host with ansible
   config.vm.provision :ansible do |ansible|
     ansible.playbook = "../../ansible/playbooks/metron_full_install.yml"
-    ansible.sudo = true
+    ansible.become = true
     ansible.tags = ansibleTags.split(",") if ansibleTags != ''
     ansible.skip_tags = ansibleSkipTags.split(",") if ansibleSkipTags != ''
     ansible.inventory_path = "ansible/inventory"
+    ansible.compatibility_mode = "1.8"
   end
 end

--- a/metron-deployment/development/centos6/Vagrantfile
+++ b/metron-deployment/development/centos6/Vagrantfile
@@ -83,7 +83,7 @@ Vagrant.configure(2) do |config|
 
   # provision the host with ansible
   config.vm.provision :ansible do |ansible|
-    ansible.playbook = "../../ansible/playbooks/metron_full_install.yml"
+    ansible.playbook = "ansible/playbook.yml"
     ansible.become = true
     ansible.tags = ansibleTags.split(",") if ansibleTags != ''
     ansible.skip_tags = ansibleSkipTags.split(",") if ansibleSkipTags != ''

--- a/metron-deployment/development/centos6/ansible/playbook.yml
+++ b/metron-deployment/development/centos6/ansible/playbook.yml
@@ -1,0 +1,23 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+---
+- hosts: all
+  roles:
+    - role: libselinux-python
+    - role: enable-swap
+
+- include: ../../../ansible/playbooks/metron_full_install.yml

--- a/metron-deployment/development/ubuntu14/Vagrantfile
+++ b/metron-deployment/development/ubuntu14/Vagrantfile
@@ -25,7 +25,7 @@ begin
      [ '--ansible-skip-tags', GetoptLong::OPTIONAL_ARGUMENT ]
    )
 
-   opts.quiet = TRUE
+   opts.quiet = true
 
    opts.each do |opt, arg|
      case opt
@@ -79,9 +79,10 @@ Vagrant.configure(2) do |config|
   # provision the host with ansible
   config.vm.provision :ansible do |ansible|
     ansible.playbook = "ansible/playbook.yml"
-    ansible.sudo = true
+    ansible.become = true
     ansible.tags = ansibleTags.split(",") if ansibleTags != ''
     ansible.skip_tags = ansibleSkipTags.split(",") if ansibleSkipTags != ''
     ansible.inventory_path = "ansible/inventory"
+    ansible.compatibility_mode = "1.8"
   end
 end


### PR DESCRIPTION
Currently the CentOS development environment (`metron-deployment/development/centos6`) is based on an image [metron/centos_base](https://app.vagrantup.com/metron/boxes/centos_base) that has not been updated in 11 months.  This image is really just a snapshot of [bento/centos6.7](https://app.vagrantup.com/bento/boxes/centos-6.7) from 11 months ago. The [bento/centos6.7](https://app.vagrantup.com/bento/boxes/centos-6.7) image has not been updated in quite some time also.

On the other hand, the [centos/6](https://app.vagrantup.com/centos/boxes/6) image was updated 23 days ago. Presumably these images are receiving critical patches for long term support.

We should base the CentOS development environment `metron-deployment/development/centos6` on the [centos/6](https://app.vagrantup.com/centos/boxes/6) image so that we can be confident that Metron continues to work on the latest patches for the CentOS 6 series.

This would match what we do for the Ubuntu development environment which is based on  [ubuntu/trusty64](https://app.vagrantup.com/ubuntu/boxes/trusty64).  This image continues to receive updates regularly despite the age of the Ubuntu 14 release.  It was updated just 3 days ago.

### Changes

1. Uses [centos/6](https://app.vagrantup.com/centos/boxes/6) as the base image for the CentOS development environment.

1. Fixes a warning from Vagrant 2.0.2 which has deprecated the use of `TRUE`.

1. Fixes a warning from Vagrant 2.0.2 that deprecates the use of `ansible.sudo`.

1. Sets a new compatibility setting which should allow the environment to work across both Vagrant 1.8.1 and 2.0.2 better.

### Testing

1. Follow the README to launch the CentOS development environment.
    * Run the Metron Service Check
    * Ensure telemetry is visible within the Alerts UI

1. Follow the README to launch the Ubuntu development environment.
    * Run the Metron Service Check
    * Ensure telemetry is visible within the Alerts UI
