### PR TITLE
METRON-1569 Allow user to change field name conversion when indexing …

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/IndexingConfigurations.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/IndexingConfigurations.java
@@ -31,6 +31,7 @@ public class IndexingConfigurations extends Configurations {
   public static final String ENABLED_CONF = "enabled";
   public static final String INDEX_CONF = "index";
   public static final String OUTPUT_PATH_FUNCTION_CONF = "outputPathFunction";
+  public static final String FIELD_NAME_CONVERTER_CONF = "fieldNameConverter";
 
   public Map<String, Object> getSensorIndexingConfig(String sensorType, boolean emptyMapOnNonExistent) {
     Map<String, Object> ret = (Map<String, Object>) getConfigurations().get(getKey(sensorType));
@@ -61,7 +62,8 @@ public class IndexingConfigurations extends Configurations {
   }
 
   public Map<String, Object> getSensorIndexingConfig(String sensorType, String writerName) {
-    Map<String, Object> ret = (Map<String, Object>) getConfigurations().get(getKey(sensorType));
+    String key = getKey(sensorType);
+    Map<String, Object> ret = (Map<String, Object>) getConfigurations().get(key);
     if(ret == null) {
       return new HashMap();
     }
@@ -147,6 +149,10 @@ public class IndexingConfigurations extends Configurations {
     return getOutputPathFunction(getSensorIndexingConfig(sensorName, writerName), sensorName);
   }
 
+  public String getFieldNameConverter(String sensorName, String writerName) {
+    return getFieldNameConverter(getSensorIndexingConfig(sensorName, writerName), sensorName);
+  }
+
   public static boolean isEnabled(Map<String, Object> conf) {
     return getAs( ENABLED_CONF
                  ,conf
@@ -187,6 +193,10 @@ public class IndexingConfigurations extends Configurations {
     );
   }
 
+  public static String getFieldNameConverter(Map<String, Object> conf, String sensorName) {
+    return getAs(FIELD_NAME_CONVERTER_CONF, conf, "", String.class);
+  }
+
   public static Map<String, Object> setEnabled(Map<String, Object> conf, boolean enabled) {
     Map<String, Object> ret = conf == null?new HashMap<>():conf;
     ret.put(ENABLED_CONF, enabled);
@@ -207,6 +217,12 @@ public class IndexingConfigurations extends Configurations {
   public static Map<String, Object> setIndex(Map<String, Object> conf, String index) {
     Map<String, Object> ret = conf == null?new HashMap<>():conf;
     ret.put(INDEX_CONF, index);
+    return ret;
+  }
+
+  public static Map<String, Object> setFieldNameConverter(Map<String, Object> conf, String index) {
+    Map<String, Object> ret = conf == null ? new HashMap<>(): conf;
+    ret.put(FIELD_NAME_CONVERTER_CONF, index);
     return ret;
   }
 

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/IndexingWriterConfiguration.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/IndexingWriterConfiguration.java
@@ -72,4 +72,9 @@ public class IndexingWriterConfiguration implements WriterConfiguration{
   public boolean isDefault(String sensorName) {
     return config.orElse(new IndexingConfigurations()).isDefault(sensorName, writerName);
   }
+
+  @Override
+  public String getFieldNameConverter(String sensorName) {
+    return config.orElse(new IndexingConfigurations()).getFieldNameConverter(sensorName, writerName);
+  }
 }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/ParserWriterConfiguration.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/ParserWriterConfiguration.java
@@ -101,4 +101,10 @@ public class ParserWriterConfiguration implements WriterConfiguration {
   public boolean isDefault(String sensorName) {
     return false;
   }
+
+  @Override
+  public String getFieldNameConverter(String sensorName) {
+    // not applicable
+    return null;
+  }
 }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/SingleBatchConfigurationFacade.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/SingleBatchConfigurationFacade.java
@@ -68,4 +68,10 @@ public class SingleBatchConfigurationFacade implements WriterConfiguration {
   public boolean isDefault(String sensorName) {
     return false;
   }
+
+  @Override
+  public String getFieldNameConverter(String sensorName) {
+    // not applicable
+    return null;
+  }
 }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/WriterConfiguration.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/WriterConfiguration.java
@@ -18,17 +18,86 @@
 
 package org.apache.metron.common.configuration.writer;
 
+import org.apache.metron.common.field.FieldNameConverter;
+
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Configures a writer to write messages to an endpoint.
+ *
+ * <p>Each destination will have its own {@link WriterConfiguration}; for example HDFS, Elasticsearch, and Solr.
+ * <p>A writer can be configured independently for each source type.
+ */
 public interface WriterConfiguration extends Serializable {
+
+  /**
+   * Defines the maximum batch size for a given sensor.
+   *
+   * @param sensorName The name of the sensor.
+   * @return The batch size for the sensor.
+   */
   int getBatchSize(String sensorName);
+
+  /**
+   * Defines the batch timeout for a given sensor.  Even if the maximum
+   * batch size has not been reached, the messages will be written when
+   * the timeout is reached.
+   *
+   * @param sensorName The name of the sensor.
+   * @return The batch timeout for the sensor.
+   */
   int getBatchTimeout(String sensorName);
+
+  /**
+   * Returns the batch timeouts for all of the currently configured sensors.
+   * @return All of the batch timeouts.
+   */
   List<Integer> getAllConfiguredTimeouts();
+
+  /**
+   * The name of the index to write to for a given sensor.
+   *
+   * @param sensorName The name of the sensor.
+   * @return The name of the index to write to
+   */
   String getIndex(String sensorName);
+
+  /**
+   * Returns true, if this writer is enabled for the given sensor.
+   *
+   * @param sensorName The name of the sensor.
+   * @return True, if this writer is enabled.  Otherwise, false.
+   */
   boolean isEnabled(String sensorName);
+
+  /**
+   * @param sensorName The name of a sensor.
+   * @return
+   */
   Map<String, Object> getSensorConfig(String sensorName);
+
+  /**
+   * Returns the global configuration.
+   * @return The global configuration.
+   */
   Map<String, Object> getGlobalConfig();
+
+  /**
+   * Returns true, if the current writer configuration is set to all default values.
+   *
+   * @param sensorName The name of the sensor.
+   * @return True, if the writer is using all default values. Otherwise, false.
+   */
   boolean isDefault(String sensorName);
+
+  /**
+   * Return the {@link FieldNameConverter} to use
+   * when writing messages.
+   *
+   * @param sensorName The name of the sensor;
+   * @return
+   */
+  String getFieldNameConverter(String sensorName);
 }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/DeDotFieldNameConverter.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/DeDotFieldNameConverter.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.common.field;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
+
+/**
+ * A {@link FieldNameConverter} that replaces all field names containing dots
+ * with colons.
+ */
+public class DeDotFieldNameConverter implements FieldNameConverter, Serializable {
+
+  private static final long serialVersionUID = -3126840090749760299L;
+  private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  @Override
+  public String convert(String originalField) {
+
+    String newField = originalField.replace(".",":");
+
+    if(LOG.isDebugEnabled() && originalField.contains(".")) {
+      LOG.debug("Renamed dotted field; original={}, new={}", originalField, newField);
+    }
+
+    return newField;
+  }
+}

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/FieldNameConverter.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/FieldNameConverter.java
@@ -15,18 +15,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.metron.common.field;
 
-package org.apache.metron.elasticsearch.writer;
+/**
+ * Allows field names to be transformed before a message is written to an endpoint.
+ */
+public interface FieldNameConverter {
 
-import org.junit.Test;
-
-import static org.junit.Assert.*;
-
-public class ElasticsearchFieldNameConverterTest {
-
-    @Test
-    public void convert() throws Exception {
-        assertEquals("testfield:with:colons",new ElasticsearchFieldNameConverter().convert("testfield.with.colons"));
-    }
-
+  /**
+   * Convert the field name.
+   *
+   * @param originalField The original field name.
+   * @return The new field name.
+   */
+  String convert(String originalField);
 }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/FieldNameConverters.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/FieldNameConverters.java
@@ -15,10 +15,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.metron.common.interfaces;
 
-public interface FieldNameConverter {
+package org.apache.metron.common.field;
 
-    String convert(String originalField);
+/**
+ * Allows the field name converter to be specified using a short-hand
+ * name, rather than the entire fully-qualified class name.
+ */
+public enum FieldNameConverters {
 
+  /**
+   * A {@link FieldNameConverter} that does not rename any fields.  All field
+   * names remain unchanged.
+   */
+  NOOP(new NoopFieldNameConverter()),
+
+  /**
+   * A {@link FieldNameConverter} that replaces all field names containing dots
+   * with colons.
+   */
+  DEDOT(new DeDotFieldNameConverter());
+
+  private FieldNameConverter converter;
+
+  FieldNameConverters(FieldNameConverter converter) {
+    this.converter = converter;
+  }
+
+  public FieldNameConverter get() {
+    return converter;
+  }
 }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/NoopFieldNameConverter.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/NoopFieldNameConverter.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.common.field;
+
+/**
+ * A {@link FieldNameConverter} that does not rename any fields.  All field
+ * names remain unchanged.
+ */
+public class NoopFieldNameConverter implements FieldNameConverter {
+
+  @Override
+  public String convert(String originalField) {
+
+    // no change to the field name
+    return originalField;
+  }
+}

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/field/DeDotFieldNameConverterTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/field/DeDotFieldNameConverterTest.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.metron.common.field;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DeDotFieldNameConverterTest {
+
+  @Test
+  public void testWithColons() throws Exception {
+    String actual = new DeDotFieldNameConverter().convert("testfield.with.colons");
+    assertEquals("testfield:with:colons", actual);
+  }
+
+  @Test
+  public void testNoColons() throws Exception {
+    String actual = new DeDotFieldNameConverter().convert("test-field-no-colons");
+    assertEquals("test-field-no-colons", actual);
+  }
+}

--- a/metron-platform/metron-elasticsearch/pom.xml
+++ b/metron-platform/metron-elasticsearch/pom.xml
@@ -216,6 +216,12 @@
             <artifactId>log4j-core</artifactId>
             <version>${global_log4j_core_version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava-testlib</artifactId>
+            <version>${global_guava_version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/metron-platform/metron-elasticsearch/src/main/java/org/apache/metron/elasticsearch/writer/CachedFieldNameConverterFactory.java
+++ b/metron-platform/metron-elasticsearch/src/main/java/org/apache/metron/elasticsearch/writer/CachedFieldNameConverterFactory.java
@@ -1,0 +1,155 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.elasticsearch.writer;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.apache.commons.lang.ClassUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.metron.common.configuration.writer.WriterConfiguration;
+import org.apache.metron.common.field.DeDotFieldNameConverter;
+import org.apache.metron.common.field.FieldNameConverter;
+import org.apache.metron.common.field.FieldNameConverters;
+import org.apache.metron.common.field.NoopFieldNameConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A {@link FieldNameConverterFactory} that is backed by a cache.
+ *
+ * <p>Each sensor type can use a different {@link FieldNameConverter} implementation.
+ *
+ * <p>The {@link WriterConfiguration} allows a user to define the {@link FieldNameConverter}
+ * that should be used for a given sensor type.
+ *
+ * <p>The {@link FieldNameConverter}s are maintained in a cache for a fixed period of time
+ * after they are created.  Once they expire, the {@link WriterConfiguration} is used to
+ * reload the {@link FieldNameConverter}.
+ *
+ * <p>The user can change the {@link FieldNameConverter} in use at runtime. A change
+ * to this configuration is recognized once the old {@link FieldNameConverter} expires
+ * from the cache.
+ *
+ * <p>Defining a shorter expiration interval allows config changes to be recognized more
+ * quickly, but also can impact performance negatively.
+ */
+public class CachedFieldNameConverterFactory implements FieldNameConverterFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  /**
+   * A cache that contains a {@link FieldNameConverter} for each sensor type.
+   *
+   * A user can alter the {@link FieldNameConverter} for a given sensor at any time
+   * by altering the Indexing configuration.  The actual {@link FieldNameConverter}
+   * in use for a given sensor will only change once the original converter has
+   * expired from the cache.
+   */
+  private Cache<String, FieldNameConverter> fieldNameConverters;
+
+  /**
+   * Creates a {@link CachedFieldNameConverterFactory}.
+   *
+   * @param expires The duration before {@link FieldNameConverter}s are expired.
+   * @param expiresUnits The units before {@link FieldNameConverter}s are expired.
+   */
+  public CachedFieldNameConverterFactory(int expires, TimeUnit expiresUnits) {
+
+    fieldNameConverters = createFieldNameConverterCache(expires, expiresUnits);
+  }
+
+  /**
+   * Creates a {@link CachedFieldNameConverterFactory} where the cache expires after 5 minutes.
+   */
+  public CachedFieldNameConverterFactory() {
+
+    this(5, TimeUnit.MINUTES);
+  }
+
+  /**
+   * Creates a {@link CachedFieldNameConverterFactory} using the given cache.  This should only
+   * be used for testing.
+   *
+   * @param fieldNameConverters A {@link Cache} containing {@link FieldNameConverter}s.
+   */
+  public CachedFieldNameConverterFactory(Cache<String, FieldNameConverter> fieldNameConverters) {
+
+    this.fieldNameConverters = fieldNameConverters;
+  }
+
+  /**
+   * Creates a cache of {@link FieldNameConverter}s, one for each source type.
+   *
+   * @return A cache of {@link FieldNameConverter}s.
+   */
+  private Cache<String, FieldNameConverter> createFieldNameConverterCache(int expire, TimeUnit expireUnits) {
+
+    return Caffeine
+            .newBuilder()
+            .expireAfterWrite(expire, expireUnits)
+            .build();
+  }
+
+  /**
+   * Create a new {@link FieldNameConverter}.
+   *
+   * @param sensorType The type of sensor.
+   * @param config The writer configuration.
+   * @return
+   */
+  @Override
+  public FieldNameConverter create(String sensorType, WriterConfiguration config) {
+
+    return fieldNameConverters.get(sensorType, (s) -> createInstance(sensorType, config));
+  }
+
+  /**
+   * Create a new {@link FieldNameConverter}.
+   *
+   * @param sensorType The type of sensor.
+   * @param config The writer configuration.
+   * @return
+   */
+  private FieldNameConverter createInstance(String sensorType, WriterConfiguration config) {
+
+    // default to the 'DEDOT' field name converter to maintain backwards compatibility
+    FieldNameConverter result = new DeDotFieldNameConverter();
+
+    // which field name converter should be used?
+    String converterName = config.getFieldNameConverter(sensorType);
+    if(StringUtils.isNotBlank(converterName)) {
+
+      try {
+        result = FieldNameConverters.valueOf(converterName).get();
+
+      } catch(IllegalArgumentException e) {
+        LOG.error("Unable to create field name converter, using default; value={}, error={}",
+                converterName, ExceptionUtils.getRootCauseMessage(e));
+      }
+    }
+
+    LOG.debug("Created field name converter; sensorType={}, configuredName={}, class={}",
+            sensorType, converterName, ClassUtils.getShortClassName(result, "null"));
+
+    return result;
+  }
+}

--- a/metron-platform/metron-elasticsearch/src/main/java/org/apache/metron/elasticsearch/writer/ElasticsearchWriter.java
+++ b/metron-platform/metron-elasticsearch/src/main/java/org/apache/metron/elasticsearch/writer/ElasticsearchWriter.java
@@ -17,15 +17,9 @@
  */
 package org.apache.metron.elasticsearch.writer;
 
-import java.io.Serializable;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 import org.apache.metron.common.Constants;
 import org.apache.metron.common.configuration.writer.WriterConfiguration;
-import org.apache.metron.common.interfaces.FieldNameConverter;
+import org.apache.metron.common.field.FieldNameConverter;
 import org.apache.metron.common.writer.BulkMessageWriter;
 import org.apache.metron.common.writer.BulkWriterResponse;
 import org.apache.metron.elasticsearch.utils.ElasticsearchUtils;
@@ -40,31 +34,58 @@ import org.json.simple.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A {@link BulkMessageWriter} that writes messages to Elasticsearch.
+ */
 public class ElasticsearchWriter implements BulkMessageWriter<JSONObject>, Serializable {
 
+  private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  /**
+   * The Elasticsearch client.
+   */
   private transient TransportClient client;
+
+  /**
+   * A simple data formatter used to build the appropriate Elasticsearch index name.
+   */
   private SimpleDateFormat dateFormat;
-  private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchWriter.class);
-  private FieldNameConverter fieldNameConverter = new ElasticsearchFieldNameConverter();
+
+  /**
+   * A factory that creates {@link FieldNameConverter} objects.
+   */
+  private FieldNameConverterFactory fieldNameConverterFactory;
 
   @Override
   public void init(Map stormConf, TopologyContext topologyContext, WriterConfiguration configurations) {
+
     Map<String, Object> globalConfiguration = configurations.getGlobalConfig();
     client = ElasticsearchUtils.getClient(globalConfiguration);
     dateFormat = ElasticsearchUtils.getIndexFormat(globalConfiguration);
+    fieldNameConverterFactory = new CachedFieldNameConverterFactory();
   }
-
 
   @Override
   public BulkWriterResponse write(String sensorType, WriterConfiguration configurations, Iterable<Tuple> tuples, List<JSONObject> messages) throws Exception {
+
+    // fetch the field name converter for this sensor type
+    FieldNameConverter fieldNameConverter = fieldNameConverterFactory.create(sensorType, configurations);
+
     final String indexPostfix = dateFormat.format(new Date());
     BulkRequestBuilder bulkRequest = client.prepareBulk();
-
     for(JSONObject message: messages) {
 
       JSONObject esDoc = new JSONObject();
       for(Object k : message.keySet()){
-        deDot(k.toString(), message, esDoc);
+        copyField(k.toString(), message, esDoc, fieldNameConverter);
       }
 
       String indexName = ElasticsearchUtils.getIndexName(sensorType, indexPostfix, configurations);
@@ -125,19 +146,30 @@ public class ElasticsearchWriter implements BulkMessageWriter<JSONObject>, Seria
     client.close();
   }
 
+  /**
+   * Copies the value of a field from the source message to the destination message.
+   *
+   * <p>A field name may also be transformed in the destination message by the {@link FieldNameConverter}.
+   *
+   * @param sourceFieldName The name of the field to copy from the source message
+   * @param source The source message.
+   * @param destination The destination message.
+   * @param fieldNameConverter The field name converter that transforms the field name
+   *                           between the source and destination.
+   */
   //JSONObject doesn't expose map generics
   @SuppressWarnings("unchecked")
-  private void deDot(String field, JSONObject origMessage, JSONObject message){
+  private void copyField(
+          String sourceFieldName,
+          JSONObject source,
+          JSONObject destination,
+          FieldNameConverter fieldNameConverter) {
 
-    if(field.contains(".")){
+    // allow the field name to be transformed
+    String destinationFieldName = fieldNameConverter.convert(sourceFieldName);
 
-      LOG.debug("Dotted field: {}", field);
-
-    }
-    String newkey = fieldNameConverter.convert(field);
-    message.put(newkey,origMessage.get(field));
-
+    // copy the field
+    destination.put(destinationFieldName, source.get(sourceFieldName));
   }
-
 }
 

--- a/metron-platform/metron-elasticsearch/src/main/java/org/apache/metron/elasticsearch/writer/FieldNameConverterFactory.java
+++ b/metron-platform/metron-elasticsearch/src/main/java/org/apache/metron/elasticsearch/writer/FieldNameConverterFactory.java
@@ -17,16 +17,20 @@
  */
 package org.apache.metron.elasticsearch.writer;
 
-import org.apache.metron.common.interfaces.FieldNameConverter;
-import java.io.Serializable;
+import org.apache.metron.common.configuration.writer.WriterConfiguration;
+import org.apache.metron.common.field.FieldNameConverter;
 
-public class ElasticsearchFieldNameConverter implements FieldNameConverter, Serializable {
+/**
+ * A factory that creates {@link FieldNameConverter} objects.
+ */
+public interface FieldNameConverterFactory {
 
-    private static final long serialVersionUID = -3126840090749760299L;
-
-    @Override
-    public String convert(String originalField) {
-        return originalField.replace(".",":");
-    }
-
+  /**
+   * Create a {@link FieldNameConverter} object.
+   *
+   * @param sensorType The type of sensor.
+   * @param config The writer configuration.
+   * @return A {@link FieldNameConverter} object.
+   */
+  FieldNameConverter create(String sensorType, WriterConfiguration config);
 }

--- a/metron-platform/metron-elasticsearch/src/test/java/org/apache/metron/elasticsearch/integration/ElasticsearchIndexingIntegrationTest.java
+++ b/metron-platform/metron-elasticsearch/src/test/java/org/apache/metron/elasticsearch/integration/ElasticsearchIndexingIntegrationTest.java
@@ -18,9 +18,9 @@
 package org.apache.metron.elasticsearch.integration;
 
 import org.adrianwalker.multilinestring.Multiline;
-import org.apache.metron.common.interfaces.FieldNameConverter;
+import org.apache.metron.common.field.DeDotFieldNameConverter;
+import org.apache.metron.common.field.FieldNameConverter;
 import org.apache.metron.elasticsearch.integration.components.ElasticSearchComponent;
-import org.apache.metron.elasticsearch.writer.ElasticsearchFieldNameConverter;
 import org.apache.metron.indexing.integration.IndexingIntegrationTest;
 import org.apache.metron.integration.ComponentRunner;
 import org.apache.metron.integration.InMemoryComponent;
@@ -43,7 +43,7 @@ public class ElasticsearchIndexingIntegrationTest extends IndexingIntegrationTes
   private String indexDir = "target/elasticsearch";
   private String dateFormat = "yyyy.MM.dd.HH";
   private String index = "yaf_index_" + new SimpleDateFormat(dateFormat).format(new Date());
-  private FieldNameConverter fieldNameConverter = new ElasticsearchFieldNameConverter();
+  private FieldNameConverter fieldNameConverter = new DeDotFieldNameConverter();
   /**
    * {
    * "yaf_doc": {

--- a/metron-platform/metron-elasticsearch/src/test/java/org/apache/metron/elasticsearch/writer/CachedFieldNameConverterFactoryTest.java
+++ b/metron-platform/metron-elasticsearch/src/test/java/org/apache/metron/elasticsearch/writer/CachedFieldNameConverterFactoryTest.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.elasticsearch.writer;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.testing.FakeTicker;
+import org.adrianwalker.multilinestring.Multiline;
+import org.apache.metron.common.configuration.IndexingConfigurations;
+import org.apache.metron.common.configuration.writer.IndexingWriterConfiguration;
+import org.apache.metron.common.configuration.writer.WriterConfiguration;
+import org.apache.metron.common.field.DeDotFieldNameConverter;
+import org.apache.metron.common.field.FieldNameConverter;
+import org.apache.metron.common.field.NoopFieldNameConverter;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests the {@link CachedFieldNameConverterFactory}.
+ */
+public class CachedFieldNameConverterFactoryTest {
+
+  private CachedFieldNameConverterFactory factory;
+  private Cache<String, FieldNameConverter> cache;
+  private FakeTicker ticker;
+
+  @Before
+  public void setup() throws Exception {
+
+    // allows us to advance time in the cache
+    ticker = new FakeTicker();
+
+    // a cache configured for testing
+    cache = Caffeine.newBuilder()
+            .expireAfterWrite(5, TimeUnit.MINUTES)
+            .executor(Runnable::run)
+            .ticker(ticker::read)
+            .recordStats()
+            .build();
+
+    // the factory being tested
+    factory = new CachedFieldNameConverterFactory(cache);
+  }
+
+  private WriterConfiguration createConfig(String writer, String sensor, String json) throws Exception {
+
+    IndexingConfigurations indexingConfig = new IndexingConfigurations();
+    indexingConfig.updateSensorIndexingConfig(sensor, json.getBytes());
+    return new IndexingWriterConfiguration(writer, indexingConfig);
+  }
+
+  /**
+   * {
+   *  "elasticsearch": {
+   *
+   *    "index": "theIndex",
+   *    "batchSize": 100,
+   *    "batchTimeout": 1000,
+   *    "enabled": true,
+   *    "fieldNameConverter": "DEDOT"
+   *  }
+   * }
+   */
+  @Multiline
+  private static String jsonWithDedot;
+
+  /**
+   * The factory should be able to create the {@link FieldNameConverter}
+   * that has been defined by the user.
+   */
+  @Test
+  public void testCreateDedot() throws Exception {
+
+    final String writer = "elasticsearch";
+    final String sensor = "bro";
+    WriterConfiguration config = createConfig(writer, sensor, jsonWithDedot);
+
+    // validate the converter created for 'bro'
+    FieldNameConverter converter = factory.create(sensor, config);
+    assertTrue(converter instanceof DeDotFieldNameConverter);
+  }
+
+  /**
+   * {
+   *  "elasticsearch": {
+   *
+   *    "index": "theIndex",
+   *    "batchSize": 100,
+   *    "batchTimeout": 1000,
+   *    "enabled": true,
+   *    "fieldNameConverter": "NOOP"
+   *  }
+   * }
+   */
+  @Multiline
+  private static String jsonWithNoop;
+
+  /**
+   * The factory should be able to create the {@link FieldNameConverter}
+   * that has been defined by the user.
+   */
+  @Test
+  public void testCreateNoop() throws Exception {
+
+    final String writer = "elasticsearch";
+    final String sensor = "bro";
+    WriterConfiguration config = createConfig(writer, sensor, jsonWithNoop);
+
+    // validate the converter created for 'bro'
+    FieldNameConverter converter = factory.create(sensor, config);
+    assertTrue(converter instanceof NoopFieldNameConverter);
+  }
+
+  /**
+   * {
+   *  "elasticsearch": {
+   *
+   *    "index": "theIndex",
+   *    "batchSize": 100,
+   *    "batchTimeout": 1000,
+   *    "enabled": true
+   *  }
+   * }
+   */
+  @Multiline
+  private static String jsonWithNoConverter;
+
+  /**
+   * The factory should create a default {@link FieldNameConverter} if none has been defined
+   * by the user in the writer configuration.
+   */
+  @Test
+  public void testCreateDefault() throws Exception {
+
+    final String writer = "elasticsearch";
+    final String sensor = "bro";
+    WriterConfiguration config = createConfig(writer, sensor, jsonWithNoConverter);
+
+    // if none defined, should default to 'DEDOT'
+    FieldNameConverter converter = factory.create(sensor, config);
+    assertTrue(converter instanceof DeDotFieldNameConverter);
+  }
+
+  /**
+   * The factory should cache and reuse {@link FieldNameConverter} objects.
+   */
+  @Test
+  public void testCacheUsage() throws Exception {
+
+    final String writer = "elasticsearch";
+    final String sensor = "bro";
+    WriterConfiguration config = createConfig(writer, sensor, jsonWithNoConverter);
+
+    // validate the converter created for 'bro'
+    FieldNameConverter converter1 = factory.create(sensor, config);
+    assertNotNull(converter1);
+    assertEquals(1, cache.stats().requestCount());
+    assertEquals(0, cache.stats().hitCount());
+    assertEquals(1, cache.stats().missCount());
+
+    // the converter should come from the cache on the next request
+    FieldNameConverter converter2 = factory.create(sensor, config);
+    assertNotNull(converter2);
+    assertEquals(2, cache.stats().requestCount());
+    assertEquals(1, cache.stats().hitCount());
+    assertEquals(1, cache.stats().missCount());
+
+    assertSame(converter1, converter2);
+  }
+
+  /**
+   * If the user changes the {@link FieldNameConverter} in the writer configuration, the new
+   * {@link FieldNameConverter} should be used after the old one expires.
+   */
+  @Test
+  public void testConfigChange() throws Exception {
+
+    final String writer = "elasticsearch";
+    final String sensor = "bro";
+
+    // no converter defined in config, should use 'DEDOT' converter
+    WriterConfiguration config = createConfig(writer, sensor, jsonWithNoConverter);
+    assertTrue(factory.create(sensor, config) instanceof DeDotFieldNameConverter);
+
+    // an 'updated' config uses the 'NOOP' converter
+    WriterConfiguration newConfig = createConfig(writer, sensor, jsonWithNoop);
+
+    // even though config has changed, the cache has not expired yet, still using 'DEDOT'
+    assertTrue(factory.create(sensor, newConfig) instanceof DeDotFieldNameConverter);
+
+    // advance 30 minutes
+    ticker.advance(8, TimeUnit.MINUTES);
+
+    // now the 'NOOP' converter should be used
+    assertTrue(factory.create(sensor, newConfig) instanceof NoopFieldNameConverter);
+  }
+
+  /**
+   * {
+   *  "elasticsearch": {
+   *
+   *    "index": "theIndex",
+   *    "batchSize": 100,
+   *    "batchTimeout": 1000,
+   *    "enabled": true,
+   *    "fieldNameConverter": "INVALID"
+   *  }
+   * }
+   */
+  @Multiline
+  private static String jsonWithInvalidConverter;
+
+  /**
+   * If an invalid field name converter is specified, it should fall-back to using the
+   * default, noop converter.
+   */
+  @Test
+  public void testCreateInvalid() throws Exception {
+
+    final String writer = "elasticsearch";
+    final String sensor = "bro";
+    WriterConfiguration config = createConfig(writer, sensor, jsonWithInvalidConverter);
+
+    // if invalid value defined, it should fall-back to using default 'DEDOT'
+    FieldNameConverter converter = factory.create(sensor, config);
+    assertTrue(converter instanceof DeDotFieldNameConverter);
+  }
+}

--- a/metron-platform/metron-indexing/README.md
+++ b/metron-platform/metron-indexing/README.md
@@ -50,6 +50,8 @@ and sent to
 By default, errors during indexing are sent back into the `indexing` kafka queue so that they can be indexed and archived.
 
 ## Sensor Indexing Configuration
+
+
 The sensor specific configuration is intended to configure the
 indexing used for a given sensor type (e.g. `snort`).  
 
@@ -58,16 +60,16 @@ Just like the global config, the format is a JSON stored in zookeeper and on dis
 * `hdfs`
 * `solr`
 
-Depending on how you start the indexing topology, it will have either
-elasticsearch or solr and hdfs writers running.
+Depending on how you start the indexing topology, it will have either Elasticsearch or Solr and HDFS writers running.
 
-The configuration for an individual writer-specific configuration is a JSON map with the following fields:
-* `index` : The name of the index to write to (defaulted to the name of the sensor).
-* `batchSize` : The size of the batch that is written to the indices at once. Defaults to `1` (no batching).
-* `batchTimeout` : The timeout after which a batch will be flushed even if batchSize has not been met.  Optional.
-If unspecified, or set to `0`, it defaults to a system-determined duration which is a fraction of the Storm 
-parameter `topology.message.timeout.secs`.  Ignored if batchSize is `1`, since this disables batching.
-* `enabled` : Whether the writer is enabled (default `true`).
+| Property             | Description                                                                           | Default Value                                                                                                                                       |
+|----------------------|---------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `index`              | The name of the index to write to.                                                    | Defaults to the name of the sensor.                                                                                                                 |
+| `batchSize`          | The size of the batch that is written to the indices at once.                         | Defaults to `1`; no batching.                                                                                                                         |
+| `batchTimeout`       | The timeout after which a batch will be flushed even if `batchSize` has not been met. | Defaults to a duration which is a fraction of the Storm parameter `topology.message.timeout.secs`, if left undefined or set to 0.  Ignored if batchSize is `1`, since this disables batching.|
+| `enabled`            | A boolean indicating whether the writer is enabled.                                   | Defaults to `true`                                                                                                                                    |
+| `fieldNameConverter` | Defines how field names are transformed before being written to the index.  Only applicable to `elasticsearch`.          | Defaults to `DEDOT`.  Acceptable values are `DEDOT` that replaces all '.' with ':' or `NOOP` that does not change the field names . |
+
 
 ### Meta Alerts
 Alerts can be grouped, after appropriate searching, into a set of alerts called a meta alert.  A meta alert is useful for maintaining the context of searching and grouping during further investigations. Standard searches can return meta alerts, but grouping and other aggregation or sorting requests will not, because there's not a clear way to aggregate in many cases if there are multiple alerts contained in the meta alert. All meta alerts will have the source type of metaalert, regardless of the contained alert's origins.

--- a/metron-platform/metron-indexing/src/test/java/org/apache/metron/indexing/integration/HDFSIndexingIntegrationTest.java
+++ b/metron-platform/metron-indexing/src/test/java/org/apache/metron/indexing/integration/HDFSIndexingIntegrationTest.java
@@ -18,16 +18,14 @@
 
 package org.apache.metron.indexing.integration;
 
-import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
-import org.apache.metron.common.interfaces.FieldNameConverter;
+import org.apache.metron.common.field.FieldNameConverter;
 import org.apache.metron.common.utils.JSONUtils;
 import org.apache.metron.integration.*;
 import org.apache.metron.integration.components.KafkaComponent;
 import org.apache.metron.integration.utils.TestUtils;
 import org.apache.storm.hdfs.bolt.rotation.TimedRotationPolicy;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;

--- a/metron-platform/metron-indexing/src/test/java/org/apache/metron/indexing/integration/IndexingIntegrationTest.java
+++ b/metron-platform/metron-indexing/src/test/java/org/apache/metron/indexing/integration/IndexingIntegrationTest.java
@@ -22,7 +22,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.metron.TestConstants;
 import org.apache.metron.common.Constants;
 import org.apache.metron.common.configuration.ConfigurationsUtils;
-import org.apache.metron.common.interfaces.FieldNameConverter;
+import org.apache.metron.common.field.FieldNameConverter;
 import org.apache.metron.common.utils.JSONUtils;
 import org.apache.metron.enrichment.integration.components.ConfigUploadComponent;
 import org.apache.metron.integration.BaseIntegrationTest;
@@ -38,7 +38,6 @@ import org.apache.zookeeper.KeeperException;
 import org.junit.Assert;
 import org.junit.Test;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/writers/SimpleHBaseEnrichmentWriterTest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/writers/SimpleHBaseEnrichmentWriterTest.java
@@ -301,7 +301,6 @@ public class SimpleHBaseEnrichmentWriterTest {
       @Override
       public Map<String, Object> getSensorConfig(String sensorName) {
         return sensorConfig;
-
       }
 
       @Override
@@ -312,6 +311,11 @@ public class SimpleHBaseEnrichmentWriterTest {
       @Override
       public boolean isDefault(String sensorName) {
         return false;
+      }
+
+      @Override
+      public String getFieldNameConverter(String sensorName) {
+        return null;
       }
     };
   }

--- a/metron-platform/metron-solr/src/test/java/org/apache/metron/solr/integration/SolrIndexingIntegrationTest.java
+++ b/metron-platform/metron-solr/src/test/java/org/apache/metron/solr/integration/SolrIndexingIntegrationTest.java
@@ -20,7 +20,7 @@ package org.apache.metron.solr.integration;
 import com.google.common.base.Function;
 import org.apache.metron.common.configuration.Configurations;
 import org.apache.metron.common.configuration.ConfigurationsUtils;
-import org.apache.metron.common.interfaces.FieldNameConverter;
+import org.apache.metron.common.field.FieldNameConverter;
 import org.apache.metron.common.utils.JSONUtils;
 import org.apache.metron.enrichment.integration.utils.SampleUtil;
 import org.apache.metron.indexing.integration.IndexingIntegrationTest;
@@ -34,7 +34,6 @@ import org.apache.metron.integration.components.ZKServerComponent;
 import org.apache.metron.solr.integration.components.SolrComponent;
 
 import javax.annotation.Nullable;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;


### PR DESCRIPTION
The `ElasticsearchWriter` has a mechanism to transform the field names of a message before it is written to Elasticsearch.  Right now this mechanism is hard-coded to replace all '.' dots with ':' colons.

This mechanism was needed for Elasticsearch 2.x which did not allow dots in field names.  Now that Metron supports Elasticsearch 5.x this is no longer a problem. A user should be able to configure the field name transformation when writing to Elasticsearch, as needed.  

While it might have been simpler to just remove the de-dotting mechanism, this would break backwards compatibility.  Taking this approach provides users with an upgrade path.

## Changes

This change allows the user to configure the field name converter as part of the index writer configuration.  

Acceptable values include the following.
* `DEDOT`: Replaces all '.' with ':' which is the default, backwards compatible behavior.
* `NOOP`: No field name change.

If no "fieldNameConverter" is defined, it defaults to using `DEDOT` which maintains backwards compatibility.

A cache of `FieldNameConverter`s is maintained since the index writer configuration can be changed at run-time and each sensor has its own index writer configuration.

An example configuration looks-like the following.
```
    {
      "hdfs" : {
        "enabled" : false
      },
      "elasticsearch" : {
        "index" : "bro",
        "batchSize" : 5,
        "enabled" : true,
        "fieldNameConverter": "NOOP"
      },
      "solr" : {
        "enabled" : false
      }
    } 
```

## Code Changes

* Added the `fieldNameConverter` parameter to the Index writer configuration.

* Moved the `FieldNameConverter` implementations to a dedicated package in `metron-common`.

* Renamed `ElasticsearchFieldNameConverter` to `DeDotFieldNameConverter`.

* Implemented the `NoopFieldNameConverter` which does not modify the field name.

* Created `FieldNameConverters` class that allows a user to specify either `DEDOT` or `NOOP` to choose the appropriate implementation.

* Implemented a `CachedFieldNameConverterFactory` that encapsulates all the logic for choosing and instantiating the appropriate `FieldNameConverter`.  

* Updated `ElasticsearchWriter` to use the `CachedFieldNameConverterFactory`.

* Updated the README to document the new configuration parameter.


## Manual Testing

1. Launch a development environment and login.

    ```
    vagrant ssh
    sudo su -
    source /etc/default/metron
    ```

1. Validate the environment by ensuring alerts are visible in the Alerts UI and that the Ambari Service Check completes successfully.  This ensures that the change is backwards compatible.

1. Login to the Storm UI and enable DEBUG logging for `org.apache.metron.common` and `org.apache.metron.elasticsearch`.

1. The Storm worker logs in `/var/log/storm/worker-artifacts/random_access_indexing*/worker.log` should contain the following log statements, if you have enabled DEBUG logging correctly.  This shows that the default `DEDOT` converter is in-use.

    ```
    2018-05-22 14:38:... [DEBUG] Renamed dotted field; original=source.type, new=source:type
    2018-05-22 14:38:... [DEBUG] Renamed dotted field; original=adapter.geoadapter.end.ts, new=adapter:geoadapter:end:ts
    2018-05-22 14:38:... [DEBUG] Renamed dotted field; original=threatintelsplitterbolt.splitter.end.ts, new=threatintelsplitterbolt:splitter:end:ts
    2018-05-22 14:38:... [DEBUG] Renamed dotted field; original=adapter.threatinteladapter.begin.ts, new=adapter:threatinteladapter:begin:ts
    2018-05-22 14:38:... [DEBUG] Renamed dotted field; original=enrichments.geo.ip_dst_addr.location_point, new=enrichments:geo:ip_dst_addr:location_point
    2018-05-22 14:38:... [DEBUG] Renamed dotted field; original=adapter.threatinteladapter.end.ts, new=adapter:threatinteladapter:end:ts
    2018-05-22 14:38:... [DEBUG] Renamed dotted field; original=enrichmentsplitterbolt.splitter.end.ts, new=enrichmentsplitterbolt:splitter:end:ts
    ```

1. Launch the REPL.

    ```
    ./bin/stellar -z $ZOOKEEPER
    ```

1. Change the field name converter to NOOP.

    ```
    [Stellar]>>> conf := SHELL_EDIT()
    {
      "hdfs" : {
        "enabled" : false
      },
      "elasticsearch" : {
        "index" : "bro",
        "batchSize" : 5,
        "enabled" : true,
        "fieldNameConverter": "NOOP"
      },
      "solr" : {
        "enabled" : false
      }
    }

    [Stellar]>>> CONFIG_PUT("INDEXING", conf, "bro")
    ```

1. It can take up to 5 minutes for the topology to pick-up this change.  The old `FieldNameConverter` needs to expire from the cache first.

1. Go back to the Storm worker logs.  When the change takes effect, we should see a log like the following indicating that the `NoopFieldNameConverter` was created.

    ```
    2018-05-22 16:... [DEBUG] Created field name converter; sensorType=bro, configuredName=NOOP, class=NoopFieldNameConverter
    ```

1. In the same logs, we will start to see tuples fail to be indexed.  Elasticsearch complains because the templates have been created to expect `source:type`, but that field no longer exists because the `FieldNameConverter` was changed.

    ```
    2018-05-22 16:0...[ERROR] Failing 1 tuples
    org.elasticsearch.index.mapper.MapperParsingException: Could not dynamically add mapping for field [source.type]. Existing mapping for [source] must be of type object but found [keyword].
    	at org.elasticsearch.index.mapper.DocumentParser.getDynamicParentMapper(DocumentParser.java:876) ~[stormjar.jar:?]
    	at org.elasticsearch.index.mapper.DocumentParser.parseValue(DocumentParser.java:596) ~[stormjar.jar:?]
    	at org.elasticsearch.index.mapper.DocumentParser.innerParseObject(DocumentParser.java:396) ~[stormjar.jar:?]
    	at org.elasticsearch.index.mapper.DocumentParser.parseObjectOrNested(DocumentParser.java:373) ~[stormjar.jar:?]
    	at org.elasticsearch.index.mapper.DocumentParser.internalParseDocument(DocumentParser.java:93) ~[stormjar.jar:?]
    	at org.elasticsearch.index.mapper.DocumentParser.parseDocument(DocumentParser.java:66) ~[stormjar.jar:?]

    ```


## Pull Request Checklist

- [ ] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [ ] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [ ] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [ ] Have you included steps or a guide to how the change may be verified and tested manually?
- [ ] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
