### PR TITLE
METRON-1552: Add gzip file validation check to the geo loader

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/utils/CompressionStrategies.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/utils/CompressionStrategies.java
@@ -27,6 +27,9 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipException;
 
+/*
+ * Factory to provide various compression strategies.
+ */
 public enum CompressionStrategies implements CompressionStrategy {
 
   GZIP(new CompressionStrategy() {

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/utils/CompressionStrategies.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/utils/CompressionStrategies.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.metron.common.utils;
+
+import java.io.EOFException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+import java.util.zip.ZipException;
+
+public enum CompressionStrategies implements CompressionStrategy {
+
+  GZIP(new CompressionStrategy() {
+    @Override
+    public void compress(File inFile, File outFile) throws IOException {
+      try (FileInputStream fis = new FileInputStream(inFile);
+          FileOutputStream fos = new FileOutputStream(outFile);
+          GZIPOutputStream gzipOS = new GZIPOutputStream(fos)) {
+        byte[] buffer = new byte[1024];
+        int len;
+        while ((len = fis.read(buffer)) != -1) {
+          gzipOS.write(buffer, 0, len);
+        }
+      }
+    }
+
+    @Override
+    public void decompress(File inFile, File outFile) throws IOException {
+      try (FileInputStream fis = new FileInputStream(inFile);
+          GZIPInputStream gis = new GZIPInputStream(fis);
+          FileOutputStream fos = new FileOutputStream(outFile)) {
+        byte[] buffer = new byte[1024];
+        int len;
+        while ((len = gis.read(buffer)) != -1) {
+          fos.write(buffer, 0, len);
+        }
+      }
+
+    }
+
+    @Override
+    public boolean test(File gzipFile) {
+      try (FileInputStream fis = new FileInputStream(gzipFile);
+          GZIPInputStream gis = new GZIPInputStream(fis)) {
+        byte[] buffer = new byte[1024];
+        // this will throw an exception on malformed file
+        gis.read(buffer);
+      } catch (ZipException | EOFException e) {
+        return false;
+      } catch (IOException e) {
+        throw new IllegalStateException("Error occurred while attempting to validate gzip file", e);
+      }
+      return true;
+    }
+  });
+
+  private CompressionStrategy strategy;
+
+  CompressionStrategies(CompressionStrategy strategy) {
+    this.strategy = strategy;
+  }
+
+  @Override
+  public void compress(File inFile, File outFile) throws IOException {
+    strategy.compress(inFile, outFile);
+  }
+
+  @Override
+  public void decompress(File inFile, File outFile) throws IOException {
+    strategy.decompress(inFile, outFile);
+  }
+
+  @Override
+  public boolean test(File gzipFile) {
+    return strategy.test(gzipFile);
+  }
+
+}

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/utils/CompressionStrategy.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/utils/CompressionStrategy.java
@@ -23,10 +23,30 @@ import java.io.IOException;
 
 public interface CompressionStrategy {
 
+  /**
+   * Compress infile.
+   *
+   * @param inFile file to compress
+   * @param outFile destination path for compressed output
+   * @throws IOException Any IO error
+   */
   void compress(File inFile, File outFile) throws IOException;
 
+  /**
+   * Decompress infile.
+   *
+   * @param inFile file to decompress
+   * @param outFile destination path for decompressed output
+   * @throws IOException Any IO error
+   */
   void decompress(File inFile, File outFile) throws IOException;
 
+  /**
+   * Test if file is proper gzip format. True if valid, false otherwise.
+   *
+   * @param gzipFile file to check for gzip compression
+   * @return true if file is a gzip format, false otherwise.
+   */
   boolean test(File gzipFile);
 
 }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/utils/CompressionStrategy.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/utils/CompressionStrategy.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.metron.common.utils;
+
+import java.io.File;
+import java.io.IOException;
+
+public interface CompressionStrategy {
+
+  void compress(File inFile, File outFile) throws IOException;
+
+  void decompress(File inFile, File outFile) throws IOException;
+
+  boolean test(File gzipFile);
+
+}

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/utils/CompressionUtilsTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/utils/CompressionUtilsTest.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.metron.common.utils;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import org.apache.metron.integration.utils.TestUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CompressionUtilsTest {
+
+  private static final String SAMPLE_TEXT = "hello world";
+  private File tempDir;
+  private File textFile;
+
+  @Before
+  public void setup() throws IOException {
+    tempDir = TestUtils.createTempDir(this.getClass().getName());
+    textFile = new File(tempDir, "test-text-file.txt");
+    TestUtils.write(textFile, SAMPLE_TEXT);
+  }
+
+  @Test
+  public void compresses_Gzip() throws IOException {
+    File gzipFile = new File(tempDir, "test-gz-compression-file.gz");
+    CompressionStrategies.GZIP.compress(textFile, gzipFile);
+    assertThat(CompressionStrategies.GZIP.test(gzipFile), equalTo(true));
+  }
+
+  @Test
+  public void decompresses_Gzip() throws IOException {
+    File gzipFile = new File(tempDir, "test-gz-decompress.gz");
+    CompressionStrategies.GZIP.compress(textFile, gzipFile);
+    assertThat("gzipped file should exist", gzipFile.exists(), equalTo(true));
+    File unzippedText = new File(tempDir, "test-gz-decompressed.txt");
+    CompressionStrategies.GZIP.decompress(gzipFile, unzippedText);
+    assertThat("decompressed file should exist", unzippedText.exists(), equalTo(true));
+    String actual = TestUtils.read(unzippedText);
+    assertThat("decompressed text should match", actual, equalTo(SAMPLE_TEXT));
+  }
+
+}

--- a/metron-platform/metron-data-management/src/main/java/org/apache/metron/dataloads/nonbulk/geo/GeoEnrichmentLoader.java
+++ b/metron-platform/metron-data-management/src/main/java/org/apache/metron/dataloads/nonbulk/geo/GeoEnrichmentLoader.java
@@ -43,6 +43,9 @@ import java.time.ZoneOffset;
 import java.util.Map;
 
 public class GeoEnrichmentLoader {
+
+  private static final String DEFAULT_RETRIES = "2";
+
   private static abstract class OptionHandler implements Function<String, Option> {
   }
 
@@ -156,7 +159,7 @@ public class GeoEnrichmentLoader {
     System.out.println("Retrieving GeoLite2 archive");
     String url = GeoEnrichmentOptions.GEO_URL.get(cli, "http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz");
     String tmpDir = GeoEnrichmentOptions.TMP_DIR.get(cli, "/tmp") + "/"; // Make sure there's a file separator at the end
-    int numRetries = Integer.parseInt(GeoEnrichmentOptions.RETRIES.get(cli, "2"));
+    int numRetries = Integer.parseInt(GeoEnrichmentOptions.RETRIES.get(cli, DEFAULT_RETRIES));
     File localGeoFile = null;
     try {
       localGeoFile = downloadGeoFile(url, tmpDir, numRetries);
@@ -202,6 +205,8 @@ public class GeoEnrichmentLoader {
         FileUtils.copyURLToFile(url, localFile, 5000, 10000);
         if (!CompressionStrategies.GZIP.test(localFile)) {
           throw new IOException("Invalid Gzip file");
+        } else {
+          valid = true;
         }
       } catch (MalformedURLException e) {
         System.err.println("Malformed URL - aborting: " + e);

--- a/metron-platform/metron-data-management/src/main/java/org/apache/metron/dataloads/nonbulk/geo/GeoEnrichmentLoader.java
+++ b/metron-platform/metron-data-management/src/main/java/org/apache/metron/dataloads/nonbulk/geo/GeoEnrichmentLoader.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.util.GenericOptionsParser;
 import org.apache.metron.common.configuration.ConfigurationsUtils;
+import org.apache.metron.common.utils.CompressionStrategies;
 import org.apache.metron.common.utils.JSONUtils;
 import org.apache.metron.enrichment.adapters.geo.GeoLiteDatabase;
 
@@ -67,6 +68,15 @@ public class GeoEnrichmentLoader {
       public Option apply(@Nullable String s) {
         Option o = new Option(s, "remote_dir", true, "HDFS directory to land formatted GeoIP file - defaults to /apps/metron/geo/<epoch millis>/");
         o.setArgName("REMOTE_DIR");
+        o.setRequired(false);
+        return o;
+      }
+    }), RETRIES("re", new GeoEnrichmentLoader.OptionHandler() {
+      @Nullable
+      @Override
+      public Option apply(@Nullable String s) {
+        Option o = new Option(s, "retries", true, "Number of geo db download retries, after an initial failure.");
+        o.setArgName("RETRIES");
         o.setRequired(false);
         return o;
       }
@@ -146,7 +156,14 @@ public class GeoEnrichmentLoader {
     System.out.println("Retrieving GeoLite2 archive");
     String url = GeoEnrichmentOptions.GEO_URL.get(cli, "http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz");
     String tmpDir = GeoEnrichmentOptions.TMP_DIR.get(cli, "/tmp") + "/"; // Make sure there's a file separator at the end
-    File localGeoFile = downloadGeoFile(url, tmpDir);
+    int numRetries = Integer.parseInt(GeoEnrichmentOptions.RETRIES.get(cli, "2"));
+    File localGeoFile = null;
+    try {
+      localGeoFile = downloadGeoFile(url, tmpDir, numRetries);
+    } catch (IllegalStateException ies) {
+      System.err.println("Failed to download geo db file. Aborting");
+      System.exit(5);
+    }
     // Want to delete the tar in event of failure
     localGeoFile.deleteOnExit();
     System.out.println("GeoIP files downloaded successfully");
@@ -167,26 +184,38 @@ public class GeoEnrichmentLoader {
     System.out.println("Successfully created and updated new GeoIP information");
   }
 
-  protected File downloadGeoFile(String urlStr, String tmpDir) {
+  protected File downloadGeoFile(String urlStr, String tmpDir, int  numRetries) {
     File localFile = null;
-    try {
-      URL url = new URL(urlStr);
-      localFile = new File(tmpDir + new File(url.getPath()).getName());
+    int attempts = 0;
+    boolean valid = false;
+    while (attempts <= numRetries) {
+      try {
+        URL url = new URL(urlStr);
+        localFile = new File(tmpDir + new File(url.getPath()).getName());
 
-      System.out.println("Downloading " + url.toString() + " to " + localFile.getAbsolutePath());
-      if (localFile.exists() && !localFile.delete()) {
-        System.err.println("File already exists locally and can't be deleted.  Please delete before continuing");
-        System.exit(3);
+        System.out.println("Downloading " + url.toString() + " to " + localFile.getAbsolutePath());
+        if (localFile.exists() && !localFile.delete()) {
+          System.err.println(
+              "File already exists locally and can't be deleted.  Please delete before continuing");
+          System.exit(3);
+        }
+        FileUtils.copyURLToFile(url, localFile, 5000, 10000);
+        if (!CompressionStrategies.GZIP.test(localFile)) {
+          throw new IOException("Invalid Gzip file");
+        }
+      } catch (MalformedURLException e) {
+        System.err.println("Malformed URL - aborting: " + e);
+        e.printStackTrace();
+        System.exit(4);
+      } catch (IOException e) {
+        System.err.println("Warning: Unable to copy remote GeoIP database to local file, attempt " + attempts + ": " + e);
+        e.printStackTrace();
       }
-      FileUtils.copyURLToFile(url, localFile, 5000, 10000);
-    } catch (MalformedURLException e) {
-      System.err.println("Malformed URL - aborting: " + e);
-      e.printStackTrace();
-      System.exit(4);
-    } catch (IOException e) {
-      System.err.println("Unable to copy remote GeoIP database to local file: " + e);
-      e.printStackTrace();
-      System.exit(5);
+      attempts++;
+    }
+    if (!valid) {
+      System.err.println("Unable to copy remote GeoIP database to local file after " + attempts + " attempts");
+      throw new IllegalStateException("Unable to download geo enrichment database.");
     }
     return localFile;
   }

--- a/metron-platform/metron-data-management/src/main/java/org/apache/metron/dataloads/nonbulk/geo/GeoEnrichmentLoader.java
+++ b/metron-platform/metron-data-management/src/main/java/org/apache/metron/dataloads/nonbulk/geo/GeoEnrichmentLoader.java
@@ -191,7 +191,7 @@ public class GeoEnrichmentLoader {
     File localFile = null;
     int attempts = 0;
     boolean valid = false;
-    while (attempts <= numRetries) {
+    while (!valid && attempts <= numRetries) {
       try {
         URL url = new URL(urlStr);
         localFile = new File(tmpDir + new File(url.getPath()).getName());

--- a/metron-platform/metron-data-management/src/test/java/org/apache/metron/dataloads/nonbulk/geo/GeoEnrichmentLoaderTest.java
+++ b/metron-platform/metron-data-management/src/test/java/org/apache/metron/dataloads/nonbulk/geo/GeoEnrichmentLoaderTest.java
@@ -17,18 +17,23 @@
  */
 package org.apache.metron.dataloads.nonbulk.geo;
 
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.PosixParser;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.util.GenericOptionsParser;
-import org.junit.*;
+import org.apache.metron.common.utils.CompressionStrategies;
+import org.apache.metron.integration.utils.TestUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
-
-import java.io.File;
-
-import static org.junit.Assert.assertTrue;
 
 public class GeoEnrichmentLoaderTest {
   private class MockGeoEnrichmentLoader extends GeoEnrichmentLoader {
@@ -76,8 +81,10 @@ public class GeoEnrichmentLoaderTest {
 
   @Test
   public void testLoadGeoIpDatabase() throws Exception {
-    File dbFile = new File(remoteDir.getAbsolutePath() + "/GeoEnrichmentLoaderTest.mmdb");
-    dbFile.createNewFile();
+    File dbPlainTextFile = new File(remoteDir.getAbsolutePath() + "/GeoEnrichmentLoaderTest.mmdb");
+    TestUtils.write(dbPlainTextFile, "hello world");
+    File dbFile = new File(remoteDir.getAbsolutePath() + "/GeoEnrichmentLoaderTest.mmdb.gz");
+    CompressionStrategies.GZIP.compress(dbPlainTextFile, dbFile);
     String[] argv = {"--geo_url", "file://" + dbFile.getAbsolutePath(), "--remote_dir", remoteDir.getAbsolutePath(), "--tmp_dir", tmpDir.getAbsolutePath(), "--zk_quorum", "test:2181"};
     String[] otherArgs = new GenericOptionsParser(argv).getRemainingArgs();
     CommandLine cli = GeoEnrichmentLoader.GeoEnrichmentOptions.parse(new PosixParser(), otherArgs);
@@ -88,4 +95,21 @@ public class GeoEnrichmentLoaderTest {
     FileSystem fs = FileSystem.get(config);
     assertTrue(fs.exists(new Path(remoteDir + "/" + dbFile.getName())));
   }
+
+  @Rule
+  public ExpectedException exception = ExpectedException.none();
+
+  @Test
+  public void loader_throws_exception_on_bad_gzip_file() throws Exception {
+    File dbFile = new File(remoteDir.getAbsolutePath() + "/GeoEnrichmentLoaderTest.mmdb");
+    dbFile.createNewFile();
+
+    String geoUrl = "file://" + dbFile.getAbsolutePath();
+    int numRetries = 2;
+    exception.expect(IllegalStateException.class);
+    exception.expectMessage("Unable to download geo enrichment database.");
+    GeoEnrichmentLoader loader = new MockGeoEnrichmentLoader();
+    loader.downloadGeoFile(geoUrl, tmpDir.getAbsolutePath(), numRetries);
+  }
+
 }

--- a/metron-platform/metron-data-management/src/test/java/org/apache/metron/dataloads/nonbulk/geo/GeoEnrichmentLoaderTest.java
+++ b/metron-platform/metron-data-management/src/test/java/org/apache/metron/dataloads/nonbulk/geo/GeoEnrichmentLoaderTest.java
@@ -48,7 +48,7 @@ public class GeoEnrichmentLoaderTest {
   private File remoteDir;
   private File tmpDir;
 
-    @Before
+  @Before
   public void setup() throws Exception {
       testFolder.create();
       remoteDir = testFolder.newFolder("remoteDir");


### PR DESCRIPTION
## Contributor Comments

https://issues.apache.org/jira/browse/METRON-1552

We don't have retries implemented in the loader, so network and other type of failures will cause the download to blow up. This adds default retries to the loader that can be overridden by the cli options passed to the loader.

I need to finish manual testing, but putting it out there. Also added a compression strategy class to metron-common to handle the validity check.

**Testing**

I performed these steps in full dev

- Verify full dev spins up. Enrichment should load as normal
- To check the fail retry functionality:
  - Stop enrichment
  - rm $METRON_HOME/config/metron_enrichment_geo_configured
  - sudo -u hdfs hdfs dfs -rm /apps/metron/geo/default/GeoLite2-City.mmdb.gz
  - Disable your internet connection. 
  - Start enrichment. Startup should fail after 3 attempts (1 initial attempt + 2 retries), e.g.
  
```
Downloading http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz to /tmp/GeoLite2-City.mmdb.gz
Warning: Unable to copy remote GeoIP database to local file, attempt 2: java.net.UnknownHostException: geolite.maxmind.com
java.net.UnknownHostException: geolite.maxmind.com
	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:184)
	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
	at java.net.Socket.connect(Socket.java:589)
	at sun.net.NetworkClient.doConnect(NetworkClient.java:175)
	at sun.net.www.http.HttpClient.openServer(HttpClient.java:432)
	at sun.net.www.http.HttpClient.openServer(HttpClient.java:527)
	at sun.net.www.http.HttpClient.<init>(HttpClient.java:211)
	at sun.net.www.http.HttpClient.New(HttpClient.java:308)
	at sun.net.www.http.HttpClient.New(HttpClient.java:326)
	at sun.net.www.protocol.http.HttpURLConnection.getNewHttpClient(HttpURLConnection.java:1202)
	at sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1138)
	at sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1032)
	at sun.net.www.protocol.http.HttpURLConnection.connect(HttpURLConnection.java:966)
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1546)
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1474)
	at org.apache.commons.io.FileUtils.copyURLToFile(FileUtils.java:1489)
	at org.apache.metron.dataloads.nonbulk.geo.GeoEnrichmentLoader.downloadGeoFile(GeoEnrichmentLoader.java:205)
	at org.apache.metron.dataloads.nonbulk.geo.GeoEnrichmentLoader.loadGeoIpDatabase(GeoEnrichmentLoader.java:165)
	at org.apache.metron.dataloads.nonbulk.geo.GeoEnrichmentLoader.main(GeoEnrichmentLoader.java:263)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.hadoop.util.RunJar.run(RunJar.java:233)
	at org.apache.hadoop.util.RunJar.main(RunJar.java:148)
Unable to copy remote GeoIP database to local file after 3 attempts
Failed to download geo db file. Aborting
```
- Enable your internet connection again and start enrichment. It should succeed and the Ambari output should contain the following detail about the geo database:
```
2018-05-15 14:56:24,047 - Creating and loading GeoIp database
2018-05-15 14:56:24,048 - Executing command /usr/metron/0.4.3/bin/geo_enrichment_load.sh                                 -g http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz                                 -r /apps/metron/geo/default/                                 -z node1:2181
2018-05-15 14:56:24,048 - Execute['/usr/metron/0.4.3/bin/geo_enrichment_load.sh                                 -g http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz                                 -r /apps/metron/geo/default/                                 -z node1:2181'] {'logoutput': True, 'tries': 1, 'user': 'metron'}
Retrieving GeoLite2 archive
Downloading http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz to /tmp/GeoLite2-City.mmdb.gz
GeoIP files downloaded successfully
Putting GeoLite2 file into HDFS at: /apps/metron/geo/default/
Putting: /tmp/GeoLite2-City.mmdb.gz onto HDFS at: /apps/metron/geo/default
Done putting GeoLite file into HDFS
```

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
n/a

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
