### PR TITLE
METRON-1584 Indexing Topology Crashes with Invalid Message

### DIFF
--- a/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/bolt/BulkMessageWriterBoltTest.java
+++ b/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/bolt/BulkMessageWriterBoltTest.java
@@ -120,7 +120,7 @@ public class BulkMessageWriterBoltTest extends BaseEnrichmentBoltTest {
   @Test
   public void testSourceTypeMissing() throws Exception {
 
-    // setup the bold
+    // setup the bolt
     BulkMessageWriterBolt bulkMessageWriterBolt = new BulkMessageWriterBolt("zookeeperUrl")
             .withBulkMessageWriter(bulkMessageWriter)
             .withMessageGetter(MessageGetters.JSON_FROM_FIELD.name())

--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/BulkWriterComponent.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/BulkWriterComponent.java
@@ -116,9 +116,9 @@ public class BulkWriterComponent<MESSAGE_T> {
   }
 
   public void error(String sensorType, Throwable e, Iterable<Tuple> tuples, MessageGetStrategy messageGetStrategy) {
-
     if(!Iterables.isEmpty(tuples)) {
-      LOG.error("Failing tuples; count={}, error={}", Iterables.size(tuples), ExceptionUtils.getRootCauseMessage(e));
+      LOG.error(String.format("Failing tuples; count=%d, error=%s",
+              Iterables.size(tuples), ExceptionUtils.getRootCauseMessage(e)), e);
     }
     tuples.forEach(t -> collector.ack(t));
     MetronError error = new MetronError()
@@ -139,9 +139,9 @@ public class BulkWriterComponent<MESSAGE_T> {
    * @param tuples The tuples to error that may not contain valid messages.
    */
   public void error(Throwable e, Iterable<Tuple> tuples) {
-
     if(!Iterables.isEmpty(tuples)) {
-      LOG.error("Failing tuples; count={}, error={}", Iterables.size(tuples), ExceptionUtils.getRootCauseMessage(e));
+      LOG.error(String.format("Failing tuples; count=%d, error=%s",
+              Iterables.size(tuples), ExceptionUtils.getRootCauseMessage(e)), e);
     }
     tuples.forEach(t -> collector.ack(t));
     MetronError error = new MetronError()

--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/bolt/BulkMessageWriterBolt.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/bolt/BulkMessageWriterBolt.java
@@ -18,6 +18,7 @@
 package org.apache.metron.writer.bolt;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.hadoop.yarn.webapp.hamlet.Hamlet;
 import org.apache.metron.common.Constants;
 import org.apache.metron.common.bolt.ConfiguredIndexingBolt;
 import org.apache.metron.common.configuration.writer.IndexingWriterConfiguration;
@@ -213,60 +214,144 @@ public class BulkMessageWriterBolt extends ConfiguredIndexingBolt {
   @SuppressWarnings("unchecked")
   @Override
   public void execute(Tuple tuple) {
+
     if (isTick(tuple)) {
-      try {
-        if (!(bulkMessageWriter instanceof WriterToBulkWriter)) {
-          //WriterToBulkWriter doesn't allow batching, so no need to flush on Tick.
-          LOG.debug("Flushing message queues older than their batchTimeouts");
-          getWriterComponent().flushTimeouts(bulkMessageWriter, configurationTransformation.apply(
-                  new IndexingWriterConfiguration(bulkMessageWriter.getName(), getConfigurations()))
-                  , messageGetStrategy);
-        }
-      }
-      catch(Exception e) {
-        throw new RuntimeException("This should have been caught in the writerComponent.  If you see this, file a JIRA", e);
-      }
-      finally {
-        collector.ack(tuple);
-      }
-      return;
-    }
+      handleTick(tuple);
 
-    try
-    {
-      JSONObject message = (JSONObject) messageGetStrategy.get(tuple);
+    } else {
+      handleMessage(tuple);
+    }
+  }
+
+  /**
+   * Handle a tuple containing a message; anything other than a tick tuple.
+   *
+   * @param tuple The tuple containing a message.
+   */
+  private void handleMessage(Tuple tuple) {
+    try {
+
+      JSONObject message = getMessage(tuple);
+      if(message == null) {
+        handleMissingMessage(tuple);
+        return;
+      }
+
       String sensorType = MessageUtils.getSensorType(message);
-      LOG.trace("Writing enrichment message: {}", message);
-      WriterConfiguration writerConfiguration = configurationTransformation.apply(
-              new IndexingWriterConfiguration(bulkMessageWriter.getName(), getConfigurations()));
       if(sensorType == null) {
-        //sensor type somehow ended up being null.  We want to error this message directly.
-        getWriterComponent().error("null"
-                             , new Exception("Sensor type is not specified for message "
-                                            + message.toJSONString()
-                                            )
-                             , ImmutableList.of(tuple)
-                             , messageGetStrategy
-                             );
+        handleMissingSensorType(tuple, message);
+        return;
       }
-      else {
-        if (writerConfiguration.isDefault(sensorType)) {
-          //want to warn, but not fail the tuple
-          collector.reportError(new Exception("WARNING: Default and (likely) unoptimized writer config used for " + bulkMessageWriter.getName() + " writer and sensor " + sensorType));
-        }
 
-        getWriterComponent().write(sensorType
-                , tuple
-                , message
-                , bulkMessageWriter
-                , writerConfiguration
-                , messageGetStrategy
-        );
-      }
-    }
-    catch(Exception e) {
+      writeMessage(tuple, message, sensorType);
+
+    } catch (Exception e) {
       throw new RuntimeException("This should have been caught in the writerComponent.  If you see this, file a JIRA", e);
     }
+  }
+
+  /**
+   * Handles a tick tuple.
+   *
+   * @param tickTuple The tick tuple.
+   */
+  private void handleTick(Tuple tickTuple) {
+
+    try {
+      if (!(bulkMessageWriter instanceof WriterToBulkWriter)) {
+        //WriterToBulkWriter doesn't allow batching, so no need to flush on Tick.
+        LOG.debug("Flushing message queues older than their batchTimeouts");
+        getWriterComponent().flushTimeouts(bulkMessageWriter, configurationTransformation.apply(
+                new IndexingWriterConfiguration(bulkMessageWriter.getName(), getConfigurations()))
+                , messageGetStrategy);
+      }
+
+    } catch(Exception e) {
+      throw new RuntimeException("This should have been caught in the writerComponent.  If you see this, file a JIRA", e);
+
+    } finally {
+      collector.ack(tickTuple);
+    }
+  }
+
+  /**
+   * Retrieves the JSON message contained in a tuple.
+   *
+   * @param tuple The tuple containing a JSON message.
+   * @return The JSON message contained in the tuple. If none, returns null.
+   */
+  private JSONObject getMessage(Tuple tuple) {
+
+    JSONObject message = null;
+    try {
+      message = (JSONObject) messageGetStrategy.get(tuple);
+
+    } catch(Throwable e) {
+      LOG.error("Unable to retrieve message from tuple", e);
+    }
+
+    return message;
+  }
+
+  /**
+   * Write a message.
+   *
+   * @param tuple The tuple containing a message.
+   * @param message The message to write.
+   * @param sensorType The sensor type of the message.
+   * @throws Exception
+   */
+  private void writeMessage(Tuple tuple, JSONObject message, String sensorType) throws Exception {
+
+    LOG.trace("Writing message: sourceType={}, message={}", sensorType, message);
+    WriterConfiguration writerConfiguration = configurationTransformation.apply(
+            new IndexingWriterConfiguration(bulkMessageWriter.getName(), getConfigurations()));
+
+    if (writerConfiguration.isDefault(sensorType)) {
+      //want to warn, but not fail the tuple
+      collector.reportError(new Exception("WARNING: Default and (likely) unoptimized writer config used for " + bulkMessageWriter.getName() + " writer and sensor " + sensorType));
+    }
+
+    getWriterComponent().write(sensorType
+            , tuple
+            , message
+            , bulkMessageWriter
+            , writerConfiguration
+            , messageGetStrategy
+    );
+  }
+
+  /**
+   * Handles error processing when a message is missing a sensor type.
+   *
+   * @param tuple The tuple.
+   * @param message The message with no sensor type.
+   */
+  private void handleMissingSensorType(Tuple tuple, JSONObject message) {
+
+    LOG.debug("Message is missing sensor type");
+
+    // sensor type somehow ended up being null.  We want to error this message directly.
+    getWriterComponent().error("null",
+            new Exception("Sensor type is not specified for message " + message.toJSONString()),
+            ImmutableList.of(tuple),
+            messageGetStrategy
+    );
+  }
+
+  /**
+   * Handles error processing when a tuple does not contain a valid message.
+   *
+   * @param tuple The tuple.
+   */
+  private void handleMissingMessage(Tuple tuple) {
+
+    LOG.debug("Unable to extract message from tuple; expected valid JSON");
+
+    getWriterComponent().error(
+            new Exception("Unable to extract message from tuple; expected valid JSON"),
+            ImmutableList.of(tuple)
+    );
   }
 
   @Override


### PR DESCRIPTION
If the indexing topology receives a message containing invalid JSON, the topology will crash.  The topology needs to handle these types of errors and continue processing.

## Changes

* Updated the `BulkWriterComponent` to provide a means for erring out tuples that do not contain valid JSON messages.

* Updated `BulkMessageWriterBolt` to handle the case where a tuple does not contain a valid JSON message.

* Updated `BulkMessageWriterBoltTest` to validate that error'd messages are being ack'd and emitted on the correct error stream.  Previously a mock was being used that hid a bug when erring out tuples with the `BulkWriterComponent` that do not contain a valid JSON message.

* Added a unit test for the case where an invalid message is sent as input to the indexing topology.

## Testing

1. Spin-up the development environment.

1. Ensure that messages are successfully being indexing by running the Service Check and/or validating the Alerts UI.

1. Change the Indexing error topic to "indexing_errors" and restart the Indexing topology.

    ![screen shot 2018-05-29 at 3 11 33 pm](https://user-images.githubusercontent.com/2475409/40680030-d41e9aaa-6352-11e8-80c5-8eba9920e4c4.png)

1. Write an invalid message to the "indexing" topic.

   ```
   export PATH=$PATH:/usr/hdp/current/kafka-broker/bin/
   source /etc/default/metron
   echo "this is a bad message" | kafka-console-producer.sh --broker-list $BROKERLIST --topic indexing
   ```

1. Wait until the invalid message gets picked-up by the Indexing topology, then ensure the invalid message is sent to the "error" topic.

   ```
   kafka-console-consumer.sh --zookeeper node1:2181 --topic indexing_errors --from-beginning
   ```

1. Ensure that an error is reported in the Storm UI.

    ![screen shot 2018-05-29 at 3 24 33 pm](https://user-images.githubusercontent.com/2475409/40680959-bb6507e4-6355-11e8-94f9-ba0f76bca5b0.png)


1. Ensure the indexing topology did not crash and messages continue to be indexed.


## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?