### PR TITLE
METRON-1493 Unhelpful Error Message When Assignment Expressions Fail

### DIFF
--- a/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/common/shell/specials/AssignmentCommand.java
+++ b/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/common/shell/specials/AssignmentCommand.java
@@ -67,10 +67,10 @@ public class AssignmentCommand implements SpecialCommand {
     if(result.isSuccess()) {
 
       Object value = null;
-      if (result.getValue().isPresent()) {
+      if(result.getValue().isPresent()) {
         value = result.getValue().get();
 
-      } else if (result.isValueNull()) {
+      } else if(result.isValueNull()) {
         value = null;
       }
 

--- a/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/common/shell/specials/AssignmentCommand.java
+++ b/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/common/shell/specials/AssignmentCommand.java
@@ -67,10 +67,10 @@ public class AssignmentCommand implements SpecialCommand {
     if(result.isSuccess()) {
 
       Object value = null;
-      if(result.getValue().isPresent()) {
+      if (result.getValue().isPresent()) {
         value = result.getValue().get();
 
-      } else if(result.isValueNull()) {
+      } else if (result.isValueNull()) {
         value = null;
       }
 
@@ -79,7 +79,7 @@ public class AssignmentCommand implements SpecialCommand {
       return result;
 
     } else {
-      return error("Assignment expression failed");
+      return result;
     }
   }
 }

--- a/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/common/shell/specials/AssignmentCommandTest.java
+++ b/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/common/shell/specials/AssignmentCommandTest.java
@@ -149,6 +149,20 @@ public class AssignmentCommandTest {
     assertFalse(executor.getState().containsKey("x"));
   }
 
+  /**
+   * If an assignment expression fails, the error message should explain
+   * why the expression fails.
+   */
+  @Test
+  public void testErrorMessageWhenAssignmentFails() {
+    StellarResult result = command.execute("x := 0/0", executor);
+
+    // validate the result
+    assertTrue(result.isError());
+    assertTrue(result.getException().isPresent());
+    assertEquals(ArithmeticException.class, result.getException().get().getClass());
+  }
+
   @Test
   public void testAssignNull() {
     StellarResult result = command.execute("x := NULL", executor);
@@ -209,4 +223,6 @@ public class AssignmentCommandTest {
     // validate assignment
     assertEquals(4, executor.getState().get("x").getResult());
   }
+
+
 }

--- a/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/common/shell/specials/AssignmentCommandTest.java
+++ b/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/common/shell/specials/AssignmentCommandTest.java
@@ -223,6 +223,4 @@ public class AssignmentCommandTest {
     // validate assignment
     assertEquals(4, executor.getState().get("x").getResult());
   }
-
-
 }


### PR DESCRIPTION
When executing an assignment expression that fails, the error message is less than helpful.  Prior to this PR the error message looks something like this.

```
[Stellar]>>> x := 0/0
[!] Assignment expression failed
java.lang.IllegalArgumentException: Assignment expression failed
	at org.apache.metron.stellar.common.shell.StellarResult.error(StellarResult.java:115)
	at org.apache.metron.stellar.common.shell.specials.AssignmentCommand.execute(AssignmentCommand.java:82)
	at org.apache.metron.stellar.common.shell.DefaultStellarShellExecutor.execute(DefaultStellarShellExecutor.java:252)
	at org.apache.metron.stellar.common.shell.cli.StellarShell.execute(StellarShell.java:357)
	at org.jboss.aesh.console.AeshProcess.run(AeshProcess.java:53)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

This has now been fixed so that you can understand exactly what happened.

```
[Stellar]>>> x := 0/0
[!] / by zero
java.lang.ArithmeticException: / by zero
	at org.apache.metron.stellar.common.evaluators.ArithmeticEvaluator$ArithmeticEvaluatorFunctions.lambda$division$3(ArithmeticEvaluator.java:98)
	at org.apache.metron.stellar.common.evaluators.ArithmeticEvaluator.evaluate(ArithmeticEvaluator.java:39)
	at org.apache.metron.stellar.common.StellarCompiler.lambda$exitArithExpr_div$2(StellarCompiler.java:316)
	at org.apache.metron.stellar.common.StellarCompiler$Expression.apply(StellarCompiler.java:190)
	at org.apache.metron.stellar.common.BaseStellarProcessor.parse(BaseStellarProcessor.java:145)
	at org.apache.metron.stellar.common.shell.DefaultStellarShellExecutor.executeStellar(DefaultStellarShellExecutor.java:401)
	at org.apache.metron.stellar.common.shell.DefaultStellarShellExecutor.execute(DefaultStellarShellExecutor.java:257)
	at org.apache.metron.stellar.common.shell.specials.AssignmentCommand.execute(AssignmentCommand.java:66)
	at org.apache.metron.stellar.common.shell.DefaultStellarShellExecutor.execute(DefaultStellarShellExecutor.java:252)
	at org.apache.metron.stellar.common.shell.cli.StellarShell.execute(StellarShell.java:357)
	at org.jboss.aesh.console.AeshProcess.run(AeshProcess.java:53)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```

To test this, launch the REPL and try it out.