### PR TITLE
METRON-1551 Profiler Should Not Use Java Serialization

### DIFF
--- a/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/ProfileMeasurement.java
+++ b/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/ProfileMeasurement.java
@@ -22,6 +22,7 @@ package org.apache.metron.profiler;
 
 import org.apache.metron.common.configuration.profiler.ProfileConfig;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -33,7 +34,7 @@ import java.util.concurrent.TimeUnit;
  * <p>A profile contains many individual {@link ProfileMeasurement} values captured over a
  * period of time.  These values in aggregate form a time series.
  */
-public class ProfileMeasurement {
+public class ProfileMeasurement implements Serializable {
 
   /**
    * The name of the profile that this measurement is associated with.

--- a/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/ProfilePeriod.java
+++ b/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/ProfilePeriod.java
@@ -20,6 +20,7 @@
 
 package org.apache.metron.profiler;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -33,7 +34,7 @@ import static java.lang.String.format;
  * The Profiler captures a ProfileMeasurement once every ProfilePeriod.  There can be
  * multiple ProfilePeriods every hour.
  */
-public class ProfilePeriod {
+public class ProfilePeriod implements Serializable {
 
   /**
    * A monotonically increasing number identifying the period.  The first period is 0

--- a/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/ProfileMeasurementTest.java
+++ b/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/ProfileMeasurementTest.java
@@ -1,0 +1,108 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.apache.metron.profiler;
+
+import org.adrianwalker.multilinestring.Multiline;
+import org.apache.metron.common.configuration.profiler.ProfileConfig;
+import org.apache.metron.common.utils.SerDeUtils;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ProfileMeasurementTest {
+
+  /**
+   * {
+   *    "profile": "test",
+   *    "foreach": "ip_src_addr",
+   *    "update": {},
+   *    "result": {
+   *      "profile": "2 + 2",
+   *      "triage": {
+   *        "eight": "4 + 4",
+   *        "sixteen": "8 + 8"
+   *      }
+   *    }
+   * }
+   */
+  @Multiline
+  private String profile;
+  private ProfileConfig definition;
+  private ProfileMeasurement measurement;
+
+  public void setup() throws Exception {
+    definition = ProfileConfig.fromJSON(profile);
+
+    measurement = new ProfileMeasurement()
+            .withProfileName("profile")
+            .withEntity("entity")
+            .withDefinition(definition)
+            .withPeriod(System.currentTimeMillis(), 10, TimeUnit.MINUTES)
+            .withProfileValue(22)
+            .withTriageValues(Collections.singletonMap("max", 200));
+  }
+
+  /**
+   * Ensure that the {@link ProfileMeasurement} can undergo Kryo serialization which
+   * occurs when the Profiler is running in Storm.
+   */
+  @Test
+  public void testKryoSerialization() throws Exception {
+
+    // round-trip serialization
+    byte[] raw = SerDeUtils.toBytes(measurement);
+    Object actual = SerDeUtils.fromBytes(raw, Object.class);
+    assertEquals(measurement, actual);
+  }
+
+  /**
+   * Ensure that the {@link ProfileMeasurement} can undergo Java serialization, should a user
+   * prefer that over Kryo serialization, which can occur when the Profiler is running
+   * in Storm.
+   */
+  @Test
+  public void testJavaSerialization() throws Exception {
+
+    // serialize using java
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    ObjectOutputStream out = new ObjectOutputStream(bytes);
+    out.writeObject(measurement);
+
+    // the serialized bits
+    byte[] raw = bytes.toByteArray();
+    assertTrue(raw.length > 0);
+
+    // deserialize using java
+    ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(raw));
+    Object actual = in.readObject();
+
+    // ensure that the round-trip was successful
+    assertEquals(measurement, actual);
+  }
+}

--- a/metron-analytics/metron-profiler/README.md
+++ b/metron-analytics/metron-profiler/README.md
@@ -123,7 +123,7 @@ Creating and refining profiles is an iterative process.  Iterating against a liv
 	[Stellar]>>> %functions PROFILER
 	PROFILER_APPLY, PROFILER_FLUSH, PROFILER_INIT
 	```  
-	
+
 1. Create a simple `hello-world` profile that will count the number of messages for each `ip_src_addr`.  The `SHELL_EDIT` function will open an editor in which you can copy/paste the following Profiler configuration.
 	```
 	[Stellar]>>> conf := SHELL_EDIT()
@@ -142,12 +142,12 @@ Creating and refining profiles is an iterative process.  Iterating against a liv
 	}
 	```
 
-1. Create a Profile execution environment; the Profile Debugger. 
+1. Create a Profile execution environment; the Profile Debugger.
 
 	The Profiler will output the number of profiles that have been defined, the number of messages that have been applied and the number of routes that have been followed.  
 
 	A route is defined when a message is applied to a specific profile.
-	* If a message is not needed by any profile, then there are no routes. 
+	* If a message is not needed by any profile, then there are no routes.
 	* If a message is needed by one profile, then one route has been followed.
 	* If a message is needed by two profiles, then two routes have been followed.
 
@@ -157,7 +157,7 @@ Creating and refining profiles is an iterative process.  Iterating against a liv
 	Profiler{1 profile(s), 0 messages(s), 0 route(s)}
 	```
 
-1. Create a message that mimics the telemetry that your profile will consume. 
+1. Create a message that mimics the telemetry that your profile will consume.
 
 	This message can be as simple or complex as you like.  For the `hello-world` profile, all you need is a message containing an `ip_src_addr` field.
 
@@ -181,11 +181,11 @@ Creating and refining profiles is an iterative process.  Iterating against a liv
 	```
 
 1. Flush the Profiler.  
-	
-	A flush is what occurs at the end of each 15 minute period in the Profiler.  The result is a list of Profile Measurements. Each measurement is a map containing detailed information about the profile data that has been generated. The `value` field is what is written to HBase when running this profile in the Profiler topology. 
-	
+
+	A flush is what occurs at the end of each 15 minute period in the Profiler.  The result is a list of Profile Measurements. Each measurement is a map containing detailed information about the profile data that has been generated. The `value` field is what is written to HBase when running this profile in the Profiler topology.
+
 	There will always be one measurement for each [profile, entity] pair.  This profile simply counts the number of messages by IP source address. Notice that the value is '3' for the entity '10.0.0.1' as we applied 3 messages with an 'ip_src_addr' of ’10.0.0.1'.
-	
+
 	```
 	[Stellar]>>> values := PROFILER_FLUSH(profiler)
 	[Stellar]>>> values
@@ -197,9 +197,9 @@ Creating and refining profiles is an iterative process.  Iterating against a liv
 
 	Once you are happy with your profile against a controlled data set, it can be useful to introduce more complex, live data.  This example extracts 10 messages of live, enriched telemetry to test your profile(s).
 	```
-	[Stellar]>>> %define bootstrap.servers := "node1:6667" 
+	[Stellar]>>> %define bootstrap.servers := "node1:6667"
 	node1:6667
-	[Stellar]>>> msgs := KAFKA_GET("indexing", 10) 
+	[Stellar]>>> msgs := KAFKA_GET("indexing", 10)
 	[Stellar]>>> LENGTH(msgs)
 	10
 	```
@@ -228,7 +228,7 @@ Continuing the previous running example, at this point, you have seen how your p
 	[Stellar]>>>
 	[Stellar]>>> %functions CONFIG CONFIG_GET, CONFIG_PUT
 	```
-	
+
 1. If you haven't already, define your profile.
 	```
 	[Stellar]>>> conf := SHELL_EDIT()
@@ -250,7 +250,7 @@ Continuing the previous running example, at this point, you have seen how your p
 1. Check what is already deployed.  
 
 	Pushing a new profile configuration is destructive.  It will overwrite any existing configuration.  Check what you have out there.  Manually merge the existing configuration with your new profile definition.
-	
+
 	```
 	[Stellar]>>> existing := CONFIG_GET("PROFILER")
 	```
@@ -260,7 +260,7 @@ Continuing the previous running example, at this point, you have seen how your p
 	[Stellar]>>> CONFIG_PUT("PROFILER", conf)
 	```
 
-### Deploying Profiles from the Command Line 
+### Deploying Profiles from the Command Line
 
 1. Create the profile definition in a file located at `$METRON_HOME/config/zookeeper/profiler.json`.  This file will likely not exist, if you have never created Profiles before.
 
@@ -364,7 +364,7 @@ Indicates whether processing time or event time is used. By default, processing 
 
 By default, no `timestampField` is defined.  In this case, the Profiler uses system time when generating profiles.  This means that the profiles are generated based on when the data has been processed by the Profiler.  This is also known as 'processing time'.
 
-This is the simplest mode of operation, but has some draw backs.  If the Profiler is consuming live data and all is well, the processing and event times will likely remain similar and consistent. If processing time diverges from event time, then the Profiler will generate skewed profiles. 
+This is the simplest mode of operation, but has some draw backs.  If the Profiler is consuming live data and all is well, the processing and event times will likely remain similar and consistent. If processing time diverges from event time, then the Profiler will generate skewed profiles.
 
 There are a few scenarios that might cause skewed profiles when using processing time.  For example when a system has undergone a scheduled maintenance window and is restarted, a high volume of messages will need to be processed by the Profiler. The output of the Profiler might indicate an increase in activity during this time, although no change in activity actually occurred on the target network. The same situation could occur if an upstream system which provides telemetry undergoes an outage.  
 
@@ -380,7 +380,7 @@ Alternatively, a `timestampField` can be defined.  This must be the name of a fi
 
 * The Profiler will use the same field across all telemetry sources and for all profiles.
 
-* Be aware of clock skew across telemetry sources.  If your profile is processing telemetry from multiple sources where the clock differs significantly, the Profiler may assume that some of those messages are late and will be ignored.  Adjusting the [`profiler.window.duration`](#profilerwindowduration) and [`profiler.window.lag`](#profilerwindowlag) can help accommodate skewed clocks. 
+* Be aware of clock skew across telemetry sources.  If your profile is processing telemetry from multiple sources where the clock differs significantly, the Profiler may assume that some of those messages are late and will be ignored.  Adjusting the [`profiler.window.duration`](#profilerwindowduration) and [`profiler.window.lag`](#profilerwindowlag) can help accommodate skewed clocks.
 
 ### Profiles
 
@@ -516,14 +516,12 @@ The REPL can be a powerful for developing profiles. Read all about [Developing P
 
 ## Configuring the Profiler
 
-The Profiler runs as an independent Storm topology.  The configuration for the Profiler topology is stored in local filesystem at `$METRON_HOME/config/profiler.properties`.
-The values can be changed on disk and then the Profiler topology must be restarted.
-
+The Profiler runs as an independent Storm topology.  The configuration for the Profiler topology is stored in local filesystem at `$METRON_HOME/config/profiler.properties`. After changing these values, the Profiler topology must be restarted for the changes to take effect.
 
 | Setting                                                                       | Description
 |---                                                                            |---
 | [`profiler.input.topic`](#profilerinputtopic)                                 | The name of the input Kafka topic.
-| [`profiler.output.topic`](#profileroutputtopic)                               | The name of the output Kafka topic. 
+| [`profiler.output.topic`](#profileroutputtopic)                               | The name of the output Kafka topic.
 | [`profiler.period.duration`](#profilerperiodduration)                         | The duration of each profile period.  
 | [`profiler.period.duration.units`](#profilerperioddurationunits)              | The units used to specify the [`profiler.period.duration`](#profilerperiodduration).
 | [`profiler.window.duration`](#profilerwindowduration)                         | The duration of each profile window.
@@ -539,6 +537,8 @@ The values can be changed on disk and then the Profiler topology must be restart
 | [`profiler.hbase.column.family`](#profilerhbasecolumnfamily)                  | The column family used to store profiles.
 | [`profiler.hbase.batch`](#profilerhbasebatch)                                 | The number of puts that are written to HBase in a single batch.
 | [`profiler.hbase.flush.interval.seconds`](#profilerhbaseflushintervalseconds) | The maximum number of seconds between batch writes to HBase.
+| [`topology.kryo.register`](#topologykryoregister)                             | Storm will use Kryo serialization for these classes.
+
 
 ### `profiler.input.topic`
 
@@ -653,6 +653,30 @@ The number of puts that are written to HBase in a single batch.
 *Default*: 30
 
 The maximum number of seconds between batch writes to HBase.
+
+### `topology.kryo.register`
+
+*Default*:
+```
+[ org.apache.metron.profiler.ProfileMeasurement, \
+  org.apache.metron.profiler.ProfilePeriod, \
+  org.apache.metron.common.configuration.profiler.ProfileResult, \
+  org.apache.metron.common.configuration.profiler.ProfileResultExpressions, \
+  org.apache.metron.common.configuration.profiler.ProfileTriageExpressions, \
+  org.apache.metron.common.configuration.profiler.ProfilerConfig, \
+  org.apache.metron.common.configuration.profiler.ProfileConfig, \
+  org.json.simple.JSONObject, \
+  java.util.LinkedHashMap, \
+  org.apache.metron.statistics.OnlineStatisticsProvider ]
+```               
+
+Storm will use Kryo serialization for these classes. Kryo serialization is more performant than Java serialization, in most cases.  
+
+For these classes, Storm will uses Kryo's `FieldSerializer` as defined in the [Storm Serialization docs]((http://storm.apache.org/releases/1.1.2/Serialization.html).  For all other classes not in this list, Storm defaults to using Java serialization which is slower and not recommended for a production topology.
+
+This value should only need altered if you have defined a profile that results in a non-primitive, user-defined type that is not in this list.  If the class is not defined in this list, Java serialization will be used and the class must adhere to Java's serialization requirements.  
+
+The performance of the entire Profiler topology can be negatively impacted if any profile produces results that undergo Java serialization.
 
 ## Examples
 

--- a/metron-analytics/metron-profiler/README.md
+++ b/metron-analytics/metron-profiler/README.md
@@ -672,7 +672,7 @@ The maximum number of seconds between batch writes to HBase.
 
 Storm will use Kryo serialization for these classes. Kryo serialization is more performant than Java serialization, in most cases.  
 
-For these classes, Storm will uses Kryo's `FieldSerializer` as defined in the [Storm Serialization docs]((http://storm.apache.org/releases/1.1.2/Serialization.html).  For all other classes not in this list, Storm defaults to using Java serialization which is slower and not recommended for a production topology.
+For these classes, Storm will uses Kryo's `FieldSerializer` as defined in the [Storm Serialization docs](http://storm.apache.org/releases/1.1.2/Serialization.html).  For all other classes not in this list, Storm defaults to using Java serialization which is slower and not recommended for a production topology.
 
 This value should only need altered if you have defined a profile that results in a non-primitive, user-defined type that is not in this list.  If the class is not defined in this list, Java serialization will be used and the class must adhere to Java's serialization requirements.  
 

--- a/metron-analytics/metron-profiler/src/main/config/profiler.properties
+++ b/metron-analytics/metron-profiler/src/main/config/profiler.properties
@@ -26,6 +26,19 @@ profiler.workers=1
 profiler.executors=0
 topology.message.timeout.secs=30
 topology.max.spout.pending=100000
+topology.fall.back.on.java.serialization=true
+topology.testing.always.try.serialize=false
+topology.kryo.register=[ org.apache.metron.profiler.ProfileMeasurement, \
+    org.apache.metron.profiler.ProfilePeriod, \
+    org.apache.metron.common.configuration.profiler.ProfileResult, \
+    org.apache.metron.common.configuration.profiler.ProfileResultExpressions, \
+    org.apache.metron.common.configuration.profiler.ProfileTriageExpressions, \
+    org.apache.metron.common.configuration.profiler.ProfilerConfig, \
+    org.apache.metron.common.configuration.profiler.ProfileConfig, \
+    org.json.simple.JSONObject, \
+    org.json.simple.JSONArray, \
+    java.util.LinkedHashMap, \
+    org.apache.metron.statistics.OnlineStatisticsProvider ]
 
 ##### Profiler #####
 

--- a/metron-analytics/metron-profiler/src/main/flux/profiler/remote.yaml
+++ b/metron-analytics/metron-profiler/src/main/flux/profiler/remote.yaml
@@ -23,6 +23,9 @@ config:
     topology.auto-credentials: ${topology.auto-credentials}
     topology.message.timeout.secs: ${topology.message.timeout.secs}
     topology.max.spout.pending: ${topology.max.spout.pending}
+    topology.testing.always.try.serialize: ${topology.testing.always.try.serialize}
+    topology.fall.back.on.java.serialization: ${topology.fall.back.on.java.serialization}
+    topology.kryo.register: ${topology.kryo.register}
 
 components:
 

--- a/metron-analytics/metron-profiler/src/test/config/zookeeper/profile-with-stats/profiler.json
+++ b/metron-analytics/metron-profiler/src/test/config/zookeeper/profile-with-stats/profiler.json
@@ -1,0 +1,12 @@
+{
+  "profiles": [
+    {
+      "profile": "profile-with-stats",
+      "foreach": "'global'",
+      "init":   { "stats": "STATS_INIT()" },
+      "update": { "stats": "STATS_ADD(stats, 1)" },
+      "result": "stats"
+    }
+  ],
+  "timestampField": "timestamp"
+}

--- a/metron-analytics/metron-statistics/src/main/java/org/apache/metron/statistics/sampling/UniformSampler.java
+++ b/metron-analytics/metron-statistics/src/main/java/org/apache/metron/statistics/sampling/UniformSampler.java
@@ -17,6 +17,7 @@
  */
 package org.apache.metron.statistics.sampling;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -25,7 +26,8 @@ import java.util.Random;
  * This is a reservoir sampler without replacement where each element sampled will be included
  * with equal probability in the reservoir.
  */
-public class UniformSampler implements Sampler {
+public class UniformSampler implements Sampler, Serializable {
+
   private List<Object> reservoir;
   private int seen = 0;
   private int size;
@@ -83,7 +85,6 @@ public class UniformSampler implements Sampler {
 
     if (getSize() != that.getSize()) return false;
     return reservoir != null ? reservoir.equals(that.reservoir) : that.reservoir == null;
-
   }
 
   @Override

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/templates/profiler.properties.j2
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/templates/profiler.properties.j2
@@ -26,6 +26,19 @@ profiler.workers={{profiler_topology_workers}}
 profiler.executors={{profiler_acker_executors}}
 topology.message.timeout.secs={{profiler_topology_message_timeout_secs}}
 topology.max.spout.pending={{profiler_topology_max_spout_pending}}
+topology.fall.back.on.java.serialization=true
+topology.testing.always.try.serialize=false
+topology.kryo.register=[ org.apache.metron.profiler.ProfileMeasurement, \
+    org.apache.metron.profiler.ProfilePeriod, \
+    org.apache.metron.common.configuration.profiler.ProfileResult, \
+    org.apache.metron.common.configuration.profiler.ProfileResultExpressions, \
+    org.apache.metron.common.configuration.profiler.ProfileTriageExpressions, \
+    org.apache.metron.common.configuration.profiler.ProfilerConfig, \
+    org.apache.metron.common.configuration.profiler.ProfileConfig, \
+    org.json.simple.JSONObject, \
+    org.json.simple.JSONArray, \
+    java.util.LinkedHashMap, \
+    org.apache.metron.statistics.OnlineStatisticsProvider ]
 
 ##### Profiler #####
 

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/profiler/ProfileResult.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/profiler/ProfileResult.java
@@ -20,10 +20,12 @@ package org.apache.metron.common.configuration.profiler;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
+
 /**
  * Defines the 'result' field of a Profile definition.
  */
-public class ProfileResult {
+public class ProfileResult implements Serializable {
 
   /**
    * A Stellar expression that is executed to produce

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/profiler/ProfileResultExpressions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/profiler/ProfileResultExpressions.java
@@ -20,11 +20,13 @@ package org.apache.metron.common.configuration.profiler;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.io.Serializable;
+
 /**
  * A Stellar expression that is executed to produce a single
  * measurement that is persisted within the profile store.
  */
-public class ProfileResultExpressions {
+public class ProfileResultExpressions implements Serializable {
 
   private String expression;
 

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/profiler/ProfileTriageExpressions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/profiler/ProfileTriageExpressions.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,7 +33,7 @@ import java.util.Map;
  * The result of evaluating each expression are made available, keyed
  * by the given name, to the threat triage process.
  */
-public class ProfileTriageExpressions {
+public class ProfileTriageExpressions implements Serializable {
 
   /**
    * A set of named Stellar expressions.  The name of the expression

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/profiler/ProfilerConfig.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/profiler/ProfilerConfig.java
@@ -56,7 +56,7 @@ public class ProfilerConfig implements Serializable {
    * <p>If a message does NOT contain this field, it will be dropped
    * and not included in any profiles.
    */
-  private Optional<String> timestampField = Optional.empty();
+  private String timestampField = null;
 
   public List<ProfileConfig> getProfiles() {
     return profiles;
@@ -73,24 +73,24 @@ public class ProfilerConfig implements Serializable {
 
   @JsonGetter("timestampField")
   public String getTimestampFieldForJson() {
-    return timestampField.orElse(null);
+    return timestampField;
   }
 
   public Optional<String> getTimestampField() {
-    return timestampField;
+    return Optional.ofNullable(timestampField);
   }
 
   @JsonSetter("timestampField")
   public void setTimestampField(String timestampField) {
-    this.timestampField = Optional.of(timestampField);
+    this.timestampField = timestampField;
   }
 
   public void setTimestampField(Optional<String> timestampField) {
-    this.timestampField = timestampField;
+    this.timestampField = timestampField.orElse(null);
   }
 
   public ProfilerConfig withTimestampField(Optional<String> timestampField) {
-    this.timestampField = timestampField;
+    this.timestampField = timestampField.orElse(null);
     return this;
   }
 

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/utils/SerDeUtils.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/utils/SerDeUtils.java
@@ -47,6 +47,7 @@ import de.javakaffee.kryoserializers.guava.ImmutableSetSerializer;
 import de.javakaffee.kryoserializers.jodatime.JodaLocalDateSerializer;
 import de.javakaffee.kryoserializers.jodatime.JodaLocalDateTimeSerializer;
 import java.io.ByteArrayInputStream;
+import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
@@ -188,7 +189,7 @@ public class SerDeUtils {
 
   public static Serializer SERIALIZER = new Serializer();
 
-  private static class Serializer implements Function<Object, byte[]> {
+  private static class Serializer implements Function<Object, byte[]>, Serializable {
     /**
      * Serializes the given Object into bytes.
      *
@@ -199,9 +200,10 @@ public class SerDeUtils {
     }
   }
 
-  public static class Deserializer<T> implements Function<byte[], T> {
+  public static class Deserializer<T> implements Function<byte[], T>, Serializable {
 
     private Class<T> clazz;
+
     public Deserializer(Class<T> clazz) {
       this.clazz = clazz;
     }
@@ -216,7 +218,6 @@ public class SerDeUtils {
       return fromBytes(bytes, clazz);
     }
   }
-
 
   private SerDeUtils() {
     // do not instantiate

--- a/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/common/utils/BloomFilter.java
+++ b/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/common/utils/BloomFilter.java
@@ -26,10 +26,13 @@ import java.util.function.Function;
 public class BloomFilter<T> implements Serializable {
 
   private static class BloomFunnel<T> implements Funnel<T>, Serializable {
+
     Function<T, byte[]> serializer;
+
     public BloomFunnel(Function<T, byte[]> serializer) {
       this.serializer = serializer;
     }
+
     @Override
     public void funnel(T obj, PrimitiveSink primitiveSink) {
       primitiveSink.putBytes(serializer.apply(obj));
@@ -46,12 +49,13 @@ public class BloomFilter<T> implements Serializable {
     }
   }
 
-  public static class DefaultSerializer<T> implements Function<T, byte[]> {
+  public static class DefaultSerializer<T> implements Function<T, byte[]>, Serializable {
     @Override
     public byte[] apply(T t) {
       return SerDeUtils.toBytes(t);
     }
   }
+
   private com.google.common.hash.BloomFilter<T> filter;
 
   public BloomFilter(Function<T, byte[]> serializer, int expectedInsertions, double falsePositiveRate) {
@@ -61,9 +65,11 @@ public class BloomFilter<T> implements Serializable {
   public boolean mightContain(T key) {
     return filter.mightContain(key);
   }
+
   public void add(T key) {
     filter.put(key);
   }
+
   public void merge(BloomFilter<T> filter2) {
     filter.putAll(filter2.filter);
   }

--- a/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/common/utils/SerDeUtils.java
+++ b/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/common/utils/SerDeUtils.java
@@ -45,6 +45,7 @@ import de.javakaffee.kryoserializers.guava.ImmutableSetSerializer;
 import de.javakaffee.kryoserializers.jodatime.JodaLocalDateSerializer;
 import de.javakaffee.kryoserializers.jodatime.JodaLocalDateTimeSerializer;
 import java.io.ByteArrayInputStream;
+import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Modifier;
@@ -88,14 +89,16 @@ public class SerDeUtils {
       UnmodifiableCollectionsSerializer.registerSerializers(ret);
       SynchronizedCollectionsSerializer.registerSerializers(ret);
 
-// custom serializers for non-jdk libs
+      // custom serializers for non-jdk libs
 
-// register CGLibProxySerializer, works in combination with the appropriate action in handleUnregisteredClass (see below)
+      // register CGLibProxySerializer, works in combination with the appropriate action in handleUnregisteredClass (see below)
       ret.register(CGLibProxySerializer.CGLibProxyMarker.class, new CGLibProxySerializer());
-// joda DateTime, LocalDate and LocalDateTime
+
+      // joda DateTime, LocalDate and LocalDateTime
       ret.register(LocalDate.class, new JodaLocalDateSerializer());
       ret.register(LocalDateTime.class, new JodaLocalDateTimeSerializer());
-// guava ImmutableList, ImmutableSet, ImmutableMap, ImmutableMultimap, UnmodifiableNavigableSet
+
+      // guava ImmutableList, ImmutableSet, ImmutableMap, ImmutableMultimap, UnmodifiableNavigableSet
       ImmutableListSerializer.registerSerializers(ret);
       ImmutableSetSerializer.registerSerializers(ret);
       ImmutableMapSerializer.registerSerializers(ret);
@@ -187,7 +190,7 @@ public class SerDeUtils {
 
   public static Serializer SERIALIZER = new Serializer();
 
-  private static class Serializer implements Function<Object, byte[]> {
+  private static class Serializer implements Function<Object, byte[]>, Serializable {
     /**
      * Serializes the given Object into bytes.
      *
@@ -198,9 +201,10 @@ public class SerDeUtils {
     }
   }
 
-  public static class Deserializer<T> implements Function<byte[], T> {
+  public static class Deserializer<T> implements Function<byte[], T>, Serializable {
 
     private Class<T> clazz;
+
     public Deserializer(Class<T> clazz) {
       this.clazz = clazz;
     }


### PR DESCRIPTION
When running the Profiler in a topology where serialization occurs, the following error happens.  This can occur when the number of workers is greater than 1.

The topology should not be using Java serialization for serializing tuple values as this will negatively impact performance. 

```
2018-05-09 10:48:35.136 o.a.s.d.executor [ERROR] 
java.lang.RuntimeException: java.lang.RuntimeException: java.io.NotSerializableException: org.apache.metron.common.configuration.profiler.ProfileResult
 at org.apache.storm.utils.DisruptorQueue.consumeBatchToCursor(DisruptorQueue.java:485) ~[storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
 at org.apache.storm.utils.DisruptorQueue.consumeBatchWhenAvailable(DisruptorQueue.java:451) ~[storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
 at org.apache.storm.disruptor$consume_batch_when_available.invoke(disruptor.clj:73) ~[storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
 at org.apache.storm.disruptor$consume_loop_STAR_$fn__7183.invoke(disruptor.clj:83) ~[storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
 at org.apache.storm.util$async_loop$fn__553.invoke(util.clj:484) [storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
 at clojure.lang.AFn.run(AFn.java:22) [clojure-1.7.0.jar:?]
 at java.lang.Thread.run(Thread.java:748) [?:1.8.0_162]
Caused by: java.lang.RuntimeException: java.io.NotSerializableException: org.apache.metron.common.configuration.profiler.ProfileResult
 at org.apache.storm.serialization.SerializableSerializer.write(SerializableSerializer.java:41) ~[storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
 at com.esotericsoftware.kryo.Kryo.writeClassAndObject(Kryo.java:628) ~[kryo-3.0.3.jar:?]
 at com.esotericsoftware.kryo.serializers.CollectionSerializer.write(CollectionSerializer.java:100) ~[kryo-3.0.3.jar:?]
 at com.esotericsoftware.kryo.serializers.CollectionSerializer.write(CollectionSerializer.java:40) ~[kryo-3.0.3.jar:?]
 at com.esotericsoftware.kryo.Kryo.writeObject(Kryo.java:534) ~[kryo-3.0.3.jar:?]
 at org.apache.storm.serialization.KryoValuesSerializer.serializeInto(KryoValuesSerializer.java:44) ~[storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
 at org.apache.storm.serialization.KryoTupleSerializer.serialize(KryoTupleSerializer.java:44) ~[storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
 at org.apache.storm.daemon.worker$mk_transfer_fn$transfer_fn__7805.invoke(worker.clj:193) ~[storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
 at org.apache.storm.daemon.executor$start_batch_transfer__GT_worker_handler_BANG_$fn__7430.invoke(executor.clj:309) ~[storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
 at org.apache.storm.disruptor$clojure_handler$reify__7166.onEvent(disruptor.clj:40) ~[storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
 at org.apache.storm.utils.DisruptorQueue.consumeBatchToCursor(DisruptorQueue.java:472) ~[storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
 ... 6 more
Caused by: java.io.NotSerializableException: org.apache.metron.common.configuration.profiler.ProfileResult
 at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1184) ~[?:1.8.0_162]
 at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1548) ~[?:1.8.0_162]
 at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1509) ~[?:1.8.0_162]
 at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1432) ~[?:1.8.0_162]
 at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1178) ~[?:1.8.0_162]
 at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:348) ~[?:1.8.0_162]
 at org.apache.storm.serialization.SerializableSerializer.write(SerializableSerializer.java:38) ~[storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
 at com.esotericsoftware.kryo.Kryo.writeClassAndObject(Kryo.java:628) ~[kryo-3.0.3.jar:?]
 at com.esotericsoftware.kryo.serializers.CollectionSerializer.write(CollectionSerializer.java:100) ~[kryo-3.0.3.jar:?]
 at com.esotericsoftware.kryo.serializers.CollectionSerializer.write(CollectionSerializer.java:40) ~[kryo-3.0.3.jar:?]
 at com.esotericsoftware.kryo.Kryo.writeObject(Kryo.java:534) ~[kryo-3.0.3.jar:?]
 at org.apache.storm.serialization.KryoValuesSerializer.serializeInto(KryoValuesSerializer.java:44) ~[storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
 at org.apache.storm.serialization.KryoTupleSerializer.serialize(KryoTupleSerializer.java:44) ~[storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
 at org.apache.storm.daemon.worker$mk_transfer_fn$transfer_fn__7805.invoke(worker.clj:193) ~[storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
 at org.apache.storm.daemon.executor$start_batch_transfer__GT_worker_handler_BANG_$fn__7430.invoke(executor.clj:309) ~[storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
 at org.apache.storm.disruptor$clojure_handler$reify__7166.onEvent(disruptor.clj:40) ~[storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
 at org.apache.storm.utils.DisruptorQueue.consumeBatchToCursor(DisruptorQueue.java:472) ~[storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
 ... 6 more
```

### Changes

* Defined a configuration property `topology.kryo.register` for Storm that specifies the classes which should use Kryo serialization.  Storm requires that you specifically tell it which classes should undergo Kryo serialization.  

* If an advanced user creates a profile that results in a user-defined type (a class not already in `topology.kryo.register`) this property allows them to register the class for Kryo serialization.  This could happen if a user is using a 3rd party library containing Stellar functions.

* Updated the existing integration tests to force them to serialize tuples and to fail if Java serialization is used.

* Created another integration test that creates a profile that uses the STATS library.  This ensures that the STATS library can be Kryo serialized.

* Updated the README to reflect this change.

* Updated all Profiler classes to be Java serializable in case a user chooses to use Java serialization in their Storm topology.  This is not recommended, but there is no reason to block a user from doing so.

### Manual Testing

1. Launch the development environment.

1. Alter the Profiler properties. 

    Set the Profiler duration to 1 minute.
    ```
    profiler.period.duration=1
    profiler.period.duration.units=MINUTES
    ```

    Force the topology to fail if Kryo serialization is not used.
    ```
    topology.fall.back.on.java.serialization=false
    ```

    Force the topology to serialize values, even with a single worker.
    ```
    topology.testing.always.try.serialize=true
    ```

1. Restart the Profiler.

    ```
    source /etc/default/metron
    storm kill profiler
    $METRON_HOME/bin/start_profiler_topology.sh
    ```

1. Create a Profile that uses the STATS library.

    ```
    $METRON_HOME/bin/stellar -z $ZOOKEEPER
    ```

    ```
    [Stellar]>>> conf := SHELL_EDIT()
    {
      "profiles": [
        {
          "profile": "profile-with-stats",
          "foreach": "'global'",
          "init":   { "stats": "STATS_INIT()" },
          "update": { "stats": "STATS_ADD(stats, 1)" },
          "result": "stats"
        }
      ],
      "timestampField": "timestamp"
    }
    [Stellar]>>> CONFIG_PUT("PROFILER",conf)
    ```

1. Wait until a flush event occurs, then attempt to retrieve the profile values.  If values can be retrieved, the change has been successful.

    ```
    [Stellar]>>> stats := PROFILE_GET("profile-with-stats", "global", PROFILE_FIXED(30, "DAYS"))
    [org.apache.metron.statistics.OnlineStatisticsProvider@c8bab446, org.apache.metron.statistics.OnlineStatisticsProvider@2990520a, org.apache.metron.statistics.OnlineStatisticsProvider@f6affafd, org.apache.metron.statistics.OnlineStatisticsProvider@de0d511, org.apache.metron.statistics.OnlineStatisticsProvider@9247daa4, org.apache.metron.statistics.OnlineStatisticsProvider@ddef62a6, org.apache.metron.statistics.OnlineStatisticsProvider@2e6874a6, org.apache.metron.statistics.OnlineStatisticsProvider@8568c433, org.apache.metron.statistics.OnlineStatisticsProvider@dc65d27e, org.apache.metron.statistics.OnlineStatisticsProvider@28b2e728]
    ```
    ```
    [Stellar]>>> STATS_MEAN(STATS_MERGE(stats))
    1.0
    ```



 



## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
