### PR TITLE
METRON-1571 Correct KAFKA_TAIL Seek to End Logic

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/metron_service.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/metron_service.py
@@ -104,6 +104,11 @@ def build_global_config_patch(params, patch_file):
         "op": "add",
         "path": "/user.settings.hbase.cf",
         "value": "{{user_settings_hbase_cf}}"
+    },
+    {
+        "op": "add",
+        "path": "/bootstrap.servers",
+        "value": "{{kafka_brokers}}"
     }
   ]
   """

--- a/metron-platform/metron-management/src/main/java/org/apache/metron/management/KafkaFunctions.java
+++ b/metron-platform/metron-management/src/main/java/org/apache/metron/management/KafkaFunctions.java
@@ -47,6 +47,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
+import static java.lang.String.format;
 import static org.apache.metron.stellar.dsl.Context.Capabilities.GLOBAL_CONFIG;
 
 /**
@@ -182,7 +183,8 @@ public class KafkaFunctions {
 
       // read some messages
       try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(properties)) {
-        consumer.subscribe(Arrays.asList(topic));
+
+        manualPartitionAssignment(topic, consumer);
 
         // continue until we have enough messages or exceeded the max wait time
         long wait = 0L;
@@ -465,6 +467,10 @@ public class KafkaFunctions {
     Set<TopicPartition> partitions = new HashSet<>();
     for(PartitionInfo partition : consumer.partitionsFor(topic)) {
       partitions.add(new TopicPartition(topic, partition.partition()));
+    }
+
+    if(partitions.size() == 0) {
+      throw new IllegalStateException(format("No partitions available for consumer assignment; topic=%s", topic));
     }
 
     // manually assign this consumer to each partition in the topic

--- a/metron-platform/metron-management/src/test/java/org/apache/metron/management/KafkaFunctionsIntegrationTest.java
+++ b/metron-platform/metron-management/src/test/java/org/apache/metron/management/KafkaFunctionsIntegrationTest.java
@@ -18,20 +18,23 @@
 
 package org.apache.metron.management;
 
-import org.apache.metron.stellar.dsl.Context;
-import org.apache.metron.stellar.dsl.DefaultVariableResolver;
-import org.apache.metron.stellar.dsl.functions.resolver.FunctionResolver;
-import org.apache.metron.stellar.dsl.functions.resolver.SimpleFunctionResolver;
-import org.apache.metron.stellar.common.StellarProcessor;
 import org.apache.metron.integration.BaseIntegrationTest;
 import org.apache.metron.integration.ComponentRunner;
 import org.apache.metron.integration.components.KafkaComponent;
 import org.apache.metron.integration.components.ZKServerComponent;
+import org.apache.metron.stellar.common.StellarProcessor;
+import org.apache.metron.stellar.dsl.Context;
+import org.apache.metron.stellar.dsl.DefaultVariableResolver;
+import org.apache.metron.stellar.dsl.functions.MapFunctions;
+import org.apache.metron.stellar.dsl.functions.resolver.FunctionResolver;
+import org.apache.metron.stellar.dsl.functions.resolver.SimpleFunctionResolver;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -39,7 +42,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 
@@ -55,11 +61,28 @@ public class KafkaFunctionsIntegrationTest extends BaseIntegrationTest {
   private static final String message2 = "{ \"ip_src_addr\": \"10.0.0.1\", \"value\": 23 }";
   private static final String message3 = "{ \"ip_src_addr\": \"10.0.0.1\", \"value\": 29011 }";
 
-  private static Map<String, Object> variables = new HashMap<>();
+  private static Map<String, Object> variables;
   private static ZKServerComponent zkServerComponent;
   private static KafkaComponent kafkaComponent;
   private static ComponentRunner runner;
   private static Properties global;
+  private static FunctionResolver functionResolver;
+  private static ExecutorService executor;
+
+  @Rule
+  public TestName testName = new TestName();
+
+  @BeforeClass
+  public static void setupExecutor() {
+    executor = Executors.newFixedThreadPool(2);
+  }
+
+  @AfterClass
+  public static void tearDownExecutor() {
+    if(executor != null && !executor.isShutdown()) {
+      executor.shutdown();
+    }
+  }
 
   @BeforeClass
   public static void setupKafka() throws Exception {
@@ -67,7 +90,6 @@ public class KafkaFunctionsIntegrationTest extends BaseIntegrationTest {
     Properties properties = new Properties();
     zkServerComponent = getZKServerComponent(properties);
     kafkaComponent = getKafkaComponent(properties, new ArrayList<>());
-
     runner = new ComponentRunner.Builder()
             .withComponent("zk", zkServerComponent)
             .withComponent("kafka", kafkaComponent)
@@ -78,10 +100,23 @@ public class KafkaFunctionsIntegrationTest extends BaseIntegrationTest {
     runner.start();
   }
 
+  @BeforeClass
+  public static void setupFunctionResolver() {
+
+    // used when executing Stellar expressions
+    functionResolver = new SimpleFunctionResolver()
+            .withClass(KafkaFunctions.KafkaGet.class)
+            .withClass(KafkaFunctions.KafkaPut.class)
+            .withClass(KafkaFunctions.KafkaProps.class)
+            .withClass(KafkaFunctions.KafkaTail.class)
+            .withClass(MapFunctions.MapGet.class);
+  }
+
   @Before
   public void setup() {
 
     // messages that will be read/written during the tests
+    variables = new HashMap<>();
     variables.put("message1", message1);
     variables.put("message2", message2);
     variables.put("message3", message3);
@@ -105,23 +140,44 @@ public class KafkaFunctionsIntegrationTest extends BaseIntegrationTest {
   }
 
   /**
-   * Write one message, read one message.
+   * KAFKA_PUT should be able to write one message to a topic.
+   * KAFKA_GET should be able to read one message from a topic.
    */
   @Test
-  public void testOneMessage() {
-    run("KAFKA_PUT('topic1', [message1])");
-    Object actual = run("KAFKA_GET('topic1')");
+  public void testKafkaPut() {
+
+    // use a unique topic name for this test
+    final String topicName = testName.getMethodName();
+    variables.put("topic", topicName);
+
+    // put a message onto the topic
+    run("KAFKA_PUT(topic, [message1])");
+
+    // get a message from the topic
+    Object actual = run("KAFKA_GET(topic)");
+
+    // validate
     assertEquals(Collections.singletonList(message1), actual);
   }
 
   /**
-   * Multiple messages can be read with a single call.
+   * KAFKA_PUT should be able to write multiple messages passed as a List.
+   * KAFKA_GET should be able to read multiple messages at once.
    */
   @Test
-  public void testMultipleMessages() {
-    run("KAFKA_PUT('topic2', [message1, message2, message3])");
-    Object actual = run("KAFKA_GET('topic2', 3)");
+  public void testKafkaPutThenGetWithMultipleMessages() {
 
+    // use a unique topic name for this test
+    final String topicName = testName.getMethodName();
+    variables.put("topic", topicName);
+
+    // put multiple messages onto the topic
+    run("KAFKA_PUT(topic, [message1, message2, message3])");
+
+    // get 3 messages from the topic
+    Object actual = run("KAFKA_GET(topic, 3)");
+
+    // validate that all 3 messages were read
     List<String> expected = new ArrayList<String>() {{
       add(message1);
       add(message2);
@@ -131,20 +187,85 @@ public class KafkaFunctionsIntegrationTest extends BaseIntegrationTest {
   }
 
   /**
+   * KAFKA_GET should maintain its consumer offsets and reuse them across subsequent calls.
+   *
    * Does the client maintain the consumer offset correctly?
+   *
+   * The offsets must be maintained correctly to read messages sequentially, in order
+   * across separate executions of KAKFA_GET
    */
   @Test
-  public void testConsumerOffsets() {
-    run("KAFKA_PUT('topic3', [message1, message2, message3])");
+  public void testKafkaGetWithSequentialReads() {
 
-    // the offsets must be maintained correctly for us to read each message, in order,
-    // sequentially across separate calls to KAFKA_GET
-    assertEquals(Collections.singletonList(message1), run("KAFKA_GET('topic3', 1)"));
-    assertEquals(Collections.singletonList(message2), run("KAFKA_GET('topic3', 1)"));
-    assertEquals(Collections.singletonList(message3), run("KAFKA_GET('topic3', 1)"));
+    // use a unique topic name for this test
+    final String topicName = testName.getMethodName();
+    variables.put("topic", topicName);
+
+    // put multiple messages onto the topic
+    run("KAFKA_PUT(topic, [message1, message2, message3])");
+
+    // read the first message
+    assertEquals(Collections.singletonList(message1), run("KAFKA_GET(topic, 1)"));
+
+    // pick-up from where we left off and read the second message
+    assertEquals(Collections.singletonList(message2), run("KAFKA_GET(topic, 1)"));
+
+    // pick-up from where we left off and read the third message
+    assertEquals(Collections.singletonList(message3), run("KAFKA_GET(topic, 1)"));
+
+    // no more messages left to read
+    assertEquals(Collections.emptyList(), run("KAFKA_GET(topic, 1)"));
   }
 
   /**
+   * KAFKA_TAIL should return new messages from the end of a topic.
+   */
+  @Test
+  public void testKafkaTail() throws Exception {
+
+    // use a unique topic name for this test
+    final String topicName = testName.getMethodName();
+    variables.put("topic", topicName);
+
+    // put multiple messages onto the topic; KAFKA tail should NOT retrieve these
+    run("KAFKA_PUT(topic, [message2, message2, message2])");
+
+    // get a message from the topic; will block until messages arrive
+    Future<Object> tailFuture = runAsync("KAFKA_TAIL(topic, 1)");
+
+    // put 10 messages onto the topic for KAFKA_TAIL to grab
+    runAsyncAndWait(Collections.nCopies(10, "KAFKA_PUT(topic, [message1])"));
+
+    // expect to receive message1, which were added to the topic while KAFKA_TAIL was running
+    Object actual = tailFuture.get(10, TimeUnit.SECONDS);
+    List<String> expected = Collections.singletonList(message1);
+    assertEquals(expected, actual);
+  }
+
+  /**
+   * KAFKA_TAIL should always seek to end of the topic.  If no messages arrives after the 'seek to end'
+   * then no messages will be returned.
+   */
+  @Test
+  public void testKafkaTailNone() {
+
+    // shorten the max wait time so we do not have to wait so long
+    global.put(KafkaFunctions.MAX_WAIT_PROPERTY, 2000);
+
+    // use a unique topic name for this test
+    final String topicName = testName.getMethodName();
+    variables.put("topic", topicName);
+
+    // put multiple messages onto the topic
+    run("KAFKA_PUT(topic, [message1, message2, message3])");
+
+    // no messages to read as KAFKA_TAIL should "seek to end" of the topic
+    assertEquals(Collections.emptyList(), run("KAFKA_TAIL(topic, 1)"));
+  }
+
+  /**
+   * KAFKA_PROPS should return the set of properties used to configure the Kafka consumer
+   *
    * The properties used for the KAFKA_* functions are calculated by compiling the default, global and user
    * properties into a single set of properties.  The global properties should override any default properties.
    */
@@ -162,6 +283,8 @@ public class KafkaFunctionsIntegrationTest extends BaseIntegrationTest {
   }
 
   /**
+   * KAFKA_PROPS should allow the global properties to be overridden
+   *
    * The properties used for the KAFKA_* functions are calculated by compiling the default, global and user
    * properties into a single set of properties.  The user properties should override any default or global properties.
    */
@@ -180,26 +303,59 @@ public class KafkaFunctionsIntegrationTest extends BaseIntegrationTest {
     Map<String, String> properties = (Map<String, String>) run(expression);
     assertEquals(expected, properties.get(overriddenKey));
   }
-
+  
   /**
    * Runs a Stellar expression.
-   * @param expr The expression to run.
+   * @param expression The expression to run.
    */
-  private Object run(String expr) {
+  private Object run(String expression) {
 
     // make the global properties available to the function
     Context context = new Context.Builder()
             .with(Context.Capabilities.GLOBAL_CONFIG, () -> global)
             .build();
 
-    FunctionResolver functionResolver = new SimpleFunctionResolver()
-            .withClass(KafkaFunctions.KafkaGet.class)
-            .withClass(KafkaFunctions.KafkaPut.class)
-            .withClass(KafkaFunctions.KafkaProps.class)
-            .withClass(KafkaFunctions.KafkaTail.class);
-
+    // execute the expression
     StellarProcessor processor = new StellarProcessor();
-    return processor.parse(expr, new DefaultVariableResolver(x -> variables.get(x),x -> variables.containsKey(x)), functionResolver, context);
+    return processor.parse(expression,
+            new DefaultVariableResolver(
+                    x -> variables.get(x),
+                    x -> variables.containsKey(x)),
+            functionResolver,
+            context);
   }
 
+  /**
+   * Runs a Stellar expression asynchronously.
+   *
+   * <p>Does not block until the expression completes.
+   *
+   * @param expression The expression to run.
+   * @return The result of executing the expression.
+   */
+  private Future<Object> runAsync(String expression) {
+    return executor.submit(() -> run(expression));
+  }
+
+  /**
+   * Runs a set of Stellar expression asynchronously and waits
+   * for each to complete before returning.
+   *
+   * @param expressions The expressions to complete.
+   * @throws Exception
+   */
+  private void runAsyncAndWait(Iterable<String> expressions) throws Exception {
+
+    // put multiple messages onto the topic asynchronously for KAFKA_TAIL to grab
+    List<Future<Object>> putFutures = new ArrayList<>();
+    for(String expression: expressions) {
+      Future<Object> future = runAsync(expression);
+      putFutures.add(future);
+    }
+
+    // wait for the puts to complete
+    for(Future<Object> future: putFutures) {
+      future.get(5, TimeUnit.SECONDS);
+    }
+  }
 }

--- a/metron-platform/metron-management/src/test/java/org/apache/metron/management/KafkaFunctionsIntegrationTest.java
+++ b/metron-platform/metron-management/src/test/java/org/apache/metron/management/KafkaFunctionsIntegrationTest.java
@@ -218,6 +218,20 @@ public class KafkaFunctionsIntegrationTest extends BaseIntegrationTest {
   }
 
   /**
+   * KAFKA_GET should return nothing if a topic does not exist
+   */
+  @Test
+  public void testKafkaGetWithNonExistentTopic() {
+
+    // use a unique topic name for this test
+    final String topicName = testName.getMethodName();
+    variables.put("topic", topicName);
+
+    // no more messages left to read
+    assertEquals(Collections.emptyList(), run("KAFKA_GET(topic, 1)"));
+  }
+
+  /**
    * KAFKA_TAIL should return new messages from the end of a topic.
    */
   @Test


### PR DESCRIPTION
### Changes

1. KAFKA_TAIL now performs manual partition assignment and correctly uses the Kafka API to seek to the end of the topic.
 
    Previously, the function messed with the 'group.id' to effectively seek to end.  This is an abuse of the API.  Also, a fixed group.id is required for using the KAFKA_* functions in a Kerberized cluster.

1. The unit tests for KAFKA_TAIL were improved.
 
1. KAKFA_GET and KAFKA_TAIL now use a more accurate mechanism for adhering to the user's requested max wait time.

    Previously, the max wait was divided by the max poll timeout to estimate how many times Kafka should be polled before returning to the user.  This method is not always accurate when some poll requests return values and others do not.

1. The MPack now defines a global property `bootstrap.servers` which allow the KAFKA_* functions to work out-of-the-box after a Metron installation.

    Previously, a user had to manually define this property before using the KAKFA_* functions.  If the property is not defined correctly, they would have to wait an excessive amount of time for the connection to timeout since there is no means in the REPL to interrupt a function call.



### Testing

1. Launch the development environment.

1. Launch the REPL in the development environment.

1. Tail some messages from Kafka

   ```
   KAFKA_TAIL("bro")
   ```

1. Get some messages from Kafka.

   ```
   KAFKA_GET("bro")
   ```

## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?