### PR TITLE
METRON-1618: Stellar boolean expressions should treat missing variables as false

### DIFF
--- a/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/dsl/Token.java
+++ b/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/dsl/Token.java
@@ -42,6 +42,7 @@ public class Token<T> {
   public T getValue() {
     return value;
   }
+
   public Class<T> getUnderlyingType() {
     return underlyingType;
   }

--- a/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/dsl/functions/BasicStellarTest.java
+++ b/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/dsl/functions/BasicStellarTest.java
@@ -975,4 +975,15 @@ public class BasicStellarTest {
     Assert.assertEquals("val1", ret.get("field1"));
     Assert.assertEquals("val2", ret.get("field2"));
   }
+
+  @Test
+  public void nullAsFalse() {
+    VariableResolver resolver = new MapVariableResolver(new HashMap<>());
+    Assert.assertTrue(runPredicate("is_alert || true", resolver));
+    Assert.assertTrue(runPredicate("NOT(is_alert)", resolver));
+    Assert.assertFalse(runPredicate("if is_alert then true else false", resolver));
+    Assert.assertFalse(runPredicate("if is_alert then true || is_alert else false", resolver));
+    Assert.assertFalse(runPredicate("if is_alert then true || is_alert else false && is_alert", resolver));
+    Assert.assertFalse(runPredicate("if is_alert then true || is_alert else false && (is_alert || true)", resolver));
+  }
 }

--- a/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/dsl/functions/BasicStellarTest.java
+++ b/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/dsl/functions/BasicStellarTest.java
@@ -985,5 +985,7 @@ public class BasicStellarTest {
     Assert.assertFalse(runPredicate("if is_alert then true || is_alert else false", resolver));
     Assert.assertFalse(runPredicate("if is_alert then true || is_alert else false && is_alert", resolver));
     Assert.assertFalse(runPredicate("if is_alert then true || is_alert else false && (is_alert || true)", resolver));
+    //make sure that nulls aren't replaced by false everywhere, only in boolean expressions.
+    Assert.assertNull(run("MAP_GET(is_alert, {false : 'blah'})", resolver));
   }
 }


### PR DESCRIPTION
## Contributor Comments
Right now, because fields may not exist, users can have an awkward time.  For instance, checking for is_alert, you end up having to preface checks with exists(is_alert).

For instance, in one of our [use-cases](https://github.com/apache/metron/tree/master/use-cases/geographic_login_outliers) we use
```
"is_alert := exists(is_alert) && is_alert",
"is_alert := is_alert || (geo_outlier != null && geo_outlier == true)"
```
 instead of :
```
"is_alert := is_alert || geo_outlier == true"
```

I suggest that we adopt a convention from javascript whereby we assume a field not existing or being null should act as false in boolean expressions.  This will simplify stellar's use and hopefully result in less awkwardness.

You can test this via the REPL.  This is what I did, in addition to unit tests:
```
{12:48}[system]~/Documents/workspace/metron/fork/incubator-metron:stellar_falsey ✓ ➭ mvn exec:java -Dexec.mainClass="org.apache.metron.stellar.common.shell.cli.StellarShell" -pl metron-stellar/stellar-common
[INFO] Scanning for projects...
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building stellar-common 0.5.0
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] --- exec-maven-plugin:1.6.0:java (default-cli) @ stellar-common ---
log4j:WARN No appenders could be found for logger (org.apache.metron.stellar.common.shell.DefaultStellarShellExecutor).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
Stellar, Go!
Functions are loading lazily in the background and will be unavailable until loaded fully.
{}
[Stellar]>>> is_alert || null
false
[Stellar]>>> NOT(is_alert)
true
[Stellar]>>> is_alert
[Stellar]>>> if is_alert then 'alert' else 'not'
not
[Stellar]>>> if is_alert || true then 'alert' else 'not'
alert
[Stellar]>>> MAP_GET(is_alert, { false : 'blah', true : 'foo' })
[Stellar]>>>
```
## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
