### PR TITLE
METRON-1543 Unable to Set Parser Output Topic in Sensor Config

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/Constants.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/Constants.java
@@ -17,9 +17,7 @@
  */
 package org.apache.metron.common;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public class Constants {
@@ -37,9 +35,17 @@ public class Constants {
   public static final String SIMPLE_HBASE_THREAT_INTEL = "hbaseThreatIntel";
   public static final String GUID = "guid";
 
+  /**
+   * The key in the global configuration that defines the global parser error topic.
+   *
+   * <p>This value is used only if the error topic is left undefined in a sensor's parser configuration.
+   */
+  public static final String PARSER_ERROR_TOPIC_GLOBALS_KEY = "parser.error.topic";
+
   public interface Field {
     String getName();
   }
+
   public enum Fields implements Field {
      SRC_ADDR("ip_src_addr")
     ,SRC_PORT("ip_src_port")

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/SensorParserConfig.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/SensorParserConfig.java
@@ -18,6 +18,9 @@
 package org.apache.metron.common.configuration;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.metron.common.utils.JSONUtils;
 
 import java.io.IOException;
@@ -27,32 +30,152 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * The configuration object that defines a parser for a given sensor.  Each
+ * sensor has its own parser configuration.
+ */
 public class SensorParserConfig implements Serializable {
 
+  /**
+   * The class name of the parser.
+   */
   private String parserClassName;
-  private String filterClassName;
-  private String sensorTopic;
-  private String writerClassName;
-  private String errorWriterClassName;
-  private String invalidWriterClassName;
-  private Boolean readMetadata = false;
-  private Boolean mergeMetadata = false;
-  private Integer numWorkers = null;
-  private Integer numAckers= null;
-  private Integer spoutParallelism = 1;
-  private Integer spoutNumTasks = 1;
-  private Integer parserParallelism = 1;
-  private Integer parserNumTasks = 1;
-  private Integer errorWriterParallelism = 1;
-  private Integer errorWriterNumTasks = 1;
-  private Map<String, Object> spoutConfig = new HashMap<>();
-  private String securityProtocol = null;
-  private Map<String, Object> stormConfig = new HashMap<>();
 
   /**
-   * Return the number of workers for the topology.  This property will be used for the parser unless overridden on the CLI.
-   * @return
+   * Allows logic to be defined to filter or ignore messages.  Messages that have been
+   * filtered will not be parsed.
+   *
+   * This should be a fully qualified name of a class that implements the
+   * org.apache.metron.parsers.interfaces.MessageFilter interface.
    */
+  private String filterClassName;
+
+  /**
+   * The input topic containing the sensor telemetry to parse.
+   */
+  private String sensorTopic;
+
+  /**
+   * The output topic where the parsed telemetry will be written.
+   */
+  private String outputTopic;
+
+  /**
+   * The error topic where errors are written to.
+   */
+  private String errorTopic;
+
+  /**
+   * The fully qualified name of a class used to write messages
+   * to the output topic.
+   *
+   * <p>A sensible default is provided.
+   */
+  private String writerClassName;
+
+  /**
+   * The fully qualified name of a class used to write messages
+   * to the error topic.
+   *
+   * <p>A sensible default is provided.
+   */
+  private String errorWriterClassName;
+
+  /**
+   * Determines if parser metadata is made available to the parser's field
+   * transformations. If true, the parser field transformations can access
+   * parser metadata values.
+   *
+   * <p>By default, this is false and parser metadata is not available
+   * to the field transformations.
+   */
+  private Boolean readMetadata = false;
+
+  /**
+   * Determines if parser metadata is automatically merged into the message.  If
+   * true, parser metadata values will appear as fields within the message.
+   *
+   * <p>By default, this is false and metadata is not merged.
+   */
+  private Boolean mergeMetadata = false;
+
+  /**
+   * The number of workers for the topology.
+   *
+   * <p>This property can be overridden on the CLI.
+   */
+  private Integer numWorkers = null;
+
+  /**
+   * The number of ackers for the topology.
+   *
+   * <p>This property can be overridden on the CLI.
+   */
+  private Integer numAckers= null;
+
+  /**
+   * The parallelism of the Kafka spout.
+   *
+   * <p>This property can be overridden on the CLI.
+   */
+  private Integer spoutParallelism = 1;
+
+  /**
+   * The number of tasks for the Kafka spout.
+   *
+   * <p>This property can be overridden on the CLI.
+   */
+  private Integer spoutNumTasks = 1;
+
+  /**
+   * The parallelism of the parser bolt.
+   *
+   * <p>This property can be overridden on the CLI.
+   */
+  private Integer parserParallelism = 1;
+
+  /**
+   * The number of tasks for the parser bolt.
+   *
+   * <p>This property can be overridden on the CLI.
+   */
+  private Integer parserNumTasks = 1;
+
+  /**
+   * The parallelism of the error writer bolt.
+   *
+   * <p>This property can be overridden on the CLI.
+   */
+  private Integer errorWriterParallelism = 1;
+
+  /**
+   * The number of tasks for the error writer bolt.
+   *
+   * <p>This property can be overridden on the CLI.
+   */
+  private Integer errorWriterNumTasks = 1;
+
+  /**
+   * Configuration properties passed to the Kafka spout.
+   *
+   * <p>This property can be overridden on the CLI.
+   */
+  private Map<String, Object> spoutConfig = new HashMap<>();
+
+  /**
+   * The Kafka security protocol.
+   *
+   * <p>This property can be overridden on the CLI.  This property can also be overridden by the spout config.
+   */
+  private String securityProtocol = null;
+
+  /**
+   * Configuration properties passed to the storm topology.
+   *
+   * <p>This property can be overridden on the CLI.
+   */
+  private Map<String, Object> stormConfig = new HashMap<>();
+
   public Integer getNumWorkers() {
     return numWorkers;
   }
@@ -61,10 +184,6 @@ public class SensorParserConfig implements Serializable {
     this.numWorkers = numWorkers;
   }
 
-  /**
-   * Return the number of ackers for the topology.  This property will be used for the parser unless overridden on the CLI.
-   * @return
-   */
   public Integer getNumAckers() {
     return numAckers;
   }
@@ -73,10 +192,6 @@ public class SensorParserConfig implements Serializable {
     this.numAckers = numAckers;
   }
 
-  /**
-   * Return the spout parallelism.  This property will be used for the parser unless overridden on the CLI.
-   * @return
-   */
   public Integer getSpoutParallelism() {
     return spoutParallelism;
   }
@@ -85,10 +200,6 @@ public class SensorParserConfig implements Serializable {
     this.spoutParallelism = spoutParallelism;
   }
 
-  /**
-   * Return the spout num tasks.  This property will be used for the parser unless overridden on the CLI.
-   * @return
-   */
   public Integer getSpoutNumTasks() {
     return spoutNumTasks;
   }
@@ -97,10 +208,6 @@ public class SensorParserConfig implements Serializable {
     this.spoutNumTasks = spoutNumTasks;
   }
 
-  /**
-   * Return the parser parallelism.  This property will be used for the parser unless overridden on the CLI.
-   * @return
-   */
   public Integer getParserParallelism() {
     return parserParallelism;
   }
@@ -109,10 +216,6 @@ public class SensorParserConfig implements Serializable {
     this.parserParallelism = parserParallelism;
   }
 
-  /**
-   * Return the parser number of tasks.  This property will be used for the parser unless overridden on the CLI.
-   * @return
-   */
   public Integer getParserNumTasks() {
     return parserNumTasks;
   }
@@ -121,10 +224,6 @@ public class SensorParserConfig implements Serializable {
     this.parserNumTasks = parserNumTasks;
   }
 
-  /**
-   * Return the error writer bolt parallelism.  This property will be used for the parser unless overridden on the CLI.
-   * @return
-   */
   public Integer getErrorWriterParallelism() {
     return errorWriterParallelism;
   }
@@ -133,10 +232,6 @@ public class SensorParserConfig implements Serializable {
     this.errorWriterParallelism = errorWriterParallelism;
   }
 
-  /**
-   * Return the error writer bolt number of tasks.  This property will be used for the parser unless overridden on the CLI.
-   * @return
-   */
   public Integer getErrorWriterNumTasks() {
     return errorWriterNumTasks;
   }
@@ -145,10 +240,6 @@ public class SensorParserConfig implements Serializable {
     this.errorWriterNumTasks = errorWriterNumTasks;
   }
 
-  /**
-   * Return the spout config.  This includes kafka properties.  This property will be used for the parser unless overridden on the CLI.
-   * @return
-   */
   public Map<String, Object> getSpoutConfig() {
     return spoutConfig;
   }
@@ -157,11 +248,6 @@ public class SensorParserConfig implements Serializable {
     this.spoutConfig = spoutConfig;
   }
 
-  /**
-   * Return security protocol to use.  This property will be used for the parser unless overridden on the CLI.
-   * The order of precedence is CLI > spout config > config in the sensor parser config.
-   * @return
-   */
   public String getSecurityProtocol() {
     return securityProtocol;
   }
@@ -170,10 +256,6 @@ public class SensorParserConfig implements Serializable {
     this.securityProtocol = securityProtocol;
   }
 
-  /**
-   * Return Storm topologyconfig.  This property will be used for the parser unless overridden on the CLI.
-   * @return
-   */
   public Map<String, Object> getStormConfig() {
     return stormConfig;
   }
@@ -182,10 +264,6 @@ public class SensorParserConfig implements Serializable {
     this.stormConfig = stormConfig;
   }
 
-  /**
-   * Return whether or not to merge metadata sent into the message.  If true, then metadata become proper fields.
-   * @return
-   */
   public Boolean getMergeMetadata() {
     return mergeMetadata;
   }
@@ -194,10 +272,6 @@ public class SensorParserConfig implements Serializable {
     this.mergeMetadata = mergeMetadata;
   }
 
-  /**
-   * Return whether or not to read metadata at all.
-   * @return
-   */
   public Boolean getReadMetadata() {
     return readMetadata;
   }
@@ -212,14 +286,6 @@ public class SensorParserConfig implements Serializable {
 
   public void setErrorWriterClassName(String errorWriterClassName) {
     this.errorWriterClassName = errorWriterClassName;
-  }
-
-  public String getInvalidWriterClassName() {
-    return invalidWriterClassName;
-  }
-
-  public void setInvalidWriterClassName(String invalidWriterClassName) {
-    this.invalidWriterClassName = invalidWriterClassName;
   }
 
   public String getWriterClassName() {
@@ -263,6 +329,22 @@ public class SensorParserConfig implements Serializable {
     this.sensorTopic = sensorTopic;
   }
 
+  public String getOutputTopic() {
+    return outputTopic;
+  }
+
+  public void setOutputTopic(String outputTopic) {
+    this.outputTopic = outputTopic;
+  }
+
+  public String getErrorTopic() {
+    return errorTopic;
+  }
+
+  public void setErrorTopic(String errorTopic) {
+    this.errorTopic = errorTopic;
+  }
+
   public Map<String, Object> getParserConfig() {
     return parserConfig;
   }
@@ -283,112 +365,100 @@ public class SensorParserConfig implements Serializable {
     }
   }
 
-
   public String toJSON() throws JsonProcessingException {
     return JSONUtils.INSTANCE.toJSON(this, true);
   }
 
   @Override
   public String toString() {
-    return "SensorParserConfig{" +
-            "parserClassName='" + parserClassName + '\'' +
-            ", filterClassName='" + filterClassName + '\'' +
-            ", sensorTopic='" + sensorTopic + '\'' +
-            ", writerClassName='" + writerClassName + '\'' +
-            ", errorWriterClassName='" + errorWriterClassName + '\'' +
-            ", invalidWriterClassName='" + invalidWriterClassName + '\'' +
-            ", readMetadata=" + readMetadata +
-            ", mergeMetadata=" + mergeMetadata +
-            ", numWorkers=" + numWorkers +
-            ", numAckers=" + numAckers +
-            ", spoutParallelism=" + spoutParallelism +
-            ", spoutNumTasks=" + spoutNumTasks +
-            ", parserParallelism=" + parserParallelism +
-            ", parserNumTasks=" + parserNumTasks +
-            ", errorWriterParallelism=" + errorWriterParallelism +
-            ", errorWriterNumTasks=" + errorWriterNumTasks +
-            ", spoutConfig=" + spoutConfig +
-            ", securityProtocol='" + securityProtocol + '\'' +
-            ", stormConfig=" + stormConfig +
-            ", parserConfig=" + parserConfig +
-            ", fieldTransformations=" + fieldTransformations +
-            '}';
+    return new ToStringBuilder(this)
+            .append("parserClassName", parserClassName)
+            .append("filterClassName", filterClassName)
+            .append("sensorTopic", sensorTopic)
+            .append("outputTopic", outputTopic)
+            .append("errorTopic", errorTopic)
+            .append("writerClassName", writerClassName)
+            .append("errorWriterClassName", errorWriterClassName)
+            .append("readMetadata", readMetadata)
+            .append("mergeMetadata", mergeMetadata)
+            .append("numWorkers", numWorkers)
+            .append("numAckers", numAckers)
+            .append("spoutParallelism", spoutParallelism)
+            .append("spoutNumTasks", spoutNumTasks)
+            .append("parserParallelism", parserParallelism)
+            .append("parserNumTasks", parserNumTasks)
+            .append("errorWriterParallelism", errorWriterParallelism)
+            .append("errorWriterNumTasks", errorWriterNumTasks)
+            .append("spoutConfig", spoutConfig)
+            .append("securityProtocol", securityProtocol)
+            .append("stormConfig", stormConfig)
+            .append("parserConfig", parserConfig)
+            .append("fieldTransformations", fieldTransformations)
+            .toString();
   }
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
 
     SensorParserConfig that = (SensorParserConfig) o;
-
-    if (getParserClassName() != null ? !getParserClassName().equals(that.getParserClassName()) : that.getParserClassName() != null)
-      return false;
-    if (getFilterClassName() != null ? !getFilterClassName().equals(that.getFilterClassName()) : that.getFilterClassName() != null)
-      return false;
-    if (getSensorTopic() != null ? !getSensorTopic().equals(that.getSensorTopic()) : that.getSensorTopic() != null)
-      return false;
-    if (getWriterClassName() != null ? !getWriterClassName().equals(that.getWriterClassName()) : that.getWriterClassName() != null)
-      return false;
-    if (getErrorWriterClassName() != null ? !getErrorWriterClassName().equals(that.getErrorWriterClassName()) : that.getErrorWriterClassName() != null)
-      return false;
-    if (getInvalidWriterClassName() != null ? !getInvalidWriterClassName().equals(that.getInvalidWriterClassName()) : that.getInvalidWriterClassName() != null)
-      return false;
-    if (getReadMetadata() != null ? !getReadMetadata().equals(that.getReadMetadata()) : that.getReadMetadata() != null)
-      return false;
-    if (getMergeMetadata() != null ? !getMergeMetadata().equals(that.getMergeMetadata()) : that.getMergeMetadata() != null)
-      return false;
-    if (getNumWorkers() != null ? !getNumWorkers().equals(that.getNumWorkers()) : that.getNumWorkers() != null)
-      return false;
-    if (getNumAckers() != null ? !getNumAckers().equals(that.getNumAckers()) : that.getNumAckers() != null)
-      return false;
-    if (getSpoutParallelism() != null ? !getSpoutParallelism().equals(that.getSpoutParallelism()) : that.getSpoutParallelism() != null)
-      return false;
-    if (getSpoutNumTasks() != null ? !getSpoutNumTasks().equals(that.getSpoutNumTasks()) : that.getSpoutNumTasks() != null)
-      return false;
-    if (getParserParallelism() != null ? !getParserParallelism().equals(that.getParserParallelism()) : that.getParserParallelism() != null)
-      return false;
-    if (getParserNumTasks() != null ? !getParserNumTasks().equals(that.getParserNumTasks()) : that.getParserNumTasks() != null)
-      return false;
-    if (getErrorWriterParallelism() != null ? !getErrorWriterParallelism().equals(that.getErrorWriterParallelism()) : that.getErrorWriterParallelism() != null)
-      return false;
-    if (getErrorWriterNumTasks() != null ? !getErrorWriterNumTasks().equals(that.getErrorWriterNumTasks()) : that.getErrorWriterNumTasks() != null)
-      return false;
-    if (getSpoutConfig() != null ? !getSpoutConfig().equals(that.getSpoutConfig()) : that.getSpoutConfig() != null)
-      return false;
-    if (getSecurityProtocol() != null ? !getSecurityProtocol().equals(that.getSecurityProtocol()) : that.getSecurityProtocol() != null)
-      return false;
-    if (getStormConfig() != null ? !getStormConfig().equals(that.getStormConfig()) : that.getStormConfig() != null)
-      return false;
-    if (getParserConfig() != null ? !getParserConfig().equals(that.getParserConfig()) : that.getParserConfig() != null)
-      return false;
-    return getFieldTransformations() != null ? getFieldTransformations().equals(that.getFieldTransformations()) : that.getFieldTransformations() == null;
-
+    return new EqualsBuilder()
+            .append(parserClassName, that.parserClassName)
+            .append(filterClassName, that.filterClassName)
+            .append(sensorTopic, that.sensorTopic)
+            .append(outputTopic, that.outputTopic)
+            .append(errorTopic, that.errorTopic)
+            .append(writerClassName, that.writerClassName)
+            .append(errorWriterClassName, that.errorWriterClassName)
+            .append(readMetadata, that.readMetadata)
+            .append(mergeMetadata, that.mergeMetadata)
+            .append(numWorkers, that.numWorkers)
+            .append(numAckers, that.numAckers)
+            .append(spoutParallelism, that.spoutParallelism)
+            .append(spoutNumTasks, that.spoutNumTasks)
+            .append(parserParallelism, that.parserParallelism)
+            .append(parserNumTasks, that.parserNumTasks)
+            .append(errorWriterParallelism, that.errorWriterParallelism)
+            .append(errorWriterNumTasks, that.errorWriterNumTasks)
+            .append(spoutConfig, that.spoutConfig)
+            .append(securityProtocol, that.securityProtocol)
+            .append(stormConfig, that.stormConfig)
+            .append(parserConfig, that.parserConfig)
+            .append(fieldTransformations, that.fieldTransformations)
+            .isEquals();
   }
 
   @Override
   public int hashCode() {
-    int result = getParserClassName() != null ? getParserClassName().hashCode() : 0;
-    result = 31 * result + (getFilterClassName() != null ? getFilterClassName().hashCode() : 0);
-    result = 31 * result + (getSensorTopic() != null ? getSensorTopic().hashCode() : 0);
-    result = 31 * result + (getWriterClassName() != null ? getWriterClassName().hashCode() : 0);
-    result = 31 * result + (getErrorWriterClassName() != null ? getErrorWriterClassName().hashCode() : 0);
-    result = 31 * result + (getInvalidWriterClassName() != null ? getInvalidWriterClassName().hashCode() : 0);
-    result = 31 * result + (getReadMetadata() != null ? getReadMetadata().hashCode() : 0);
-    result = 31 * result + (getMergeMetadata() != null ? getMergeMetadata().hashCode() : 0);
-    result = 31 * result + (getNumWorkers() != null ? getNumWorkers().hashCode() : 0);
-    result = 31 * result + (getNumAckers() != null ? getNumAckers().hashCode() : 0);
-    result = 31 * result + (getSpoutParallelism() != null ? getSpoutParallelism().hashCode() : 0);
-    result = 31 * result + (getSpoutNumTasks() != null ? getSpoutNumTasks().hashCode() : 0);
-    result = 31 * result + (getParserParallelism() != null ? getParserParallelism().hashCode() : 0);
-    result = 31 * result + (getParserNumTasks() != null ? getParserNumTasks().hashCode() : 0);
-    result = 31 * result + (getErrorWriterParallelism() != null ? getErrorWriterParallelism().hashCode() : 0);
-    result = 31 * result + (getErrorWriterNumTasks() != null ? getErrorWriterNumTasks().hashCode() : 0);
-    result = 31 * result + (getSpoutConfig() != null ? getSpoutConfig().hashCode() : 0);
-    result = 31 * result + (getSecurityProtocol() != null ? getSecurityProtocol().hashCode() : 0);
-    result = 31 * result + (getStormConfig() != null ? getStormConfig().hashCode() : 0);
-    result = 31 * result + (getParserConfig() != null ? getParserConfig().hashCode() : 0);
-    result = 31 * result + (getFieldTransformations() != null ? getFieldTransformations().hashCode() : 0);
-    return result;
+    return new HashCodeBuilder(17, 37)
+            .append(parserClassName)
+            .append(filterClassName)
+            .append(sensorTopic)
+            .append(outputTopic)
+            .append(errorTopic)
+            .append(writerClassName)
+            .append(errorWriterClassName)
+            .append(readMetadata)
+            .append(mergeMetadata)
+            .append(numWorkers)
+            .append(numAckers)
+            .append(spoutParallelism)
+            .append(spoutNumTasks)
+            .append(parserParallelism)
+            .append(parserNumTasks)
+            .append(errorWriterParallelism)
+            .append(errorWriterNumTasks)
+            .append(spoutConfig)
+            .append(securityProtocol)
+            .append(stormConfig)
+            .append(parserConfig)
+            .append(fieldTransformations)
+            .toHashCode();
   }
 }

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/topology/ParserTopologyCLITest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/topology/ParserTopologyCLITest.java
@@ -217,17 +217,21 @@ public class ParserTopologyCLITest {
     private Map<String, Object> spoutConfig;
     private String securityProtocol;
     private Config stormConf;
+    private String outputTopic;
+    private String errorTopic;
 
-    public ParserInput( ValueSupplier<Integer> spoutParallelism
-                      , ValueSupplier<Integer> spoutNumTasks
-                      , ValueSupplier<Integer> parserParallelism
-                      , ValueSupplier<Integer> parserNumTasks
-                      , ValueSupplier<Integer> errorParallelism
-                      , ValueSupplier<Integer> errorNumTasks
-                      , ValueSupplier<Map> spoutConfig
-                      , ValueSupplier<String> securityProtocol
-                      , ValueSupplier<Config> stormConf
-                      , SensorParserConfig config
+    public ParserInput(ValueSupplier<Integer> spoutParallelism,
+                       ValueSupplier<Integer> spoutNumTasks,
+                       ValueSupplier<Integer> parserParallelism,
+                       ValueSupplier<Integer> parserNumTasks,
+                       ValueSupplier<Integer> errorParallelism,
+                       ValueSupplier<Integer> errorNumTasks,
+                       ValueSupplier<Map> spoutConfig,
+                       ValueSupplier<String> securityProtocol,
+                       ValueSupplier<Config> stormConf,
+                       ValueSupplier<String> outputTopic,
+                       ValueSupplier<String> errorTopic,
+                       SensorParserConfig config
                       )
     {
       this.spoutParallelism = spoutParallelism.get(config, Integer.class);
@@ -239,6 +243,8 @@ public class ParserTopologyCLITest {
       this.spoutConfig = spoutConfig.get(config, Map.class);
       this.securityProtocol = securityProtocol.get(config, String.class);
       this.stormConf = stormConf.get(config, Config.class);
+      this.outputTopic = outputTopic.get(config, String.class);
+      this.errorTopic = outputTopic.get(config, String.class);
     }
 
     public Integer getSpoutParallelism() {
@@ -276,30 +282,43 @@ public class ParserTopologyCLITest {
     public Config getStormConf() {
       return stormConf;
     }
-  }
-  /**
-{
-  "parserClassName": "org.apache.metron.parsers.GrokParser",
-  "sensorTopic": "squid",
-  "parserConfig": {
-    "grokPath": "/patterns/squid",
-    "patternLabel": "SQUID_DELIMITED",
-    "timestampField": "timestamp"
-  },
-  "fieldTransformations" : [
-    {
-      "transformation" : "STELLAR"
-    ,"output" : [ "full_hostname", "domain_without_subdomains" ]
-    ,"config" : {
-      "full_hostname" : "URL_TO_HOST(url)"
-      ,"domain_without_subdomains" : "DOMAIN_REMOVE_SUBDOMAINS(full_hostname)"
-                }
+
+    public String getOutputTopic() {
+      return outputTopic;
     }
-                           ]
-}
+
+    public String getErrorTopic() {
+      return errorTopic;
+    }
+  }
+
+  /**
+   * {
+   *   "parserClassName": "org.apache.metron.parsers.GrokParser",
+   *   "sensorTopic": "squid",
+   *   "parserConfig": {
+   *      "grokPath": "/patterns/squid",
+   *      "patternLabel": "SQUID_DELIMITED",
+   *      "timestampField": "timestamp"
+   *   },
+   *   "fieldTransformations" : [
+   *      {
+   *        "transformation" : "STELLAR",
+   *        "output" : [
+   *            "full_hostname",
+   *            "domain_without_subdomains"
+   *        ],
+   *        "config" : {
+   *            "full_hostname" : "URL_TO_HOST(url)",
+   *            "domain_without_subdomains" : "DOMAIN_REMOVE_SUBDOMAINS(full_hostname)"
+   *        }
+   *      }
+   *   ]
+   * }
    */
   @Multiline
   public static String baseConfig;
+
   private static SensorParserConfig getBaseConfig() {
     try {
       return JSONUtils.INSTANCE.load(baseConfig, SensorParserConfig.class);
@@ -600,18 +619,37 @@ public class ParserTopologyCLITest {
     final ParserInput[] parserInput = new ParserInput[]{null};
     new ParserTopologyCLI() {
       @Override
-      protected ParserTopologyBuilder.ParserTopology getParserTopology(String zookeeperUrl, Optional<String> brokerUrl, String sensorType, ValueSupplier<Integer> spoutParallelism, ValueSupplier<Integer> spoutNumTasks, ValueSupplier<Integer> parserParallelism, ValueSupplier<Integer> parserNumTasks, ValueSupplier<Integer> errorParallelism, ValueSupplier<Integer> errorNumTasks, ValueSupplier<Map> spoutConfig, ValueSupplier<String> securityProtocol, ValueSupplier<Config> stormConf, Optional<String> outputTopic) throws Exception {
-       parserInput[0] = new ParserInput( spoutParallelism
-                                        , spoutNumTasks
-                                        , parserParallelism
-                                        , parserNumTasks
-                                        , errorParallelism
-                                        , errorNumTasks
-                                        , spoutConfig
-                                        , securityProtocol
-                                        , stormConf
-                                        , config
-                                        );
+      protected ParserTopologyBuilder.ParserTopology getParserTopology(
+              String zookeeperUrl,
+              Optional<String> brokerUrl,
+              String sensorType,
+              ValueSupplier<Integer> spoutParallelism,
+              ValueSupplier<Integer> spoutNumTasks,
+              ValueSupplier<Integer> parserParallelism,
+              ValueSupplier<Integer> parserNumTasks,
+              ValueSupplier<Integer> errorParallelism,
+              ValueSupplier<Integer> errorNumTasks,
+              ValueSupplier<Map> spoutConfig,
+              ValueSupplier<String> securityProtocol,
+              ValueSupplier<Config> stormConf,
+              ValueSupplier<String> outputTopic,
+              ValueSupplier<String> errorTopic) throws Exception {
+
+       parserInput[0] = new ParserInput(
+               spoutParallelism,
+               spoutNumTasks,
+               parserParallelism,
+               parserNumTasks,
+               errorParallelism,
+               errorNumTasks,
+               spoutConfig,
+               securityProtocol,
+               stormConf,
+               outputTopic,
+               errorTopic,
+               config
+       );
+
         return null;
       }
     }.createParserTopology(cmd);

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/writers/integration/WriterBoltIntegrationTest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/writers/integration/WriterBoltIntegrationTest.java
@@ -45,7 +45,6 @@ import java.io.IOException;
 import java.util.*;
 
 public class WriterBoltIntegrationTest extends BaseIntegrationTest {
-  private static final String ERROR_TOPIC = "parser_error";
 
   public static class MockValidator implements FieldValidation{
 
@@ -62,48 +61,53 @@ public class WriterBoltIntegrationTest extends BaseIntegrationTest {
     }
   }
   /**
-   {
-    "fieldValidations" : [
-        {
-          "validation" : "org.apache.metron.writers.integration.WriterBoltIntegrationTest$MockValidator"
-        }
-                         ],
-   "parser.error.topic":"parser_error"
-   }
-    */
+   * {
+   *   "fieldValidations" : [
+   *      { "validation" : "org.apache.metron.writers.integration.WriterBoltIntegrationTest$MockValidator" }
+   *   ]
+   * }
+   */
   @Multiline
   public static String globalConfig;
 
   /**
-   {
-    "parserClassName" : "org.apache.metron.parsers.csv.CSVParser"
-   ,"sensorTopic":"dummy"
-   ,"parserConfig":
-   {
-    "columns" : {
-                "action" : 0
-               ,"dummy" : 1
-                 }
-   }
-   }
+   * {
+   *    "parserClassName" : "org.apache.metron.parsers.csv.CSVParser",
+   *    "sensorTopic": "dummy",
+   *    "outputTopic": "output",
+   *    "errorTopic": "parser_error",
+   *    "parserConfig": {
+   *        "columns" : {
+   *            "action" : 0,
+   *            "dummy" : 1
+   *        }
+   *    }
+   * }
    */
   @Multiline
-  public static String parserConfig;
+  public static String parserConfigJSON;
 
   @Test
   public void test() throws UnableToStartException, IOException, ParseException {
+
     UnitTestHelper.setLog4jLevel(CSVParser.class, org.apache.log4j.Level.FATAL);
     final String sensorType = "dummy";
+
+    SensorParserConfig parserConfig = JSONUtils.INSTANCE.load(parserConfigJSON, SensorParserConfig.class);
+
+    // the input messages to parser
     final List<byte[]> inputMessages = new ArrayList<byte[]>() {{
       add(Bytes.toBytes("valid,foo"));
       add(Bytes.toBytes("invalid,foo"));
       add(Bytes.toBytes("error"));
     }};
+
+    // setup external components; zookeeper, kafka
     final Properties topologyProperties = new Properties();
     final ZKServerComponent zkServerComponent = getZKServerComponent(topologyProperties);
     final KafkaComponent kafkaComponent = getKafkaComponent(topologyProperties, new ArrayList<KafkaComponent.Topic>() {{
       add(new KafkaComponent.Topic(sensorType, 1));
-      add(new KafkaComponent.Topic(ERROR_TOPIC, 1));
+      add(new KafkaComponent.Topic(parserConfig.getErrorTopic(), 1));
       add(new KafkaComponent.Topic(Constants.ENRICHMENT_TOPIC, 1));
     }});
     topologyProperties.setProperty("kafka.broker", kafkaComponent.getBrokerList());
@@ -111,14 +115,16 @@ public class WriterBoltIntegrationTest extends BaseIntegrationTest {
     ConfigUploadComponent configUploadComponent = new ConfigUploadComponent()
             .withTopologyProperties(topologyProperties)
             .withGlobalConfig(globalConfig)
-            .withParserSensorConfig(sensorType, JSONUtils.INSTANCE.load(parserConfig, SensorParserConfig.class));
+            .withParserSensorConfig(sensorType, parserConfig);
 
     ParserTopologyComponent parserTopologyComponent = new ParserTopologyComponent.Builder()
             .withSensorType(sensorType)
             .withTopologyProperties(topologyProperties)
-            .withBrokerUrl(kafkaComponent.getBrokerList()).build();
+            .withBrokerUrl(kafkaComponent.getBrokerList())
+            .withErrorTopic(parserConfig.getErrorTopic())
+            .withOutputTopic(parserConfig.getOutputTopic())
+            .build();
 
-    //UnitTestHelper.verboseLogging();
     ComponentRunner runner = new ComponentRunner.Builder()
             .withComponent("zk", zkServerComponent)
             .withComponent("kafka", kafkaComponent)
@@ -131,48 +137,42 @@ public class WriterBoltIntegrationTest extends BaseIntegrationTest {
     try {
       runner.start();
       kafkaComponent.writeMessages(sensorType, inputMessages);
-      ProcessorResult<Map<String, List<JSONObject>>> result = runner.process(getProcessor());
+      ProcessorResult<Map<String, List<JSONObject>>> result = runner.process(
+              getProcessor(parserConfig.getOutputTopic(), parserConfig.getErrorTopic()));
+
+      // validate the output messages
       Map<String,List<JSONObject>> outputMessages = result.getResult();
       Assert.assertEquals(2, outputMessages.size());
       Assert.assertEquals(1, outputMessages.get(Constants.ENRICHMENT_TOPIC).size());
       Assert.assertEquals("valid", outputMessages.get(Constants.ENRICHMENT_TOPIC).get(0).get("action"));
-      Assert.assertEquals(2, outputMessages.get(ERROR_TOPIC).size());
-      JSONObject invalidMessage = outputMessages.get(ERROR_TOPIC).get(0);
+      Assert.assertEquals(2, outputMessages.get(parserConfig.getErrorTopic()).size());
+
+      // validate an error message
+      JSONObject invalidMessage = outputMessages.get(parserConfig.getErrorTopic()).get(0);
       Assert.assertEquals(Constants.ErrorType.PARSER_INVALID.getType(), invalidMessage.get(Constants.ErrorFields.ERROR_TYPE.getName()));
       JSONObject rawMessage = JSONUtils.INSTANCE.load((String) invalidMessage.get(Constants.ErrorFields.RAW_MESSAGE.getName()), JSONObject.class);
       Assert.assertEquals("foo", rawMessage.get("dummy"));
       Assert.assertEquals("invalid", rawMessage.get("action"));
-      JSONObject errorMessage = outputMessages.get(ERROR_TOPIC).get(1);
+
+      // validate the next error message
+      JSONObject errorMessage = outputMessages.get(parserConfig.getErrorTopic()).get(1);
       Assert.assertEquals(Constants.ErrorType.PARSER_ERROR.getType(), errorMessage.get(Constants.ErrorFields.ERROR_TYPE.getName()));
       Assert.assertEquals("error", errorMessage.get(Constants.ErrorFields.RAW_MESSAGE.getName()));
-      // It's unclear if we need a rawMessageBytes field so commenting out for now
-      //Assert.assertTrue(Arrays.equals(listToBytes(errorMessage.get(Constants.ErrorFields.RAW_MESSAGE_BYTES.getName())), "error".getBytes()));
-    }
-    finally {
+
+    } finally {
       if(runner != null) {
         runner.stop();
       }
     }
   }
-  private static byte[] listToBytes(Object o ){
-    List<Byte> l = (List<Byte>)o;
-    byte[] ret = new byte[l.size()];
-    int i = 0;
-    for(Number b : l) {
-      ret[i++] = b.byteValue();
-    }
-    return ret;
-  }
+
   private static List<JSONObject> loadMessages(List<byte[]> outputMessages) {
     List<JSONObject> tmp = new ArrayList<>();
-    Iterables.addAll(tmp
-            , Iterables.transform(outputMessages
-                    , message -> {
+    Iterables.addAll(tmp,
+            Iterables.transform(outputMessages,
+                    message -> {
                       try {
-                        return new JSONObject(JSONUtils.INSTANCE.load(new String(message)
-                                             ,JSONUtils.MAP_SUPPLIER 
-                                             )
-                        );
+                        return new JSONObject(JSONUtils.INSTANCE.load(new String(message), JSONUtils.MAP_SUPPLIER));
                       } catch (Exception ex) {
                         throw new IllegalStateException(ex);
                       }
@@ -181,13 +181,14 @@ public class WriterBoltIntegrationTest extends BaseIntegrationTest {
     );
     return tmp;
   }
+
   @SuppressWarnings("unchecked")
-  private KafkaProcessor<Map<String,List<JSONObject>>> getProcessor(){
+  private KafkaProcessor<Map<String,List<JSONObject>>> getProcessor(String outputTopic, String errorTopic){
 
     return new KafkaProcessor<>()
             .withKafkaComponentName("kafka")
-            .withReadTopic(Constants.ENRICHMENT_TOPIC)
-            .withErrorTopic(ERROR_TOPIC)
+            .withReadTopic(outputTopic)
+            .withErrorTopic(errorTopic)
             .withValidateReadMessages(new Function<KafkaMessageSet, Boolean>() {
               @Nullable
               @Override
@@ -201,7 +202,7 @@ public class WriterBoltIntegrationTest extends BaseIntegrationTest {
               public Map<String,List<JSONObject>> apply(@Nullable KafkaMessageSet messageSet) {
                 return new HashMap<String, List<JSONObject>>() {{
                   put(Constants.ENRICHMENT_TOPIC, loadMessages(messageSet.getMessages()));
-                  put(ERROR_TOPIC, loadMessages(messageSet.getErrors()));
+                  put(errorTopic, loadMessages(messageSet.getErrors()));
                 }};
               }
             });

--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/kafka/KafkaWriter.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/kafka/KafkaWriter.java
@@ -76,6 +76,11 @@ public class KafkaWriter extends AbstractWriter implements MessageWriter<JSONObj
     this.brokerUrl = brokerUrl;
   }
 
+  public KafkaWriter withBrokerUrl(String brokerUrl) {
+    this.brokerUrl = brokerUrl;
+    return this;
+  }
+
   public KafkaWriter withZkQuorum(String zkQuorum) {
     this.zkQuorum = zkQuorum;
     return this;


### PR DESCRIPTION
The only way to alter the output topic for a Parser topology is to manually launch the topology using the CLI with the `-ot` parameter.  The user needs to be able to define this as part of the sensor's parser configuration so that the value is stored in Zookeeper and can be altered in the Management UI and launched from Ambari.

## Manual Testing




1. Launch the development environment.

    ```
    cd metron-deployment/develoment/centos6
    vagrant up
    ```

1. Validate the development environment. 
    * Ensure the 'Service Check' is successful.
    * Ensure alerts are visible in the 'Alerts UI'.

1. Stop all topologies.

1. Launch the REPL.

    ```
    vagrant ssh
    sudo su -
    source /etc/default/metron
    cd $METRON_HOME
    bin/stellar -z $ZOOKEEPER
    ```

1. Change the output topic for the 'bro' sensor.

    ```
    [Stellar]>>> conf := CONFIG_GET("PARSER","bro")
    {
      "parserClassName":"org.apache.metron.parsers.bro.BasicBroParser",
      "sensorTopic":"bro",
      "parserConfig": {}
    }

    [Stellar]>>> conf := SHELL_EDIT(conf)
    {
      "parserClassName":"org.apache.metron.parsers.bro.BasicBroParser",
      "sensorTopic":"bro",
      "parserConfig": {},
      "outputTopic": "new-topic"
    }

    [Stellar]>>> CONFIG_PUT("PARSER", conf, "bro")
    [Stellar]>>> CONFIG_GET("PARSER", "bro")
    {
      "parserClassName":"org.apache.metron.parsers.bro.BasicBroParser",
      "sensorTopic":"bro",
      "parserConfig": {},
      "outputTopic": "new-topic"
    }
    ```

1. Start the Parser topologies again using Ambari.

1. Wait for the Bro parser topology to start.  Then ensure that the parser is publishing messages to "new-topic".

    ```
    [Stellar]>>> %define bootstrap.servers := "node1:6667"
    node1:6667

    [Stellar]>>> KAFKA_GET("new-topic")
    []

    [Stellar]>>> KAFKA_GET("new-topic")
    [{"bro_timestamp":"1524849662.943861","method":"GET","ip_dst_port":8080,"request_body_len":0,"uri":"\/api\/v1\/clusters\/metron_cluster\/alerts?format=groupedSummary&_=1484169223317","tags":[],"source.type":"bro","uid":"CUrRne3iLIxXavQtci","referrer":"http:\/\/node1:8080\/","trans_depth":198,"protocol":"http","original_string":"HTTP | id.orig_p:50451 method:GET request_body_len:0 id.resp_p:8080 uri:\/api\/v1\/clusters\/metron_cluster\/alerts?format=groupedSummary&_=1484169223317 tags:[] uid:CUrRne3iLIxXavQtci referrer:http:\/\/node1:8080\/ trans_depth:198 host:node1 id.orig_h:192.168.66.1 response_body_len:0 user_agent:Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_12_2) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/55.0.2883.95 Safari\/537.36 ts:1524849662.943861 id.resp_h:192.168.66.121","ip_dst_addr":"192.168.66.121","ip_src_port":50451,"host":"node1","guid":"f230947f-f6c8-49c4-84a5-cff124c4df60","response_body_len":0,"ip_src_addr":"192.168.66.1","user_agent":"Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_12_2) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/55.0.2883.95 Safari\/537.36","timestamp":1524849662943}]
    ```

## Pull Request Checklist

- [ ] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [ ] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [ ] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [ ] Have you included steps or a guide to how the change may be verified and tested manually?
- [ ] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
