### PR TITLE
METRON-1578 - EC2 10 Node Deployment - Reverting to using control_path with %C for Mac

### DIFF
--- a/metron-deployment/amazon-ec2/README.md
+++ b/metron-deployment/amazon-ec2/README.md
@@ -190,6 +190,7 @@ key_file: ~/.ssh/metron-private-key.pub
 Common Errors
 -------------
 
+
 ### Error: [unsupported_operation_exception] custom format isn't supported
 
 This error might be seen within Metron's default dashboard in Kibana 4.  This occurs when the index templates do not exist for the Snort, Bro or YAF indices in Elasticsearch.  
@@ -320,3 +321,15 @@ fatal: [ec2-52-26-113-221.us-west-2.compute.amazonaws.com]: UNREACHABLE! => {
 #### Solution
 
 This most often indicates that Ansible cannot connect to the host with the SSH key that it has access to.  This could occur if hosts are provisioned with one SSH key, but the playbook is executed subsequently with a different SSH key.  The issue can be addressed by either altering the `key_file` variable to point to the key that was used to provision the hosts or by simply terminating all hosts and re-running the playbook.
+
+
+### Error: 'Failed to connect to the host via ssh: percent_expand: unknown key %C\r'
+
+'%C' in the control_path of ansible.cfg might not be recognizable in certain distributions of Linux. The control_path is used for SSH connectivity between the host and the nodes being deployed to EC2. 
+
+#### Solution
+Update the control_path in /amazon-ec2/ansible.cfg to the following: 
+```
+[ssh_connection]
+control_path = ~/.ssh/ansible-ssh-%%h-%%r
+```

--- a/metron-deployment/amazon-ec2/ansible.cfg
+++ b/metron-deployment/amazon-ec2/ansible.cfg
@@ -24,8 +24,9 @@ forks = 20
 log_path = ./ansible.log
 
 # fix for "ssh throws 'unix domain socket too long' " problem
-#[ssh_connection]
-#control_path = ~/.ssh/ansible-ssh-%%C
-
 [ssh_connection]
-control_path = ~/.ssh/ansbile-ssh-%%h-%%r
+control_path = ~/.ssh/ansible-ssh-%%C
+
+# fix for "Failed to connect to the host via ssh: percent_expand: unknown key %C" problem
+#[ssh_connection]
+#control_path = ~/.ssh/ansbile-ssh-%%h-%%r


### PR DESCRIPTION
## Contributor Comments
A description of the problem:
This PR is to revert to the previous control_path in ansible.cfg that is compatible with Mac OS (ansible-ssh-%%C). This corrects an issue due to [PR 754](https://github.com/apache/metron/pull/754) that was submitted on Sept 2017. 

This PR also updates the "Error" section of the ec2 README.md to include a solution to the error "percent_expand: unknown key %C" that may occur with certain Linux distributions. 

Testing was done on Mac OS High Sierra using "master" code from 2018-05-23. However the error that was thrown might not be to due to the control_path issue since ambari_* TASKs were succeeding. 
"TASK [python-pip : Install Python's pip Centos ] ... FAILED.. you need to be root to perform this command.."

## Pull Request Checklist
Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?
 "master" code from 2018-05-23


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?

Reproduce Bug: 
1) if ansible.cfg has "control_path = ~/.ssh/ansbile-ssh-%%h-%%r"
2) ./run.sh
3) "ssh throws unix domain socket too long"  error is thrown 

- [x] Have you included steps or a guide to how the change may be verified and tested manually?
1) update ansible.cfg with "control_path = ~/.ssh/ansible-ssh-%%C"
2) ./run.sh
3) see if install tasks are succeeding (i.e. TASK [httplib2 : Install .... ]) 

- [ ] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```



- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
