### PR TITLE
METRON-1519 Indexing Error Topic Property Not Displayed in MPack

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/themes/metron_theme.json
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/themes/metron_theme.json
@@ -514,6 +514,10 @@
           "subsection-name": "subsection-indexing-kafka"
         },
         {
+          "config": "metron-indexing-env/indexing_error_topic",
+          "subsection-name": "subsection-indexing-kafka"
+        },
+        {
           "config": "metron-indexing-env/update_hbase_table",
           "subsection-name": "subsection-indexing-update"
         },
@@ -553,7 +557,6 @@
           "config": "metron-indexing-env/batch_indexing_topology_max_spout_pending",
           "subsection-name": "subsection-indexing-hdfs"
         },
-
         {
           "config": "metron-indexing-env/ra_indexing_kafka_spout_parallelism",
           "subsection-name": "subsection-indexing-storm"
@@ -562,7 +565,6 @@
           "config": "metron-indexing-env/batch_indexing_kafka_spout_parallelism",
           "subsection-name": "subsection-indexing-hdfs"
         },
-
         {
           "config": "metron-indexing-env/ra_indexing_writer_parallelism",
           "subsection-name": "subsection-indexing-storm"


### PR DESCRIPTION
The user is not able to configure the Indexing Error Topic in the MPack. A property has been defined for this in the Mpack, but it is not configured correctly to be displayed. The name of the property is "Indexing Error Topic".

### Testing

1. Spin-up the development environment.

2. Navigate to Metron > Configs > Indexing.

3. Change the value for "Indexing Error Topic".

4. Restart the Indexing topology.

5. Ensure that the new topic is in use by checking the topology's properties.

![screen shot 2018-04-10 at 6 06 48 pm](https://user-images.githubusercontent.com/2475409/38586047-1a9233e6-3cea-11e8-82f1-459c627b91ec.png)
