### PR TITLE
METRON-1608: Add configuration for threat.triage.field name

### DIFF
--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/service/impl/SearchServiceImpl.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/service/impl/SearchServiceImpl.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.metron.common.Constants;
+import org.apache.metron.common.configuration.ConfigurationsUtils;
 import org.apache.metron.indexing.dao.IndexDao;
 import org.apache.metron.indexing.dao.search.FieldType;
 import org.apache.metron.indexing.dao.search.GetRequest;
@@ -147,13 +148,9 @@ public class SearchServiceImpl implements SearchService {
     if (!alertUserSettings.isPresent() || alertUserSettings.get().getFacetFields() == null) {
       String facetFieldsProperty = environment
           .getProperty(SEARCH_FACET_FIELDS_SPRING_PROPERTY, String.class, "");
-
-      Map<String, Object> globalConfig = globalConfigService.get();
-      String sourceTypeField = Constants.SENSOR_TYPE.replace('.', ':');
+      String sourceTypeField = ConfigurationsUtils.getFieldName(globalConfigService.get(), SENSOR_TYPE_FIELD_PROPERTY,
+              Constants.SENSOR_TYPE.replace('.', ':'));
       List<String> facetFields = new ArrayList<>();
-      if (globalConfig != null) {
-        sourceTypeField = (String) globalConfig.getOrDefault(SENSOR_TYPE_FIELD_PROPERTY, sourceTypeField);
-      }
       facetFields.add(sourceTypeField);
       if (facetFieldsProperty != null) {
         facetFields.addAll(Arrays.asList(facetFieldsProperty.split(",")));

--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/service/impl/SearchServiceImpl.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/service/impl/SearchServiceImpl.java
@@ -18,6 +18,7 @@
 package org.apache.metron.rest.service.impl;
 
 import static org.apache.metron.common.Constants.ERROR_TYPE;
+import static org.apache.metron.common.Constants.SENSOR_TYPE_FIELD_PROPERTY;
 import static org.apache.metron.indexing.dao.MetaAlertDao.METAALERT_TYPE;
 import static org.apache.metron.rest.MetronRestConstants.INDEX_WRITER_NAME;
 import static org.apache.metron.rest.MetronRestConstants.SEARCH_FACET_FIELDS_SPRING_PROPERTY;
@@ -151,7 +152,7 @@ public class SearchServiceImpl implements SearchService {
       String sourceTypeField = Constants.SENSOR_TYPE.replace('.', ':');
       List<String> facetFields = new ArrayList<>();
       if (globalConfig != null) {
-        sourceTypeField = (String) globalConfig.getOrDefault("source.type.field", sourceTypeField);
+        sourceTypeField = (String) globalConfig.getOrDefault(SENSOR_TYPE_FIELD_PROPERTY, sourceTypeField);
       }
       facetFields.add(sourceTypeField);
       if (facetFieldsProperty != null) {

--- a/metron-interface/metron-rest/src/test/java/org/apache/metron/rest/service/impl/SearchServiceImplTest.java
+++ b/metron-interface/metron-rest/src/test/java/org/apache/metron/rest/service/impl/SearchServiceImplTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.metron.rest.service.impl;
 
+import static org.apache.metron.common.Constants.SENSOR_TYPE_FIELD_PROPERTY;
 import static org.apache.metron.rest.MetronRestConstants.INDEX_WRITER_NAME;
 import static org.apache.metron.rest.MetronRestConstants.SEARCH_FACET_FIELDS_SPRING_PROPERTY;
 import static org.junit.Assert.assertEquals;
@@ -183,7 +184,7 @@ public class SearchServiceImplTest {
     when(environment.getProperty(SEARCH_FACET_FIELDS_SPRING_PROPERTY, String.class, ""))
         .thenReturn("ip_src_addr");
     Map<String, Object> globalConfig = new HashMap<>();
-    globalConfig.put("source.type.field", "source.type");
+    globalConfig.put(SENSOR_TYPE_FIELD_PROPERTY, "source.type");
     when(globalConfigService.get()).thenReturn(globalConfig);
     when(alertsUIService.getAlertsUIUserSettings()).thenReturn(Optional.empty());
     List<String> defaultFields = searchService.getDefaultFacetFields();

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/Constants.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/Constants.java
@@ -27,6 +27,7 @@ public class Constants {
   public static final String ZOOKEEPER_TOPOLOGY_ROOT = ZOOKEEPER_ROOT + "/topology";
   public static final long DEFAULT_CONFIGURED_BOLT_TIMEOUT = 5000;
   public static final String SENSOR_TYPE = "source.type";
+  public static final String SENSOR_TYPE_FIELD_PROPERTY = "source.type.field";
   public static final String ENRICHMENT_TOPIC = "enrichments";
   public static final String INDEXING_TOPIC = "indexing";
   public static final String ERROR_STREAM = "error";

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/ConfigurationsUtils.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/ConfigurationsUtils.java
@@ -799,5 +799,12 @@ public class ConfigurationsUtils {
       out.println(type + " Config: " + name + System.lineSeparator() + data);
     }, configType, configName);
   }
+
+  public static String getFieldName(Map<String, Object> globalConfig, String globalConfigKey, String defaultFieldName) {
+    if (globalConfig == null) {
+      return defaultFieldName;
+    }
+    return (String) globalConfig.getOrDefault(globalConfigKey, defaultFieldName);
+  }
 }
 

--- a/metron-platform/metron-elasticsearch/src/main/java/org/apache/metron/elasticsearch/dao/ElasticsearchDao.java
+++ b/metron-platform/metron-elasticsearch/src/main/java/org/apache/metron/elasticsearch/dao/ElasticsearchDao.java
@@ -125,6 +125,14 @@ public class ElasticsearchDao implements IndexDao {
     //uninitialized.
   }
 
+  public AccessConfig getAccessConfig() {
+    return accessConfig;
+  }
+
+  public void setAccessConfig(AccessConfig accessConfig) {
+    this.accessConfig = accessConfig;
+  }
+
   private static Map<String, FieldType> elasticsearchSearchTypeMap;
 
   static {

--- a/metron-platform/metron-elasticsearch/src/main/java/org/apache/metron/elasticsearch/dao/ElasticsearchMetaAlertDao.java
+++ b/metron-platform/metron-elasticsearch/src/main/java/org/apache/metron/elasticsearch/dao/ElasticsearchMetaAlertDao.java
@@ -18,22 +18,9 @@
 
 package org.apache.metron.elasticsearch.dao;
 
-import static org.apache.metron.common.Constants.GUID;
-import static org.apache.metron.common.Constants.SENSOR_TYPE_FIELD_PROPERTY;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
-import static org.elasticsearch.index.query.QueryBuilders.constantScoreQuery;
-import static org.elasticsearch.index.query.QueryBuilders.existsQuery;
-import static org.elasticsearch.index.query.QueryBuilders.nestedQuery;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import java.io.IOException;
-import java.util.*;
-import java.util.Map.Entry;
-import java.util.stream.Collectors;
-import org.apache.commons.collections4.SetUtils;
 import org.apache.lucene.search.join.ScoreMode;
 import org.apache.metron.common.Constants;
+import org.apache.metron.common.configuration.ConfigurationsUtils;
 import org.apache.metron.indexing.dao.AccessConfig;
 import org.apache.metron.indexing.dao.IndexDao;
 import org.apache.metron.indexing.dao.MetaAlertDao;
@@ -52,29 +39,37 @@ import org.apache.metron.indexing.dao.search.SearchRequest;
 import org.apache.metron.indexing.dao.search.SearchResponse;
 import org.apache.metron.indexing.dao.search.SearchResult;
 import org.apache.metron.indexing.dao.update.Document;
-import org.elasticsearch.action.get.GetResponse;
-import org.elasticsearch.action.get.MultiGetItemResponse;
-import org.elasticsearch.action.get.MultiGetRequest.Item;
-import org.elasticsearch.action.get.MultiGetRequestBuilder;
-import org.elasticsearch.action.get.MultiGetResponse;
-import org.elasticsearch.action.index.IndexRequest;
+import org.apache.metron.indexing.dao.update.OriginalNotFoundException;
+import org.apache.metron.indexing.dao.update.PatchRequest;
+import org.apache.metron.stellar.common.utils.ConversionUtils;
 import org.elasticsearch.action.search.SearchRequestBuilder;
-import org.elasticsearch.action.support.replication.ReplicationResponse.ShardInfo;
-import org.elasticsearch.action.update.UpdateRequest;
-import org.elasticsearch.action.update.UpdateResponse;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.InnerHitBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.QueryStringQueryBuilder;
 import org.elasticsearch.search.SearchHit;
-import org.apache.metron.indexing.dao.update.OriginalNotFoundException;
-import org.apache.metron.indexing.dao.update.PatchRequest;
-import org.apache.metron.stellar.common.utils.ConversionUtils;
-import org.elasticsearch.action.search.SearchRequestBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.index.query.QueryStringQueryBuilder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.apache.metron.common.Constants.GUID;
+import static org.apache.metron.common.Constants.SENSOR_TYPE_FIELD_PROPERTY;
+import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static org.elasticsearch.index.query.QueryBuilders.constantScoreQuery;
+import static org.elasticsearch.index.query.QueryBuilders.existsQuery;
+import static org.elasticsearch.index.query.QueryBuilders.nestedQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 
 public class ElasticsearchMetaAlertDao implements MetaAlertDao {
 
@@ -195,7 +190,7 @@ public class ElasticsearchMetaAlertDao implements MetaAlertDao {
     Document metaAlert = buildCreateDocument(alerts, request.getGroups());
     calculateMetaScores(metaAlert);
     // Add source type to be consistent with other sources and allow filtering
-    metaAlert.getDocument().put(getField(SENSOR_TYPE_FIELD_PROPERTY, SOURCE_TYPE), MetaAlertDao.METAALERT_TYPE);
+    metaAlert.getDocument().put(getFieldName(SENSOR_TYPE_FIELD_PROPERTY, SOURCE_TYPE), MetaAlertDao.METAALERT_TYPE);
 
     // Start a list of updates / inserts we need to run
     Map<Document, Optional<String>> updates = new HashMap<>();
@@ -352,7 +347,7 @@ public class ElasticsearchMetaAlertDao implements MetaAlertDao {
       List<Map<String, Object>> currentAlerts = (List<Map<String, Object>>) metaAlert.getDocument()
           .get(MetaAlertDao.ALERT_FIELD);
       currentAlerts.stream().forEach(currentAlert -> {
-        getRequests.add(new GetRequest((String) currentAlert.get(GUID), (String) currentAlert.get(getField(SENSOR_TYPE_FIELD_PROPERTY, SOURCE_TYPE))));
+        getRequests.add(new GetRequest((String) currentAlert.get(GUID), (String) currentAlert.get(getFieldName(SENSOR_TYPE_FIELD_PROPERTY, SOURCE_TYPE))));
       });
       Iterable<Document> alerts = indexDao.getAllLatest(getRequests);
       List<Map<String, Object>> updatedAlerts = new ArrayList<>();
@@ -684,7 +679,7 @@ public class ElasticsearchMetaAlertDao implements MetaAlertDao {
       ArrayList<Double> scores = new ArrayList<>();
       for (Object alertRaw : alertsRaw) {
         Map<String, Object> alert = (Map<String, Object>) alertRaw;
-        Double scoreNum = parseThreatField(alert.get(getField(THREAT_FIELD_PROPERTY, THREAT_TRIAGE_FIELD)));
+        Double scoreNum = parseThreatField(alert.get(getFieldName(THREAT_FIELD_PROPERTY, THREAT_TRIAGE_FIELD)));
         if (scoreNum != null) {
           scores.add(scoreNum);
         }
@@ -699,7 +694,7 @@ public class ElasticsearchMetaAlertDao implements MetaAlertDao {
     Object threatScore = metaScores.getMetaScores().get(threatSort);
 
     // add the threat score as a float; type needs to match the threat score field from each of the sensor indices
-    metaAlert.getDocument().put(getField(THREAT_FIELD_PROPERTY, THREAT_TRIAGE_FIELD), ConversionUtils.convert(threatScore, Float.class));
+    metaAlert.getDocument().put(getFieldName(THREAT_FIELD_PROPERTY, THREAT_TRIAGE_FIELD), ConversionUtils.convert(threatScore, Float.class));
   }
 
   private Double parseThreatField(Object threatRaw) {
@@ -720,11 +715,11 @@ public class ElasticsearchMetaAlertDao implements MetaAlertDao {
     this.pageSize = pageSize;
   }
 
-  private String getField(String globalConfigKey, String defaultField) {
+  private String getFieldName(String globalConfigKey, String defaultFieldName) {
     if (this.elasticsearchDao == null || this.elasticsearchDao.getAccessConfig() == null) {
-      return defaultField;
+      return defaultFieldName;
     }
     Map<String, Object> globalConfig = this.elasticsearchDao.getAccessConfig().getGlobalConfigSupplier().get();
-    return (String) globalConfig.getOrDefault(globalConfigKey, defaultField);
+    return ConfigurationsUtils.getFieldName(globalConfig, globalConfigKey, defaultFieldName);
   }
 }

--- a/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/MetaAlertDao.java
+++ b/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/MetaAlertDao.java
@@ -68,7 +68,8 @@ public interface MetaAlertDao extends IndexDao {
   String METAALERT_TYPE = "metaalert";
   String METAALERT_FIELD = "metaalerts";
   String METAALERT_DOC = METAALERT_TYPE + "_doc";
-  String THREAT_FIELD_DEFAULT = "threat:triage:score";
+  String THREAT_FIELD_DEFAULT = "threat.triage.score";
+  String THREAT_FIELD_PROPERTY = "threat.triage.score.field";
   String THREAT_SORT_DEFAULT = "sum";
   String ALERT_FIELD = "alert";
   String STATUS_FIELD = "status";


### PR DESCRIPTION
## Contributor Comments
This PR adds a configuration to the global config for the `threat.triage.score` field name, similar to what was done in https://github.com/apache/metron/pull/1010 for `source.type`, minus the UI changes.

I also opportunistically fixed a bug where the `source.type` field name wasn't being read from the global config.  Normally this would be a separate PR but the fix overlaps with what was done here so I included it.  I also added a constant for the `source.type.field` property.

## Changes
- Added constants for `source.type.field` and `threat.triage.field` (would `threat.triage.score.field` be better?)
- Added getter/setter for AccessConfig in the ElasticsearchDao (necessary for testing)
- Refactored the default threat triage field name in ElasticsearchMetaAlertDao to match source type field name pattern
- Added a `getField` method that gets the field name from the global config or returns the default field name if not found
- Added unit and integration tests for both `source.type.field` and `threat.triage.field`

## Testing
Testing this in full dev requires changing our indexing topology to use fields with '.'s rather than ':'s.  To do that:

1. Stop the snort sensor with `service sensor-stubs stop snort`
2. Delete the snort ES index with `curl -XDELETE http://node1:9200/snort_index*`
3. Edit the template at `/var/lib/ambari-agent/cache/common-services/METRON/0.5.0/package/files/snort_index.template` by changing `source:type` to `source.type` and `threat:triage:*score` to `threat.triage.*score`
4. Reinstall the template using the "Elasticsearch Template Install" in Ambari
5. Update the global config with the new field names:
```
curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' -d '{
  "es.clustername": "metron",
  "es.ip": "node1:9300",
  "es.date.format": "yyyy.MM.dd.HH",
  "parser.error.topic": "indexing",
  "update.hbase.table": "metron_update",
  "update.hbase.cf": "t",
  "es.client.settings": {
    "client.transport.ping_timeout": "500s"
  },
  "profiler.client.period.duration": "15",
  "profiler.client.period.duration.units": "MINUTES",
  "user.settings.hbase.table": "user_settings",
  "user.settings.hbase.cf": "cf",
  "bootstrap.servers": "node1:6667",
  "geo.hdfs.file": "/apps/metron/geo/default/GeoLite2-City.mmdb.gz",
"source.type.field":"source.type",
"threat.triage.score.field":"threat.triage.score"
}' 'http://node1:8082/api/v1/global/config'
```
6. Update the snort indexing config to not DEDOT the field names:
```
curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' -d '{
  "hdfs": {
    "index": "snort",
    "batchSize": 1,
    "enabled": true
  },
  "elasticsearch": {
    "index": "snort",
    "batchSize": 1,
    "enabled": true,
    "fieldNameConverter": "NOOP"
  },
  "solr": {
    "index": "snort",
    "batchSize": 1,
    "enabled": true
  }
}' 'http://node1:8082/api/v1/sensor/indexing/config/snort'
```
7. Start the snort sensor again with `service sensor-stubs start snort`
8.  Wait for data to appear in the snort ES index and then perform a search:
```
curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' -d '{
"facetFields":[],
  "from": 0,
  "indices": [
    "snort"
  ],
  "query": "*",
  "size": 5
}' 'http://node1:8082/api/v1/search/search'
```
9. Grab a guid from one of the snort search results and create a metaalert:
```
curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' -d '{
  "alerts": [
    {
      "guid": "1c082f1a-ad3a-4e46-ae1e-828b73c9a016",
      "sensorType": "snort"
    }
  ],
  "groups": [
    "string"
  ]
}' 'http://node1:8082/api/v1/metaalert/create'
```
10. Now find the metaalert from the guid returned in the previous step:
```
curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' -d '{
  "guid": "1ad8be85-3164-4be9-a773-379abb044d0a",
  "sensorType": "metaalert"
}' 'http://node1:8082/api/v1/search/findOne'
```

Before this PR there were a couple problems.  First the metaalert had the `source:type` field even though we've switched to "source.type" in the global config.  Second, the `threat.triage.score` field in the metaalert would be 0 because the wrong threat triage field name is used to get scores from alerts.  With this PR the metalaert should correctly have the `source.type` field and the `threat.triage.score` field should be > 0 (assuming the snort alert has a threat triage score):
```
{
  "average": 10,
  "max": 10,
  "threat.triage.score": 10,
  "count": 1,
  "groups": [
    "string"
  ],
  "sum": 10,
  "source.type": "metaalert",
  "min": 10,
  "median": 10,
  "alert": [
    ...
  ]
}
```

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
