### PR TITLE
METRON-1501: Parser messages that fail to validate are dropped silently

### DIFF
--- a/metron-platform/metron-parsers/README.md
+++ b/metron-platform/metron-parsers/README.md
@@ -51,20 +51,14 @@ There are two general types types of parsers:
 Currently, we have a few mechanisms for either deferring processing of
 messages or marking messages as invalid.
 
-### Invalid
+### Invalidation Errors
 
-There are two ways for a message to get marked as invalid:
+There are two reasons a message will be marked as invalid:
 * Fail [global validation](../metron-common#validation-framework)
 * Fail the parser's validate function (generally that means to not have a `timestamp` field or a `original_string` field.
 
 Those messages which are marked as invalid are sent to the error queue
 with an indication that they are invalid in the error message.
-
-### Filtered
-
-One can also filter a message by specifying a `filterClassName` in the
-parser config.  Filtered messages are just dropped rather than passed
-through.
 
 ### Parser Errors
 
@@ -72,7 +66,13 @@ Errors, which are defined as unexpected exceptions happening during the
 parse, are sent along to the error queue with a message indicating that
 there was an error in parse along with a stacktrace.  This is to
 distinguish from the invalid messages.
-    
+ 
+## Filtered
+
+One can also filter a message by specifying a `filterClassName` in the
+parser config.  Filtered messages are just dropped rather than passed
+through.
+   
 ## Parser Architecture
 
 ![Architecture](parser_arch.png)

--- a/metron-platform/metron-parsers/README.md
+++ b/metron-platform/metron-parsers/README.md
@@ -45,6 +45,33 @@ There are two general types types of parsers:
       * `ERROR` : Throw an error when a multidimensional map is encountered
     * `jsonpQuery` : A [JSON Path](#json_path) query string. If present, the result of the JSON Path query should be a list of messages. This is useful if you have a JSON document which contains a list or array of messages embedded in it, and you do not have another means of splitting the message.
     * A field called `timestamp` is expected to exist and, if it does not, then current time is inserted.  
+
+## Parser Error Routing
+
+Currently, we have a few mechanisms for either deferring processing of
+messages or marking messages as invalid.
+
+### Invalid
+
+There are two ways for a message to get marked as invalid:
+* Fail [global validation](../metron-common#validation-framework)
+* Fail the parser's validate function (generally that means to not have a `timestamp` field or a `original_string` field.
+
+Those messages which are marked as invalid are sent to the error queue
+with an indication that they are invalid in the error message.
+
+### Filtered
+
+One can also filter a message by specifying a `filterClassName` in the
+parser config.  Filtered messages are just dropped rather than passed
+through.
+
+### Parser Errors
+
+Errors, which are defined as unexpected exceptions happening during the
+parse, are sent along to the error queue with a message indicating that
+there was an error in parse along with a stacktrace.  This is to
+distinguish from the invalid messages.
     
 ## Parser Architecture
 


### PR DESCRIPTION
## Contributor Comments
Currently we have two concepts of dealing with messages that are not going to be passed through:

* Messages that fail global validation
* Messages that fail the parser's validation function
* Messages that are filtered out
Currently 
* in the case of messages that fail global validation, we send them to the error queue.
* in the case of messages that fail the parser's validation function, we drop them silently.
* in the case of messages that are filtered out, we drop them silently as well.

Given the use-cases behind filtering (e.g. a kafka topic with multiple types of messages where we want to pass along only one type), it makes sense to drop them silently.  However, in the case of the messages that fail the parser's validation function, we should like to know that and treat those similarly to those messages that fail global validation.

In order to test this, create a grok parser without a timestamp configured (this will make it fail the grok parser's validation) and pass along a message.  Ensure that it makes it to the error queue rather than being dropped silently.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
