### PR TITLE
METRON-1544 Flaky test: org.apache.metron.stellar.common.CachingStell…

### DIFF
--- a/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/common/CachingStellarProcessor.java
+++ b/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/common/CachingStellarProcessor.java
@@ -161,14 +161,18 @@ public class CachingStellarProcessor extends StellarProcessor {
   }
 
   /**
-   * Create a cache key.
+   * Create a cache key using the expression and all variables used by that expression.
    *
    * @param expression The Stellar expression.
    * @param resolver The variable resolver.
    * @return A key with which to do a cache lookup.
    */
   private Key toKey(String expression, VariableResolver resolver) {
+
+    // fetch only the variables used in the expression
     Set<String> variablesUsed = variableCache.get().computeIfAbsent(expression, this::variablesUsed);
+
+    // resolve each of the variables used by the expression
     Map<String, Object> input = new HashMap<>();
     for(String v : variablesUsed) {
       input.computeIfAbsent(v, resolver::resolve);

--- a/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/common/CachingStellarProcessor.java
+++ b/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/common/CachingStellarProcessor.java
@@ -19,11 +19,16 @@ package org.apache.metron.stellar.common;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.metron.stellar.common.utils.ConversionUtils;
 import org.apache.metron.stellar.dsl.Context;
 import org.apache.metron.stellar.dsl.VariableResolver;
 import org.apache.metron.stellar.dsl.functions.resolver.FunctionResolver;
+import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -35,12 +40,38 @@ import java.util.concurrent.TimeUnit;
  * LFU cache.
  */
 public class CachingStellarProcessor extends StellarProcessor {
+
+  private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private static ThreadLocal<Map<String, Set<String>> > variableCache = ThreadLocal.withInitial(() -> new HashMap<>());
+
+  /**
+   * A property that defines the maximum cache size.
+   */
   public static String MAX_CACHE_SIZE_PARAM = "stellar.cache.maxSize";
+
+  /**
+   * A property that defines the max time that elements are retained in the cache.
+   */
   public static String MAX_TIME_RETAIN_PARAM = "stellar.cache.maxTimeRetain";
 
+  /**
+   * A property that defines if cache usage stats should be recorded.
+   */
+  public static String RECORD_STATS = "stellar.cache.record.stats";
+
+  /**
+   * The cache key is based on the expression and input values.
+   */
   public static class Key {
+
+    /**
+     * The expression to execute.
+     */
     private String expression;
+
+    /**
+     * The variables that serve as input to the expression.
+     */
     private Map<String, Object> input;
 
     public Key(String expression, Map<String, Object> input) {
@@ -58,58 +89,92 @@ public class CachingStellarProcessor extends StellarProcessor {
 
     @Override
     public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
+      if (this == o) {
+        return true;
+      }
+
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
 
       Key key = (Key) o;
-
-      if (getExpression() != null ? !getExpression().equals(key.getExpression()) : key.getExpression() != null)
-        return false;
-      return getInput() != null ? getInput().equals(key.getInput()) : key.getInput() == null;
-
+      return new EqualsBuilder()
+              .append(expression, key.expression)
+              .append(input, key.input)
+              .isEquals();
     }
 
     @Override
     public int hashCode() {
-      int result = getExpression() != null ? getExpression().hashCode() : 0;
-      result = 31 * result + (getInput() != null ? getInput().hashCode() : 0);
-      return result;
+      return new HashCodeBuilder(17, 37)
+              .append(expression)
+              .append(input)
+              .toHashCode();
+    }
+
+    @Override
+    public String toString() {
+      return new ToStringBuilder(this)
+              .append("expression", expression)
+              .append("input", input)
+              .toString();
     }
   }
 
-
   /**
-   * Parses and evaluates the given Stellar expression, {@code expression}.  Results will be taken from a cache if possible.
+   * Parses and evaluates the given Stellar expression, {@code expression}. Results will be taken
+   * from a cache if possible.
    *
-   * @param expression             The Stellar expression to parse and evaluate.
-   * @param variableResolver The {@link VariableResolver} to determine values of variables used in the Stellar expression, {@code expression}.
-   * @param functionResolver The {@link FunctionResolver} to determine values of functions used in the Stellar expression, {@code expression}.
-   * @param context          The context used during validation.
+   * @param expression The Stellar expression to parse and evaluate.
+   * @param variableResolver The {@link VariableResolver} to determine values of variables used in
+   *     the Stellar expression, {@code expression}.
+   * @param functionResolver The {@link FunctionResolver} to determine values of functions used in
+   *     the Stellar expression, {@code expression}.
+   * @param context The context used during validation.
    * @return The value of the evaluated Stellar expression, {@code expression}.
    */
   @Override
-  public Object parse(String expression, VariableResolver variableResolver, FunctionResolver functionResolver, Context context) {
+  public Object parse(
+      String expression,
+      VariableResolver variableResolver,
+      FunctionResolver functionResolver,
+      Context context) {
+
     Optional<Object> cacheOpt = context.getCapability(Context.Capabilities.CACHE, false);
     if(cacheOpt.isPresent()) {
+
+      // use the cache
       Cache<Key, Object> cache = (Cache<Key, Object>) cacheOpt.get();
       Key k = toKey(expression, variableResolver);
       return cache.get(k, x -> parseUncached(x.expression, variableResolver, functionResolver, context));
-    }
-    else {
+
+    } else {
+
+      // no cache present
       return parseUncached(expression, variableResolver, functionResolver, context);
     }
   }
 
   protected Object parseUncached(String expression, VariableResolver variableResolver, FunctionResolver functionResolver, Context context) {
+    LOG.debug("Executing Stellar; expression={}", expression);
     return super.parse(expression, variableResolver, functionResolver, context);
   }
 
+  /**
+   * Create a cache key.
+   *
+   * @param expression The Stellar expression.
+   * @param resolver The variable resolver.
+   * @return A key with which to do a cache lookup.
+   */
   private Key toKey(String expression, VariableResolver resolver) {
     Set<String> variablesUsed = variableCache.get().computeIfAbsent(expression, this::variablesUsed);
     Map<String, Object> input = new HashMap<>();
     for(String v : variablesUsed) {
       input.computeIfAbsent(v, resolver::resolve);
     }
+
+    LOG.debug("Created cache key; expression={}, vars={}", expression, input);
     return new Key(expression, input);
   }
 
@@ -119,18 +184,39 @@ public class CachingStellarProcessor extends StellarProcessor {
    * @return A cache.
    */
   public static Cache<Key, Object> createCache(Map<String, Object> config) {
+
+    // the cache configuration is required
     if(config == null) {
+      LOG.debug("Cannot create cache; missing cache configuration");
       return null;
     }
+
+    // max cache size is required
     Long maxSize = getParam(config, MAX_CACHE_SIZE_PARAM, null, Long.class);
-    Integer maxTimeRetain = getParam(config, MAX_TIME_RETAIN_PARAM, null, Integer.class);
-    if(maxSize == null || maxTimeRetain == null || maxSize <= 0 || maxTimeRetain <= 0) {
+    if(maxSize == null || maxSize <= 0) {
+      LOG.error("Cannot create cache; missing or invalid configuration; {} = {}", MAX_CACHE_SIZE_PARAM, maxSize);
       return null;
     }
-    return Caffeine.newBuilder()
-                   .maximumSize(maxSize)
-                   .expireAfterWrite(maxTimeRetain, TimeUnit.MINUTES)
-                   .build();
+
+    // max time retain is required
+    Integer maxTimeRetain = getParam(config, MAX_TIME_RETAIN_PARAM, null, Integer.class);
+    if(maxTimeRetain == null || maxTimeRetain <= 0) {
+      LOG.error("Cannot create cache; missing or invalid configuration; {} = {}", MAX_TIME_RETAIN_PARAM, maxTimeRetain);
+      return null;
+    }
+
+    Caffeine<Object, Object> cache = Caffeine
+            .newBuilder()
+            .maximumSize(maxSize)
+            .expireAfterWrite(maxTimeRetain, TimeUnit.MINUTES);
+
+    // record stats is optional
+    Boolean recordStats = getParam(config, RECORD_STATS, false, Boolean.class);
+    if(recordStats) {
+      cache.recordStats();
+    }
+
+    return cache.build();
   }
 
   private static <T> T getParam(Map<String, Object> config, String key, T defaultVal, Class<T> clazz) {

--- a/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/common/CachingStellarProcessorTest.java
+++ b/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/common/CachingStellarProcessorTest.java
@@ -22,14 +22,13 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.metron.stellar.dsl.Context;
 import org.apache.metron.stellar.dsl.MapVariableResolver;
 import org.apache.metron.stellar.dsl.StellarFunctions;
-import org.apache.metron.stellar.dsl.VariableResolver;
-import org.apache.metron.stellar.dsl.functions.resolver.FunctionResolver;
-import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
 
 public class CachingStellarProcessorTest {
 
@@ -37,68 +36,128 @@ public class CachingStellarProcessorTest {
       put("name", "blah");
     }};
 
+  private CachingStellarProcessor processor;
+  private Cache<CachingStellarProcessor.Key, Object> cache;
+  private Context contextWithCache;
+
+  @Before
+  public void setup() throws Exception {
+
+    // create the cache
+    Map<String, Object> cacheConfig = ImmutableMap.of(
+            CachingStellarProcessor.MAX_CACHE_SIZE_PARAM, 2,
+            CachingStellarProcessor.MAX_TIME_RETAIN_PARAM, 10,
+            CachingStellarProcessor.RECORD_STATS, true
+    );
+    cache = CachingStellarProcessor.createCache(cacheConfig);
+    contextWithCache = new Context.Builder()
+            .with(Context.Capabilities.CACHE, () -> cache)
+            .build();
+
+    // create the object to test
+    processor = new CachingStellarProcessor();
+  }
+
+  /**
+   * Running the same expression multiple times should hit the cache.
+   */
   @Test
-  public void testNoCaching() throws Exception {
-    //no caching, so every expression is a cache miss.
-    Assert.assertEquals(2, countMisses(2, Context.EMPTY_CONTEXT(), "TO_UPPER(name)"));
-    //Ensure the correct result is returned.
-    Assert.assertEquals("BLAH", evaluateExpression(Context.EMPTY_CONTEXT(), "TO_UPPER(name)"));
+  public void testWithCache() {
+
+    Object result = execute("TO_UPPER(name)", contextWithCache);
+    assertEquals("BLAH", result);
+    assertEquals(1, cache.stats().requestCount());
+    assertEquals(1, cache.stats().missCount());
+    assertEquals(0, cache.stats().hitCount());
+
+    result = execute("TO_UPPER(name)", contextWithCache);
+    assertEquals("BLAH", result);
+    assertEquals(2, cache.stats().requestCount());
+    assertEquals(1, cache.stats().missCount());
+    assertEquals(1, cache.stats().hitCount());
+
+    result = execute("TO_UPPER(name)", contextWithCache);
+    assertEquals("BLAH", result);
+    assertEquals(3, cache.stats().requestCount());
+    assertEquals(1, cache.stats().missCount());
+    assertEquals(2, cache.stats().hitCount());
   }
 
+  /**
+   * The processor should work, even if no cache is present in the execution context.
+   */
   @Test
-  public void testCaching() throws Exception {
-    Cache<CachingStellarProcessor.Key, Object> cache = CachingStellarProcessor.createCache(
-                                                 ImmutableMap.of(CachingStellarProcessor.MAX_CACHE_SIZE_PARAM, 2
-                                                                ,CachingStellarProcessor.MAX_TIME_RETAIN_PARAM, 10
-                                                                )
-                                                                           );
-    Context context = new Context.Builder()
-                                 .with( Context.Capabilities.CACHE , () -> cache )
-                                 .build();
-    //running the same expression twice should hit the cache on the 2nd time and only yield one miss
-    Assert.assertEquals(1, countMisses(2, context, "TO_UPPER(name)"));
+  public void testNoCache() throws Exception {
 
-    //Ensure the correct result is returned.
-    Assert.assertEquals("BLAH", evaluateExpression(context, "TO_UPPER(name)"));
+    // the execution context does not contain a cache
+    Context contextNoCache = Context.EMPTY_CONTEXT();
 
-    //running the same expression 20 more times should pull from the cache
-    Assert.assertEquals(0, countMisses(20, context, "TO_UPPER(name)"));
-
-    //Now we are running 4 distinct operations with a cache size of 2.  The cache has 1 element in it before we start:
-    //  TO_LOWER(name) - miss (brand new), cache is full
-    //  TO_UPPER(name) - hit, cache is full
-    //  TO_UPPER('foo') - miss (brand new), cache is still full, but TO_LOWER is evicted as the least frequently used
-    //  JOIN... - miss (brand new), cache is still full, but TO_UPPER('foo') is evicted as the least frequently used
-    //this pattern repeats a 2nd time to add another 3 cache misses, totalling 6.
-    Assert.assertEquals(6, countMisses(2, context, "TO_LOWER(name)", "TO_UPPER(name)", "TO_UPPER('foo')", "JOIN([name, 'blah'], ',')"));
+    assertEquals("BLAH", execute("TO_UPPER(name)", contextNoCache));
+    assertEquals("BLAH", execute("TO_UPPER(name)", contextNoCache));
   }
 
-  private Object evaluateExpression(Context context, String expression) {
-    StellarProcessor processor = new CachingStellarProcessor();
-    return processor.parse(expression
-                , new MapVariableResolver(fields)
-                , StellarFunctions.FUNCTION_RESOLVER()
-                , context);
+  /**
+   * The processor should continue to work correctly, even when the max cache size is exceeded.
+   * @throws Exception
+   */
+  @Test
+  public void testWithFullCache() throws Exception {
+
+    // miss
+    Object result = execute("TO_UPPER(name)", contextWithCache);
+    assertEquals("BLAH", result);
+    assertEquals(1, cache.stats().requestCount());
+    assertEquals(1, cache.stats().missCount());
+    assertEquals(0, cache.stats().hitCount());
+
+    // miss
+    execute("TO_LOWER(name)", contextWithCache);
+    assertEquals(2, cache.stats().requestCount());
+    assertEquals(2, cache.stats().missCount());
+    assertEquals(0, cache.stats().hitCount());
+
+    // hit and cache is full
+    execute("TO_UPPER(name)", contextWithCache);
+    assertEquals(3, cache.stats().requestCount());
+    assertEquals(2, cache.stats().missCount());
+    assertEquals(1, cache.stats().hitCount());
+
+    //  miss and `TO_LOWER` is evicted as the least frequently used
+    execute("TO_UPPER('foo')", contextWithCache);
+    assertEquals(4, cache.stats().requestCount());
+    assertEquals(3, cache.stats().missCount());
+    assertEquals(1, cache.stats().hitCount());
+
+    // miss and `TO_UPPER('foo')` is evicted as the least frequently used
+    execute("JOIN([name, 'blah'], ',')", contextWithCache);
+    assertEquals(5, cache.stats().requestCount());
+    assertEquals(4, cache.stats().missCount());
+    assertEquals(1, cache.stats().hitCount());
+
+    // miss as `TO_LOWER` was previously evicted
+    execute("TO_LOWER(name)", contextWithCache);
+    assertEquals(6, cache.stats().requestCount());
+    assertEquals(5, cache.stats().missCount());
+    assertEquals(1, cache.stats().hitCount());
+
+    // hit
+    execute("TO_LOWER(name)", contextWithCache);
+    assertEquals(7, cache.stats().requestCount());
+    assertEquals(5, cache.stats().missCount());
+    assertEquals(2, cache.stats().hitCount());
   }
 
-  private int countMisses(int numRepetition, Context context, String... expressions) {
-    AtomicInteger numExpressions = new AtomicInteger(0);
-    StellarProcessor processor = new CachingStellarProcessor() {
-      @Override
-      protected Object parseUncached(String expression, VariableResolver variableResolver, FunctionResolver functionResolver, Context context) {
-        numExpressions.incrementAndGet();
-        return super.parseUncached(expression, variableResolver, functionResolver, context);
-      }
-    };
+  /**
+   * Execute each expression.
+   * @param expression The expression to execute.
+   */
+  private Object execute(String expression, Context context) {
 
-    for(int i = 0;i < numRepetition;++i) {
-      for(String expression : expressions) {
-        processor.parse(expression
-                , new MapVariableResolver(fields)
-                , StellarFunctions.FUNCTION_RESOLVER()
-                , context);
-      }
-    }
-    return numExpressions.get();
+    Object result = processor.parse(
+            expression,
+            new MapVariableResolver(fields),
+            StellarFunctions.FUNCTION_RESOLVER(),
+            context);
+    return result;
   }
 }

--- a/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/common/CachingStellarProcessorTest.java
+++ b/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/common/CachingStellarProcessorTest.java
@@ -148,6 +148,32 @@ public class CachingStellarProcessorTest {
   }
 
   /**
+   * The cache should continue to hit, even if variables not used in the cached expression change.
+   */
+  @Test
+  public void testUnrelatedVariableChange() {
+
+    // expect miss
+    Object result = execute("TO_UPPER(name)", contextWithCache);
+    assertEquals("BLAH", result);
+    assertEquals(1, cache.stats().requestCount());
+    assertEquals(1, cache.stats().missCount());
+    assertEquals(0, cache.stats().hitCount());
+
+    // add an irrelevant variable that is not used in the expression
+    fields.put("unrelated_var_1", "true");
+    fields.put("unrelated_var_2", 22);
+
+    // still expect a hit
+    result = execute("TO_UPPER(name)", contextWithCache);
+    assertEquals("BLAH", result);
+    assertEquals(2, cache.stats().requestCount());
+    assertEquals(1, cache.stats().missCount());
+    assertEquals(1, cache.stats().hitCount());
+
+  }
+
+  /**
    * Execute each expression.
    * @param expression The expression to execute.
    */


### PR DESCRIPTION
This fixes the `CachingStellarProcessorTest` which is failing intermittently.

```
Running org.apache.metron.stellar.common.CachingStellarProcessorTest
Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.054 sec <<< FAILURE! - in org.apache.metron.stellar.common.CachingStellarProcessorTest
testCaching(org.apache.metron.stellar.common.CachingStellarProcessorTest) Time elapsed: 0.053 sec <<< FAILURE!
java.lang.AssertionError: expected:<6> but was:<4>
 at org.junit.Assert.fail(Assert.java:88)
 at org.junit.Assert.failNotEquals(Assert.java:834)
 at org.junit.Assert.assertEquals(Assert.java:645)
 at org.junit.Assert.assertEquals(Assert.java:631)
 at org.apache.metron.stellar.common.CachingStellarProcessorTest.testCaching(CachingStellarProcessorTest.java:73)
 at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
 at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
 at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
 at java.lang.reflect.Method.invoke(Method.java:498)
 at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
 at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
 at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
 at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
 at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
 at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
 at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
 at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
 at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
 at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
 at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
 at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
 at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
 at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:283)
 at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:173)
 at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
 at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:128)
 at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
 at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
 at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)
```

### Changes

* Added a property `stellar.cache.record.stats` that allows recording of cache usage stats. 

* Updated the tests to use the stats produced by Caffeine.


## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
