### PR TITLE
METRON-1587: Make collection utility work for HDP search

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/indexing_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/indexing_commands.py
@@ -25,6 +25,7 @@ from resource_management.core.exceptions import Fail
 from resource_management.core.logger import Logger
 from resource_management.core.resources.system import Execute, File
 from resource_management.libraries.functions import format as ambari_format
+from resource_management.libraries.functions.format import format
 
 import metron_service
 import metron_security
@@ -85,14 +86,13 @@ class IndexingCommands:
         :return: Dict where key is the name of a collection and the
           value is a path to file containing the schema definition.
         """
-        from params import params
-        return {
-            "bro": params.bro_schema_path,
-            "yaf": params.yaf_schema_path,
-            "snort": params.snort_schema_path,
-            "error": params.error_schema_path,
-            "metaalert": params.meta_schema_path
-        }
+        return [
+            "bro",
+            "yaf",
+            "snort",
+            "error",
+            "metaalert"
+        ]
 
     def is_configured(self):
         return self.__configured
@@ -199,6 +199,53 @@ class IndexingCommands:
               cmd=cmd.format(self.__params.es_http_url, template_name),
               user=self.__params.metron_user,
               err_msg=err_msg.format(template_name))
+
+    def solr_schema_install(self, env):
+        from params import params
+        env.set_params(params)
+        Logger.info("Installing Solr schemas")
+        if self.__params.security_enabled:
+            metron_security.kinit(self.__params.kinit_path_local,
+                                  self.__params.solr_keytab_path,
+                                  self.__params.solr_principal_name,
+                                  self.__params.solr_user)
+
+        commands = IndexingCommands(params)
+        for collection_name in commands.get_solr_schemas():
+
+            # install the schema
+            cmd = format((
+                "export ZOOKEEPER={solr_zookeeper_url};"
+                "export SECURITY_ENABLED={security_enabled};"
+            ))
+            cmd += "{0}/bin/create_collection.sh {1};"
+
+            Execute(
+                cmd.format(params.metron_home, collection_name),
+                user=self.__params.solr_user)
+
+    def solr_schema_delete(self, env):
+        from params import params
+        env.set_params(params)
+        Logger.info("Deleting Solr schemas")
+        if self.__params.security_enabled:
+            metron_security.kinit(self.__params.kinit_path_local,
+                                  self.__params.solr_keytab_path,
+                                  self.__params.solr_principal_name,
+                                  self.__params.solr_user)
+
+        commands = IndexingCommands(params)
+        for collection_name in commands.get_solr_schemas():
+            # delete the schema
+            cmd = format((
+                "export ZOOKEEPER={solr_zookeeper_url};"
+                "export SECURITY_ENABLED={security_enabled};"
+            ))
+            cmd += "{0}/bin/delete_collection.sh {1};"
+
+            Execute(
+                cmd.format(params.metron_home, collection_name),
+                user=self.__params.solr_user)
 
     def start_batch_indexing_topology(self, env):
         Logger.info('Starting ' + self.__batch_indexing_topology)

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/indexing_master.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/indexing_master.py
@@ -97,11 +97,10 @@ class Indexing(Script):
         self.configure(env)
         commands = IndexingCommands(params)
         if params.ra_indexing_writer == 'Solr':
-            Logger.info("Loading Solr schemas")
             # Install Solr schemas
             try:
                 if not commands.is_solr_schema_installed():
-                    self.solr_schema_install(env)
+                    commands.solr_schema_install(env)
                     commands.set_solr_schema_installed()
 
             except Exception as e:
@@ -169,34 +168,6 @@ class Indexing(Script):
             Execute(
               cmd.format(params.es_http_url, template_name),
               logoutput=True)
-
-    def solr_schema_install(self, env):
-        from params import params
-        env.set_params(params)
-        Logger.info("Installing Solr schemas")
-
-        commands = IndexingCommands(params)
-        for collection_name, config_path in commands.get_solr_schemas().iteritems():
-
-            # install the schema
-
-            cmd = "{0}/bin/solr create -c {1} -d {2}"
-            Execute(
-                cmd.format(params.solr_home, collection_name, config_path),
-                logoutput=True, user="solr")
-
-    def solr_schema_delete(self, env):
-        from params import params
-        env.set_params(params)
-        Logger.info("Deleting Solr schemas")
-
-        commands = IndexingCommands(params)
-        for collection_name, config_path in commands.get_solr_schemas().iteritems():
-            # delete the schema
-            cmd = "{0}/bin/solr delete -c {1}"
-            Execute(
-                cmd.format(params.solr_home, collection_name),
-                logoutput=True, user="solr")
 
     @OsFamilyFuncImpl(os_family=OsFamilyImpl.DEFAULT)
     def kibana_dashboard_install(self, env):

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/params_linux.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/params_linux.py
@@ -128,6 +128,9 @@ if has_zk_host:
 solr_version = '6.6.2'
 solr_home = '/var/solr/solr-' + solr_version
 solr_zookeeper_url = format(format(config['configurations']['metron-env']['solr_zookeeper_url']))
+solr_user = config['configurations']['solr-config-env']['solr_config_user']
+solr_principal_name = config['configurations']['solr-config-env']['solr_principal_name']
+solr_keytab_path = config['configurations']['solr-config-env']['solr_keytab_path']
 
 # Storm
 storm_rest_addr = status_params.storm_rest_addr
@@ -255,6 +258,8 @@ if security_enabled:
     kafka_keytab_path = config['configurations']['kafka-env']['kafka_keytab']
 
     nimbus_seeds = config['configurations']['storm-site']['nimbus.seeds']
+
+    solr_principal_name = solr_principal_name.replace('_HOST', hostname_lowercase)
 
 # Management UI
 metron_rest_host = default("/clusterHostInfo/metron_rest_hosts", [hostname])[0]

--- a/metron-platform/metron-solr/README.md
+++ b/metron-platform/metron-solr/README.md
@@ -20,7 +20,10 @@ limitations under the License.
 ## Table of Contents
 
 * [Introduction](#introduction)
+* [Configuration](#configuration)
 * [Installing](#installing)
+* [Schemas](#schemas)
+* [Collections](#collections)
 
 ## Introduction
 
@@ -111,3 +114,31 @@ A PointType field should be defined as:
 <fieldType name="point" class="solr.PointType" subFieldSuffix="_point"/>
 ```
 If any copy fields are defined, stored and docValues should be set to false.
+
+## Collections
+
+Convenience scripts are provided with Metron to create and delete collections.  Ambari uses these scripts to automatically create collections.  To use them outside of Ambari, a few environment variables must be set first:
+```
+# Path to the zookeeper node used by Solr
+export ZOOKEEPER=node1:2181/solr
+# Set to true if Kerberos is enabled
+export SECURITY_ENABLED=true 
+```
+The scripts can then be called directly with the collection name as the first argument .  For example, to create the bro collection:
+```
+$METRON_HOME/bin/create_collection.sh bro
+```
+To delete the bro collection:
+```
+$METRON_HOME/bin/delete_collection.sh bro
+```
+The `create_collection.sh` script depends on schemas installed in `$METRON_HOME/config/schema`.  There are several schemas that come with Metron:
+
+* bro
+* snort
+* yaf
+* metaalert
+* error
+
+Additional schemas should be installed in that location if using the `create_collection.sh` script.  Any collection can be deleted with the `delete_collection.sh` script.
+These scripts use the [Solr Collection API](http://lucene.apache.org/solr/guide/6_6/collections-api.html).


### PR DESCRIPTION
## Contributor Comments
This PR improves the metron-solr create_collection.sh and delete_collection.sh scripts by switching to the Solr REST api instead of the Solr CLI tools.  This removes the requirement that Metron is colocated with a Solr client and makes the scripts easier to use with different versions and distributions.  Now only a zookeeper client is required for retrieving a Solr node address.

I refactored the Ambari code a little bit to match the rest of our MPack.  The solr_schema_install and 
solr_schema_delete functions were moved from indexing_master.py to indexing_commands.py because specific, low-level functions are generally in the *_commands.py scripts.  If this is confusing, doesn't make sense or makes reviewing this harder I'm happy to move them back.

I also added Kerberos support to these scripts.  The way I've done it creates a dependency on the HDP Search 3 Mpack but makes configuring Kerberos easy with no configuration required.  I would like to hear what the community thinks about this approach.  If we do decide to make this a dependency I can also remove the Solr zookeeper configuration setting in Ambari.  At that point using Solr is as easy as switching the "Random Access Search Engine" setting.

This has been tested in full dev with Kerberos enabled.  To test this PR, first install HDP Search 3 in full dev (https://docs.hortonworks.com/HDPDocuments/HDP2/HDP-2.6.4/bk_solr-search-installation/content/hdp-search30-install-mpack.html).  Kerberos can also be enabled now if desired.  Then in Ambari set "Solr Zookeeper Urls" in the "Index Settings" tab to `node1:2181/solr` and change the "Random Access Search Engine" setting in the Indexing tab to `Solr`.  Now stop the Metron Indexing component, then start it.  Note that restart does not trigger automatic Solr collection creation, matching how ES template loading works.  If we think adding collection creation on restart is desirable I can make that change.  Collections (bro, snort, metaalert, yaf, error) should now be present in Solr at node1:8983.

The scripts can also be tested independently from Ambari.  Just have to set a few environment variables first:
```
export ZOOKEEPER=node1:2181/solr
export SECURITY_ENABLED=true  # if Kerberos is enabled
```
Then the scripts should work when executed directly.  For example, to create the bro collection:
```
$METRON_HOME/bin/create_collection.sh bro
```
and to delete the bro collection:
```
$METRON_HOME/bin/delete_collection.sh bro
```

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
