### PR TITLE
METRON-1531 Web Start Scripts Incorrectly Report OK If Process Dies

### DIFF
--- a/metron-interface/metron-alerts/scripts/metron-alerts-ui
+++ b/metron-interface/metron-alerts/scripts/metron-alerts-ui
@@ -47,16 +47,9 @@ PIDFILE="$METRON_PID_DIR/$NAME.pid"
 DAEMON="node $METRON_HOME/web/expressjs/alerts-server.js -c $METRON_HOME/config/alerts_ui.yml"
 
 #
-# start the rest application
+# start the application
 #
 start() {
-
-  # if pidfile exists, do not start another
-  if [ -f $PIDFILE ]; then
-      PID=`cat $PIDFILE`
-      printf "OK [$PID]\n"
-      return
-  fi
 
   if [ ! -d "$METRON_LOG_DIR" ]; then
       mkdir -p "$METRON_LOG_DIR" && chown "$METRON_USER":"$METRON_GROUP" "$METRON_LOG_DIR"
@@ -64,6 +57,18 @@ start() {
 
   if [ ! -d "$METRON_PID_DIR" ]; then
       mkdir -p "$METRON_PID_DIR" && chown "$METRON_USER":"$METRON_GROUP" "$METRON_PID_DIR"
+  fi
+
+  if [ -f $PIDFILE ]; then
+      PID=`cat $PIDFILE`
+      if [ kill -0 $PID >/dev/null 2>&1 ]; then
+          # process already running, do not start another
+          printf "OK [$PID]\n"
+          return
+      else
+          # clean-up old pid file and continue start
+          rm $PIDFILE
+      fi
   fi
 
   # kick-off the daemon
@@ -79,7 +84,7 @@ start() {
 }
 
 #
-# stop the rest application
+# stop the application
 #
 stop() {
   if [ -f $PIDFILE ]; then
@@ -106,7 +111,7 @@ status() {
     if [ -z "`ps axf | grep ${PID} | grep -v grep`" ]; then
       printf "%s\n" "Process dead but pidfile exists"
     else
-      echo "Running"
+      printf "Running [$PID]\n"
     fi
   else
     printf "%s\n" "Service not running"

--- a/metron-interface/metron-config/scripts/metron-management-ui
+++ b/metron-interface/metron-config/scripts/metron-management-ui
@@ -47,16 +47,9 @@ PIDFILE="$METRON_PID_DIR/$NAME.pid"
 DAEMON="node $METRON_HOME/web/expressjs/server.js -c $METRON_HOME/config/management_ui.yml"
 
 #
-# start the rest application
+# start the application
 #
 start() {
-
-  # if pidfile exists, do not start another
-  if [ -f $PIDFILE ]; then
-      PID=`cat $PIDFILE`
-      printf "OK [$PID]\n"
-      return
-  fi
 
   if [ ! -d "$METRON_LOG_DIR" ]; then
       mkdir -p "$METRON_LOG_DIR" && chown "$METRON_USER":"$METRON_GROUP" "$METRON_LOG_DIR"
@@ -64,6 +57,19 @@ start() {
 
   if [ ! -d "$METRON_PID_DIR" ]; then
       mkdir -p "$METRON_PID_DIR" && chown "$METRON_USER":"$METRON_GROUP" "$METRON_PID_DIR"
+  fi
+
+  if [ -f $PIDFILE ]; then
+      PID=`cat $PIDFILE`
+      if [ kill -0 $PID >/dev/null 2>&1 ]; then
+          # process already running, do not start another
+          printf "OK [$PID]\n"
+          return
+      else
+          # clean-up old pid file and continue start
+          printf "Process dead but pidfile exists\n"
+          rm $PIDFILE
+      fi
   fi
 
   # kick-off the daemon
@@ -79,7 +85,7 @@ start() {
 }
 
 #
-# stop the rest application
+# stop the application
 #
 stop() {
   if [ -f $PIDFILE ]; then
@@ -106,7 +112,7 @@ status() {
     if [ -z "`ps axf | grep ${PID} | grep -v grep`" ]; then
       printf "%s\n" "Process dead but pidfile exists"
     else
-      echo "Running"
+      printf "Running [$PID]\n"
     fi
   else
     printf "%s\n" "Service not running"


### PR DESCRIPTION
The start scripts for the Alerts and Management UIs will incorrectly report OK when running 'start', if the previously started process has died or been killed.  This is misleading.

## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [ ] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [ ] Have you included steps or a guide to how the change may be verified and tested manually?
- [ ] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

