### PR TITLE
METRON-1500 Enhance 'prepare-commit' to Support Feature Branches

### DIFF
--- a/dev-utilities/committer-utils/prepare-commit
+++ b/dev-utilities/committer-utils/prepare-commit
@@ -19,9 +19,9 @@
 # not likely to change
 METRON_UPSTREAM="https://git-wip-us.apache.org/repos/asf/metron.git"
 BRO_PLUGIN_UPSTREAM="https://git-wip-us.apache.org/repos/asf/metron-bro-plugin-kafka.git"
-BASE_BRANCH=master
 CONFIG_FILE=~/.metron-prepare-commit
 GITHUB_REMOTE="origin"
+BASE_BRANCH=master
 
 # does a config file already exist?
 if [ -f $CONFIG_FILE ]; then
@@ -114,6 +114,11 @@ if [ ! -d "$WORK" ]; then
   read -p "  origin repo [$ORIGIN]: " INPUT
   [ -n "$INPUT" ] && ORIGIN=$INPUT
 
+  # what branch did the PR get submitted against?  could be a feature branch
+  BASE_BRANCH=`curl -s https://api.github.com/repos/apache/${CHOSEN_REPO}/pulls/$PR | python -c 'import sys, json; print json.load(sys.stdin)["base"]["ref"]'`
+  read -p "  base branch to merge into [$BASE_BRANCH]: " INPUT
+  [ -n "$INPUT" ] && BASE_BRANCH=$INPUT
+
   # clone the repository and fetch updates
   mkdir -p $WORK
   git clone $ORIGIN $WORK
@@ -125,11 +130,23 @@ if [ ! -d "$WORK" ]; then
 
   # fetch any changes from upstream
   git remote add upstream $UPSTREAM
-  git fetch upstream $BASE_BRANCH
+  if git fetch upstream "$BASE_BRANCH"; then
 
-  # merge any changes from upstream
-  git checkout $BASE_BRANCH
-  git merge upstream/$BASE_BRANCH
+    if [ $BASE_BRANCH = "master" ]; then
+      # merge any changes from upstream
+      git checkout $BASE_BRANCH
+      git merge upstream/$BASE_BRANCH
+
+    else
+      # create a local branch from the remote feature branch
+      git checkout -B $BASE_BRANCH upstream/$BASE_BRANCH
+
+    fi
+
+  else
+    # unable to fetch the base branch
+    exit $?
+  fi
 
 else
 


### PR DESCRIPTION
This update allows you to commit PRs against a feature branch in the same way that we have always used this script to commit PRs against master.

An extra prompt has been added to ask the user what base branch the PR should be merged into.  The Github PR is interrogated to determine which branch the user submitted the PR against.  This is used as the default value so that in most cases you do not need to actually type the name of the base branch.

The extra prompt looks something like the following.
```
  base branch to merge into [feature/METRON-1416-upgrade-solr]:
```

### Testing

#### Merge a PR into a Feature Branch

```
$ prepare-commit
  ...using settings from /Users/nallen/.metron-prepare-commit
    [1] metron
    [2] metron-bro-plugin-kafka
  which repo? [1]:
  pull request: 970
  local working directory [/Users/nallen/tmp/metron-pr970]:
  origin repo [https://github.com/apache/metron]:
  base branch to merge into [feature/METRON-1416-upgrade-solr]:

...

  github contributor's username [justinleet]:
  github contributor's email [justinjleet@gmail.com]:
  issue identifier in jira [METRON-1421]:
  issue description [Create a SolrMetaAlertDao]:
  commit message [METRON-1421 Create a SolrMetaAlertDao (justinleet via nickwallen) closes apache/metron#970]:

Updating f715d6db..d2ad9be2
Fast-forward
Squash commit -- not updating HEAD
 metron-interface/metron-rest/src/main/java/org/apache/metron/rest/config/IndexConfig.java                                              |   10 +-
...

af4e87ad (HEAD -> feature/METRON-1416-upgrade-solr) METRON-1421 Create a SolrMetaAlertDao (justinleet via nickwallen) closes apache/metron#970

  run test suite? [yN]

Review commit carefully then run...
    cd /Users/nallen/tmp/metron-pr970
    git push upstream master
```

You can see that the commit was prepared correctly.
```
$ cd ~/tmp/metron-pr970/
$ git log -2
commit af4e87ad3d7182446b01fe2dd3eebabdc8a8b676 (HEAD -> feature/METRON-1416-upgrade-solr)
Author: justinleet <justinjleet@gmail.com>
Date:   Thu Mar 22 10:50:15 2018 -0400

    METRON-1421 Create a SolrMetaAlertDao (justinleet via nickwallen) closes apache/metron#970

commit f715d6dbaf7ab4272c2e51430f4da13c8f688916 (upstream/feature/METRON-1416-upgrade-solr, origin/feature/METRON-1416-upgrade-solr)
Author: merrimanr <merrimanr@gmail.com>
Date:   Wed Mar 21 09:13:16 2018 -0500

    METRON-1424 Kerberos: Solr (merrimanr) closes apache/metron#960
```

#### Merge a PR into Master

```
$ prepare-commit
  ...using settings from /Users/nallen/.metron-prepare-commit
    [1] metron
    [2] metron-bro-plugin-kafka
  which repo? [1]:
  pull request: 967
  local working directory [/Users/nallen/tmp/metron-pr967]:
  origin repo [https://github.com/apache/metron]:
  base branch to merge into [master]:

...

  github contributor's username [nickwallen]:
  github contributor's email [nick@nickallen.org]:
  issue identifier in jira [METRON-1494]:
  issue description [Profiler Emits Messages to Kafka When Not Needed]:
  commit message [METRON-1494 Profiler Emits Messages to Kafka When Not Needed (nickwallen) closes apache/metron#967]:

...

198884af (HEAD -> master) METRON-1494 Profiler Emits Messages to Kafka When Not Needed (nickwallen) closes apache/metron#967

  run test suite? [yN]

Review commit carefully then run...
    cd /Users/nallen/tmp/metron-pr967
    git push upstream master
```

You can see that the commit was prepared correctly.

```
$ cd ~/tmp/metron-pr967/
$ git log -2
commit 198884af27aab0775b740cf5b87c6a40691e0558 (HEAD -> master)
Author: nickwallen <nick@nickallen.org>
Date:   Thu Mar 22 10:52:25 2018 -0400

    METRON-1494 Profiler Emits Messages to Kafka When Not Needed (nickwallen) closes apache/metron#967

commit 5ed9631a2936ec60d0ea6557ca4396cffdadc688 (upstream/master, origin/master, origin/HEAD)
Author: cstella <cestella@gmail.com>
Date:   Tue Mar 20 16:08:02 2018 -0600
```