### PR TITLE
METRON-1593: Setting Metron rest additional classpath removes HBase and Hadoop configs from classpath

### DIFF
--- a/metron-interface/metron-rest/src/main/scripts/metron-rest.sh
+++ b/metron-interface/metron-rest/src/main/scripts/metron-rest.sh
@@ -49,7 +49,10 @@ if [ -f "$METRON_SYSCONFIG" ]; then
     . "$METRON_SYSCONFIG"
 fi
 
-METRON_REST_CLASSPATH="${METRON_REST_CLASSPATH:-$HADOOP_CONF_DIR:${HBASE_HOME}/conf}"
+if [ ${METRON_REST_CLASSPATH} ]; then
+    METRON_REST_CLASSPATH+=":"
+fi
+METRON_REST_CLASSPATH+="$HADOOP_CONF_DIR:${HBASE_HOME}/conf"
 
 # Use a custom REST jar if provided, else pull the metron-rest jar
 rest_jar_pattern="${METRON_HOME}/lib/metron-rest*.jar"


### PR DESCRIPTION
## Contributor Comments
This PR fixes a small bug in the metron-rest.sh start script.  Currently the classpath defaults to `$HADOOP_CONF_DIR:${HBASE_HOME}/conf` in the event that the $METRON_REST_CLASSPATH environment variable is not populated initially.  Instead the HBase and Hadoop directories should be added regardless.

This has been tested in full dev.  To reproduce the issue, update Ambari > Metron > Advanced > Advanced metron-rest-env > Metron rest additional classpath to any value and restart Metron REST.  The HBase and Hadoop directories will be missing from the metron-rest classpath (view it with `ps -ef | grep metron-rest`).  After this PR, the HBase and Hadoop configuration directories should be present on the classpath whether that property is set in Ambari or not.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
