### PR TITLE
METRON-1624 Set Profiler and Enrichment batch parameters in Ambari

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/configuration/metron-enrichment-env.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/configuration/metron-enrichment-env.xml
@@ -89,6 +89,18 @@
     <value>indexing</value>
     <display-name>Threat Intel Error Topic</display-name>
   </property>
+  <property>
+    <name>enrichment_kafka_writer_batch_size</name>
+    <value>15</value>
+    <description>The number of records to batch when writing to Kakfa.</description>
+    <display-name>Kafka Writer Batch Size</display-name>
+  </property>
+  <property>
+    <name>enrichment_kafka_writer_batch_timeout</name>
+    <value>0</value>
+    <description>The timeout in milliseconds after which a batch will be written to Kafka, even if the batch size has not been met.  If unspecified, or set to `0`, this defaults to a system-determined duration.</description>
+    <display-name>Kafka Writer Batch Timeout</display-name>
+  </property>
 
   <!--
     hbase parameters

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/configuration/metron-profiler-env.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/configuration/metron-profiler-env.xml
@@ -221,4 +221,16 @@
     <description>The profiler storm topology acker executors</description>
     <display-name>Number of Acker Executors</display-name>
   </property>
+  <property>
+    <name>profiler_kafka_writer_batch_size</name>
+    <value>15</value>
+    <description>The number of records to batch when writing to Kakfa.</description>
+    <display-name>Kafka Writer Batch Size</display-name>
+  </property>
+  <property>
+    <name>profiler_kafka_writer_batch_timeout</name>
+    <value>0</value>
+    <description>The timeout in milliseconds after which a batch will be written to Kafka, even if the batch size has not been met.  If unspecified, or set to `0`, this defaults to a system-determined duration.</description>
+    <display-name>Kafka Writer Batch Timeout</display-name>
+  </property>
 </configuration>

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/metron_service.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/metron_service.py
@@ -119,6 +119,26 @@ def build_global_config_patch(params, patch_file):
         "op": "add",
         "path": "/threat.triage.score.field",
         "value": "{{threat_triage_score_field}}"
+    },
+    {
+        "op": "add",
+        "path": "/enrichment.writer.batchSize",
+        "value": "{{enrichment_kafka_writer_batch_size}}"
+    },
+    {
+        "op": "add",
+        "path": "/enrichment.writer.batchTimeout",
+        "value": "{{enrichment_kafka_writer_batch_timeout}}"
+    },
+    {
+        "op": "add",
+        "path": "/profiler.writer.batchSize",
+        "value": "{{profiler_kafka_writer_batch_size}}"
+    },
+    {
+        "op": "add",
+        "path": "/profiler.writer.batchTimeout",
+        "value": "{{profiler_kafka_writer_batch_timeout}}"
     }
   ]
   """

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/params_linux.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/params_linux.py
@@ -268,6 +268,8 @@ enrichment_input_topic = status_params.enrichment_input_topic
 enrichment_output_topic = config['configurations']['metron-enrichment-env']['enrichment_output_topic']
 enrichment_error_topic = config['configurations']['metron-enrichment-env']['enrichment_error_topic']
 threatintel_error_topic = config['configurations']['metron-enrichment-env']['threatintel_error_topic']
+enrichment_kafka_writer_batch_size = config['configurations']['metron-enrichment-env']['enrichment_kafka_writer_batch_size']
+enrichment_kafka_writer_batch_timeout = config['configurations']['metron-enrichment-env']['enrichment_kafka_writer_batch_timeout']
 
 # Enrichment - Storm common parameters
 enrichment_workers = config['configurations']['metron-enrichment-env']['enrichment_workers']
@@ -328,6 +330,8 @@ profiler_window_lag=config['configurations']['metron-profiler-env']['profiler_wi
 profiler_window_lag_units=config['configurations']['metron-profiler-env']['profiler_window_lag_units']
 profiler_topology_message_timeout_secs=config['configurations']['metron-profiler-env']['profiler_topology_message_timeout_secs']
 profiler_topology_max_spout_pending=config['configurations']['metron-profiler-env']['profiler_topology_max_spout_pending']
+profiler_kafka_writer_batch_size = config['configurations']['metron-profiler-env']['profiler_kafka_writer_batch_size']
+profiler_kafka_writer_batch_timeout = config['configurations']['metron-profiler-env']['profiler_kafka_writer_batch_timeout']
 
 # Indexing
 ra_indexing_kafka_start = config['configurations']['metron-indexing-env']['ra_indexing_kafka_start']

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/themes/metron_theme.json
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/themes/metron_theme.json
@@ -484,6 +484,14 @@
           "subsection-name": "subsection-enrichment-kafka"
         },
         {
+          "config": "metron-enrichment-env/enrichment_kafka_writer_batch_size",
+          "subsection-name": "subsection-enrichment-kafka"
+        },
+        {
+          "config": "metron-enrichment-env/enrichment_kafka_writer_batch_timeout",
+          "subsection-name": "subsection-enrichment-kafka"
+        },
+        {
           "config": "metron-enrichment-env/enrichment_workers",
           "subsection-name": "subsection-enrichment-storm"
         },
@@ -665,6 +673,14 @@
         },
         {
           "config": "metron-profiler-env/profiler_kafka_start",
+          "subsection-name": "subsection-profiler-kafka"
+        },
+        {
+          "config": "metron-profiler-env/profiler_kafka_writer_batch_size",
+          "subsection-name": "subsection-profiler-kafka"
+        },
+        {
+          "config": "metron-profiler-env/profiler_kafka_writer_batch_timeout",
           "subsection-name": "subsection-profiler-kafka"
         },
         {
@@ -864,7 +880,6 @@
           "type": "text-field"
         }
       },
-
       {
         "config": "metron-enrichment-env/geoip_url",
         "widget": {
@@ -903,6 +918,18 @@
       },
       {
         "config": "metron-enrichment-env/threatintel_error_topic",
+        "widget": {
+          "type": "text-field"
+        }
+      },
+      {
+        "config": "metron-enrichment-env/enrichment_kafka_writer_batch_size",
+        "widget": {
+          "type": "text-field"
+        }
+      },
+      {
+        "config": "metron-enrichment-env/enrichment_kafka_writer_batch_timeout",
         "widget": {
           "type": "text-field"
         }
@@ -1183,6 +1210,18 @@
         "config": "metron-profiler-env/profiler_kafka_start",
         "widget": {
           "type": "combo"
+        }
+      },
+      {
+        "config": "metron-profiler-env/profiler_kafka_writer_batch_size",
+        "widget": {
+          "type": "text-field"
+        }
+      },
+      {
+        "config": "metron-profiler-env/profiler_kafka_writer_batch_timeout",
+        "widget": {
+          "type": "text-field"
         }
       },
       {


### PR DESCRIPTION
METRON-1594 introduced a mechanism to control the batch size and timeout when writing records to Kafka by updating the global properties.  

Both Enrichment and the Profiler write records back into Kafka.  The user can independently set the batch size and timeout for each of those. Since these are global properties, the user must set these using the CLI.

    ```
    "profiler.writer.batchSize" : 15,
    "profiler.writer.batchTimeout" : 0,
    "enrichment.writer.batchSize" : 15,
    "enrichment.writer.batchTimeout" : 0
    ```

With this change, the user can now adjust these values in Ambari.

## Testing

1. Launch the development environment.  Ensure alerts are visible in the Alerts UI and that the Service Check passes.

1. Open the REPL and validate the current value of the global property 'threat.triage.score.field'.  The value here, the default value should be `threat:triage:score`.

    ```
    [root@node1 ~]# source /etc/default/metron
    [root@node1 ~]# $METRON_HOME/bin/stellar -z $ZOOKEEPER
    Stellar, Go!
    ...
    [Stellar]>>> globals := CONFIG_GET("GLOBAL")
    {
      ...
      "profiler.writer.batchSize" : "15",
      "profiler.writer.batchTimeout" : "0",
      ...
      "enrichment.writer.batchSize" : "15",
      "enrichment.writer.batchTimeout" : "0",
      ...
    }
    ```

1. Change any of these values in Ambari by going to either... 

    * Metron > Configs > Profiler > Kafka

        ![screen shot 2018-06-19 at 3 48 27 pm](https://user-images.githubusercontent.com/2475409/41662561-692bfd68-746f-11e8-8e51-bf800a9d8486.png)

    * Metron > Configs > Enrichment > Kafka 
         
        ![screen shot 2018-06-19 at 3 48 07 pm](https://user-images.githubusercontent.com/2475409/41662569-6b15ba7e-746f-11e8-8f03-4e9d23c914b2.png)

1. After saving the change, Ambari should prompt for either the Profiler or Enrichment topology to be restarted

1. Restart all affected services.

1. After the services have been restarted, open the REPL and validate that the value of the global property 'threat.triage.score.field' changed in the global config.

    ```
    [root@node1 ~]# source /etc/default/metron
    [root@node1 ~]# $METRON_HOME/bin/stellar -z $ZOOKEEPER
    Stellar, Go!
    ...
    [Stellar]>>> globals := CONFIG_GET("GLOBAL")
    {
      ...
      "profiler.writer.batchSize" : "150",
      "profiler.writer.batchTimeout" : "5000",
      ...
      "enrichment.writer.batchSize" : "400",
      "enrichment.writer.batchTimeout" : "10000",
      ...
    }
    ```

## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?