### PR TITLE
METRON-1580 Release candidate check script requires Bro Plugin

### DIFF
--- a/dev-utilities/release-utils/metron-rc-check
+++ b/dev-utilities/release-utils/metron-rc-check
@@ -22,7 +22,7 @@ function help {
   echo "usage: ${0}"
   echo "    -v/--version=<version>   The version of the metron release. [Required]"
   echo "    -c/--candidate=<RC#>      Defines the Release Candidate. [Required]"
-  echo "    -b/--bro=<bro version>   The version of the bro kafka plugin. [Required]"
+  echo "    -b/--bro=<bro version>   The version of the bro kafka plugin. [Optional]"
   echo "    -h/--help                Usage information."
   echo " "
   echo "example: "
@@ -119,21 +119,22 @@ else
   exit 1
 fi
 
-if [ -z "$BRO" ]; then
-	echo "Missing -b/--bro which is required"
-	exit 1
-fi
-
-if [[ "$BRO" =~ ^[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2} ]]; then
-  BRO_VERSION="$BRO"
-else
-  echo "[ERROR] $BRO may not be a valid version number"
-  exit 1
+# validating the bro plugin is not required
+if [ -n "$BRO" ]; then
+  if [[ "$BRO" =~ ^[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2} ]]; then
+    BRO_VERSION="$BRO"
+  else
+    echo "[ERROR] $BRO may not be a valid version number"
+    exit 1
+  fi
 fi
 
 echo "Metron Version $METRON_VERSION"
 echo "Release Candidate $RC"
-echo "Bro Plugin Version $BRO_VERSION"
+
+if [ -n "$BRO" ]; then
+  echo "Bro Plugin Version $BRO_VERSION"
+fi
 
 METRON_RC_DIST="$METRON_DIST$METRON_VERSION-$UPPER_RC"
 echo "Metron RC Distribution Root is $METRON_RC_DIST"
@@ -158,8 +159,7 @@ echo "Working directory $WORK"
 KEYS="$METRON_RC_DIST/KEYS"
 METRON_ASSEMBLY="$METRON_RC_DIST/apache-metron-$METRON_VERSION-$RC.tar.gz"
 METRON_ASSEMBLY_SIG="$METRON_ASSEMBLY.asc"
-METRON_KAFKA_BRO_ASSEMBLY="$METRON_RC_DIST/apache-metron-bro-plugin-kafka_$BRO_VERSION.tar.gz"
-METRON_KAFKA_BRO_ASSEMBLY_ASC="$METRON_KAFKA_BRO_ASSEMBLY.asc"
+
 
 echo "Downloading $KEYS"
 if ! wget -P "$WORK" "$KEYS" ; then
@@ -172,20 +172,29 @@ if ! wget -P "$WORK" "$METRON_ASSEMBLY" ; then
   echo "[ERROR] Failed to download $METRON_ASSEMBLY"
   exit 1
 fi
+
 echo "Downloading $METRON_ASSEMBLY_SIG"
 if ! wget -P "$WORK" "$METRON_ASSEMBLY_SIG" ; then
   echo "[ERROR] Failed to download $METRON_ASSEMBLY_SIG"
   exit 1
 fi
-echo "Downloading $METRON_KAFKA_BRO_ASSEMBLY"
-if ! wget -P "$WORK" "$METRON_KAFKA_BRO_ASSEMBLY" ; then
-  echo "[ERROR] Failed to download $METRON_KAFKA_BRO_ASSEMBLY"
-  exit 1
-fi
-echo "Downloading $METRON_KAFKA_BRO_ASSEMBLY_ASC"
-if ! wget -P "$WORK" "$METRON_KAFKA_BRO_ASSEMBLY_ASC" ; then
-  echo "[ERROR] Failed to download $METRON_KAFKA_BRO_ASSEMBLY_ASC"
-  exit 1
+
+if [ -n "$BRO" ]; then
+
+  METRON_KAFKA_BRO_ASSEMBLY="$METRON_RC_DIST/apache-metron-bro-plugin-kafka_$BRO_VERSION.tar.gz"
+  METRON_KAFKA_BRO_ASSEMBLY_ASC="$METRON_KAFKA_BRO_ASSEMBLY.asc"
+
+  echo "Downloading $METRON_KAFKA_BRO_ASSEMBLY"
+  if ! wget -P "$WORK" "$METRON_KAFKA_BRO_ASSEMBLY" ; then
+    echo "[ERROR] Failed to download $METRON_KAFKA_BRO_ASSEMBLY"
+    exit 1
+  fi
+
+  echo "Downloading $METRON_KAFKA_BRO_ASSEMBLY_ASC"
+  if ! wget -P "$WORK" "$METRON_KAFKA_BRO_ASSEMBLY_ASC" ; then
+    echo "[ERROR] Failed to download $METRON_KAFKA_BRO_ASSEMBLY_ASC"
+    exit 1
+  fi
 fi
 
 cd "$WORK" || exit 1
@@ -202,20 +211,24 @@ if ! gpg --verify ./"apache-metron-$METRON_VERSION-$RC.tar.gz.asc" "apache-metro
   exit 1
 fi
 
-echo "Verifying Bro Kafka Plugin Assembly"
-if ! gpg --verify ./"apache-metron-bro-plugin-kafka_$BRO_VERSION.tar.gz.asc" "apache-metron-bro-plugin-kafka_$BRO_VERSION.tar.gz" ; then
-  echo "[ERROR] failed to verify Bro Kafka Plugin Assembly"
-  exit 1
+if [ -n "$BRO" ]; then
+
+  echo "Verifying Bro Kafka Plugin Assembly"
+  if ! gpg --verify ./"apache-metron-bro-plugin-kafka_$BRO_VERSION.tar.gz.asc" "apache-metron-bro-plugin-kafka_$BRO_VERSION.tar.gz" ; then
+    echo "[ERROR] failed to verify Bro Kafka Plugin Assembly"
+    exit 1
+  fi
+
+  if ! tar -xzf "apache-metron-bro-plugin-kafka_$BRO_VERSION.tar.gz" ; then
+    echo "[ERROR] failed to unpack  Bro Kafka Plugin Assembly"
+    exit 1
+  fi
+
 fi
 
 echo "Unpacking Assemblies"
 if ! tar -xzf "apache-metron-$METRON_VERSION-$RC.tar.gz" ; then
   echo "[ERROR] failed to unpack Metron Assembly"
-  exit 1
-fi
-
-if ! tar -xzf "apache-metron-bro-plugin-kafka_$BRO_VERSION.tar.gz" ; then
-  echo "[ERROR] failed to unpack  Bro Kafka Plugin Assembly"
   exit 1
 fi
 


### PR DESCRIPTION
Not all Metron releases will include a new version of the Bro Plugin.  The release candidate script currently requires it though.  These changes make the `--bro` argument option which allows us to validate releases which do not contain an updated Bro plugin.

## Testing

```
./dev-utilities/release-utils/metron-rc-check --version=0.5.0 --candidate=RC1
```

## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [ ] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
