### PR TITLE
METRON-1590: validate-jira-for-release script checks out project into current directory not workdir

### DIFF
--- a/dev-utilities/release-utils/validate-jira-for-release
+++ b/dev-utilities/release-utils/validate-jira-for-release
@@ -162,9 +162,10 @@ fi
 # clone the metron repo and fetch all tags
 WORKDIR="./tmp"
 cd ~
+rm -rf "$WORKDIR/metron-$VERSION"
 git clone $REPO "$WORKDIR/metron-$VERSION"
-git checkout $BRANCH
 cd "$WORKDIR/metron-$VERSION"
+git checkout $BRANCH
 git fetch --all --tags
 
 # find all JIRAs that have been committed since the last release

--- a/dev-utilities/release-utils/validate-jira-for-release
+++ b/dev-utilities/release-utils/validate-jira-for-release
@@ -137,8 +137,6 @@ for i in "$@"; do
   esac
 done
 
-WORKDIR="~/tmp"
-
 # ensure all required values are set
 if [ -z "$VERSION" ]; then
 	echo "Missing -v/--version is is required"
@@ -162,7 +160,9 @@ if [ -z "$BRANCH" ]; then
 fi
 
 # clone the metron repo and fetch all tags
-git clone $REPO "metron-$VERSION"
+WORKDIR="./tmp"
+cd ~
+git clone $REPO "$WORKDIR/metron-$VERSION"
 git checkout $BRANCH
 cd "$WORKDIR/metron-$VERSION"
 git fetch --all --tags

--- a/dev-utilities/release-utils/validate-jira-for-release
+++ b/dev-utilities/release-utils/validate-jira-for-release
@@ -160,11 +160,20 @@ if [ -z "$BRANCH" ]; then
 fi
 
 # clone the metron repo and fetch all tags
-WORKDIR="./tmp"
+WORK="./tmp"
 cd ~
-rm -rf "$WORKDIR/metron-$VERSION"
-git clone $REPO "$WORKDIR/metron-$VERSION"
-cd "$WORKDIR/metron-$VERSION"
+# warn the user if the working directory exists
+if [ -d "$WORK" ]; then
+  read -p "  directory exists [$WORK].  overwrite existing repo? [yN] " -n 1 -r
+  echo
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    exit 1
+  fi
+fi
+
+rm -rf "$WORK/metron-$VERSION"
+git clone $REPO "$WORK/metron-$VERSION"
+cd "$WORK/metron-$VERSION"
 git checkout $BRANCH
 git fetch --all --tags
 


### PR DESCRIPTION
## Contributor Comments
Altering the script a bit. Note that you can't just `git clone git clone $REPO "$WORKDIR/metron-$VERSION"` while leaving `WORKDIR="~/tmp"` because git clone is always relative to current dir and you'll end up with a new folder named `~`.

Also moved `WORKDIR` down to where it's actually used for clarity, since it gets created earlier than it needs to be.

To test, run `./validate-jira-for-release --version=0.5.0 --start=tags/apache-metron-0.4.2-release` and ensure that the checkout occurs in `~/tmp/metron-0.5.0`, rather than in current directory.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron 

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
