### PR TITLE
METRON-1549: Add empty object test to WriterBoltIntegrationTest implementation

### DIFF
--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/writers/integration/WriterBoltIntegrationTest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/writers/integration/WriterBoltIntegrationTest.java
@@ -17,32 +17,44 @@
  */
 package org.apache.metron.writers.integration;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import javax.annotation.Nullable;
 import org.adrianwalker.multilinestring.Multiline;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.metron.common.Constants;
 import org.apache.metron.common.configuration.SensorParserConfig;
-import org.apache.metron.stellar.dsl.Context;
 import org.apache.metron.common.field.validation.FieldValidation;
 import org.apache.metron.common.utils.JSONUtils;
 import org.apache.metron.enrichment.integration.components.ConfigUploadComponent;
-import org.apache.metron.integration.*;
+import org.apache.metron.integration.BaseIntegrationTest;
+import org.apache.metron.integration.ComponentRunner;
+import org.apache.metron.integration.Processor;
+import org.apache.metron.integration.ProcessorResult;
+import org.apache.metron.integration.ReadinessState;
 import org.apache.metron.integration.components.KafkaComponent;
-import org.apache.metron.integration.processors.KafkaMessageSet;
 import org.apache.metron.integration.components.ZKServerComponent;
+import org.apache.metron.integration.processors.KafkaMessageSet;
 import org.apache.metron.integration.processors.KafkaProcessor;
-import org.apache.metron.parsers.csv.CSVParser;
 import org.apache.metron.parsers.integration.components.ParserTopologyComponent;
-import org.apache.metron.test.utils.UnitTestHelper;
+import org.apache.metron.parsers.interfaces.MessageParser;
+import org.apache.metron.stellar.dsl.Context;
 import org.json.simple.JSONObject;
-import org.json.simple.parser.ParseException;
 import org.junit.Assert;
 import org.junit.Test;
-
-import javax.annotation.Nullable;
-import java.io.IOException;
-import java.util.*;
 
 public class WriterBoltIntegrationTest extends BaseIntegrationTest {
 
@@ -60,6 +72,14 @@ public class WriterBoltIntegrationTest extends BaseIntegrationTest {
     public void initialize(Map<String, Object> validationConfig, Map<String, Object> globalConfig) {
     }
   }
+
+
+  /**
+   * { }
+   */
+  @Multiline
+  public static String globalConfigEmpty;
+
   /**
    * {
    *   "fieldValidations" : [
@@ -68,7 +88,7 @@ public class WriterBoltIntegrationTest extends BaseIntegrationTest {
    * }
    */
   @Multiline
-  public static String globalConfig;
+  public static String globalConfigWithValidation;
 
   /**
    * {
@@ -88,9 +108,7 @@ public class WriterBoltIntegrationTest extends BaseIntegrationTest {
   public static String parserConfigJSON;
 
   @Test
-  public void test() throws UnableToStartException, IOException, ParseException {
-
-    UnitTestHelper.setLog4jLevel(CSVParser.class, org.apache.log4j.Level.FATAL);
+  public void parser_with_global_validations_writes_bad_records_to_error_topic() throws Exception {
     final String sensorType = "dummy";
 
     SensorParserConfig parserConfig = JSONUtils.INSTANCE.load(parserConfigJSON, SensorParserConfig.class);
@@ -114,7 +132,7 @@ public class WriterBoltIntegrationTest extends BaseIntegrationTest {
 
     ConfigUploadComponent configUploadComponent = new ConfigUploadComponent()
             .withTopologyProperties(topologyProperties)
-            .withGlobalConfig(globalConfig)
+            .withGlobalConfig(globalConfigWithValidation)
             .withParserSensorConfig(sensorType, parserConfig);
 
     ParserTopologyComponent parserTopologyComponent = new ParserTopologyComponent.Builder()
@@ -137,8 +155,9 @@ public class WriterBoltIntegrationTest extends BaseIntegrationTest {
     try {
       runner.start();
       kafkaComponent.writeMessages(sensorType, inputMessages);
-      ProcessorResult<Map<String, List<JSONObject>>> result = runner.process(
-              getProcessor(parserConfig.getOutputTopic(), parserConfig.getErrorTopic()));
+      KafkaProcessor<Map<String, List<JSONObject>>> kafkaProcessor = getKafkaProcessor(
+          parserConfig.getOutputTopic(), parserConfig.getErrorTopic());
+      ProcessorResult<Map<String, List<JSONObject>>> result = runner.process(kafkaProcessor);
 
       // validate the output messages
       Map<String,List<JSONObject>> outputMessages = result.getResult();
@@ -166,6 +185,139 @@ public class WriterBoltIntegrationTest extends BaseIntegrationTest {
     }
   }
 
+  /**
+   * {
+   *    "parserClassName":"org.apache.metron.writers.integration.WriterBoltIntegrationTest$EmptyObjectParser",
+   *    "sensorTopic":"emptyobjectparser",
+   *    "outputTopic": "enrichments",
+   *    "errorTopic": "parser_error"
+   * }
+   */
+  @Multiline
+  public static String offsetParserConfigJSON;
+
+  @Test
+  public void commits_kafka_offsets_for_emtpy_objects() throws Exception {
+    final String sensorType = "emptyobjectparser";
+
+    SensorParserConfig parserConfig = JSONUtils.INSTANCE.load(offsetParserConfigJSON, SensorParserConfig.class);
+
+    // the input messages to parser
+    final List<byte[]> inputMessages = new ArrayList<byte[]>() {{
+      add(Bytes.toBytes("foo"));
+      add(Bytes.toBytes("bar"));
+      add(Bytes.toBytes("baz"));
+    }};
+
+    // setup external components; zookeeper, kafka
+    final Properties topologyProperties = new Properties();
+    final ZKServerComponent zkServerComponent = getZKServerComponent(topologyProperties);
+    final KafkaComponent kafkaComponent = getKafkaComponent(topologyProperties, new ArrayList<KafkaComponent.Topic>() {{
+      add(new KafkaComponent.Topic(sensorType, 1));
+      add(new KafkaComponent.Topic(parserConfig.getErrorTopic(), 1));
+      add(new KafkaComponent.Topic(Constants.ENRICHMENT_TOPIC, 1));
+    }});
+    topologyProperties.setProperty("kafka.broker", kafkaComponent.getBrokerList());
+
+    ConfigUploadComponent configUploadComponent = new ConfigUploadComponent()
+        .withTopologyProperties(topologyProperties)
+        .withGlobalConfig(globalConfigEmpty)
+        .withParserSensorConfig(sensorType, parserConfig);
+
+    ParserTopologyComponent parserTopologyComponent = new ParserTopologyComponent.Builder()
+        .withSensorType(sensorType)
+        .withTopologyProperties(topologyProperties)
+        .withBrokerUrl(kafkaComponent.getBrokerList())
+        .withErrorTopic(parserConfig.getErrorTopic())
+        .withOutputTopic(parserConfig.getOutputTopic())
+        .build();
+
+    ComponentRunner runner = new ComponentRunner.Builder()
+        .withComponent("zk", zkServerComponent)
+        .withComponent("kafka", kafkaComponent)
+        .withComponent("config", configUploadComponent)
+        .withComponent("org/apache/storm", parserTopologyComponent)
+        .withMillisecondsBetweenAttempts(5000)
+        .withNumRetries(10)
+        .withCustomShutdownOrder(new String[]{"org/apache/storm","config","kafka","zk"})
+        .build();
+
+    try {
+      runner.start();
+      kafkaComponent.writeMessages(sensorType, inputMessages);
+      ProcessorResult<Set<JSONObject>> result = runner.process(new Processor<Set<JSONObject>>() {
+        // used for calculating readiness and returning result set
+        final Set<JSONObject> outputMessages = new HashSet<>();
+
+        @Override
+        public ReadinessState process(ComponentRunner runner) {
+          KafkaComponent kc = runner.getComponent("kafka", KafkaComponent.class);
+          outputMessages.addAll(readMessagesFromKafka(kc, Constants.ENRICHMENT_TOPIC));
+          return calcReadiness(inputMessages.size(), outputMessages.size());
+        }
+
+        private Set<JSONObject> readMessagesFromKafka(KafkaComponent kc, String topic) {
+          Set<JSONObject> out = new HashSet<>();
+          for (byte[] b : kc.readMessages(topic)) {
+            try {
+              JSONObject m = new JSONObject(
+                  JSONUtils.INSTANCE.load(new String(b), JSONUtils.MAP_SUPPLIER));
+              out.add(m);
+            } catch (IOException e) {
+              throw new IllegalStateException(e);
+            }
+          }
+          return out;
+        }
+
+        private ReadinessState calcReadiness(int in, int out) {
+          return in == out ? ReadinessState.READY : ReadinessState.NOT_READY;
+        }
+
+        @Override
+        public ProcessorResult<Set<JSONObject>> getResult() {
+          return new ProcessorResult<>(outputMessages, null);
+        }
+      });
+
+      // validate the output messages
+      assertThat("size should match", result.getResult().size(), equalTo(inputMessages.size()));
+      for (JSONObject record : result.getResult()) {
+        assertThat("record should have a guid", record.containsKey("guid"), equalTo(true));
+        assertThat("record should have correct source.type", record.get("source.type"),
+            equalTo(sensorType));
+      }
+    } finally {
+      if (runner != null) {
+        runner.stop();
+      }
+    }
+  }
+
+  /**
+   * Goal is to check returning an empty JSONObject in our List returned by parse.
+   */
+  public static class EmptyObjectParser implements MessageParser<JSONObject>, Serializable {
+
+    @Override
+    public void init() {
+    }
+
+    @Override
+    public List<JSONObject> parse(byte[] bytes) {
+      return ImmutableList.of(new JSONObject());
+    }
+
+    @Override
+    public boolean validate(JSONObject message) {
+      return true;
+    }
+
+    @Override
+    public void configure(Map<String, Object> map) {
+    }
+  }
+
   private static List<JSONObject> loadMessages(List<byte[]> outputMessages) {
     List<JSONObject> tmp = new ArrayList<>();
     Iterables.addAll(tmp,
@@ -183,7 +335,7 @@ public class WriterBoltIntegrationTest extends BaseIntegrationTest {
   }
 
   @SuppressWarnings("unchecked")
-  private KafkaProcessor<Map<String,List<JSONObject>>> getProcessor(String outputTopic, String errorTopic){
+  private KafkaProcessor<Map<String,List<JSONObject>>> getKafkaProcessor(String outputTopic, String errorTopic){
 
     return new KafkaProcessor<>()
             .withKafkaComponentName("kafka")


### PR DESCRIPTION
## Contributor Comments

https://issues.apache.org/jira/browse/METRON-1549

Adding a new integration test case to the writer bolt integration test to verify an edge case with how our parserbolt, parsers, and writers handle empty objects returned from custom parsers.

## Pull Request Checklist

In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
(pending travis)
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?


### For documentation related changes:
n/a
