### PR TITLE
METRON-1672: Add metron-alerts's UI unit tests to travis build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@
 
 dist: trusty
 sudo: required
+addons:
+  chrome: stable
 
 env:
   - TEST_TYPE=default

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ addons:
   chrome: stable
 
 env:
-  - SCRIPT="mvn surefire:test@unit-tests -T 2C -q -B -V"
-  - SCRIPT="mvn surefire:test@integration-tests -q -B -V"
-  - SCRIPT="mvn test --projects metron-interface/metron-config,metron-interface/metron-alerts -q -B -V"
-  - SCRIPT="build_utils/verify_licenses.sh"
+  - SCRIPT="mvn surefire:test@unit-tests -T 2C"
+  - SCRIPT="mvn surefire:test@integration-tests"
+  - SCRIPT="mvn test --projects metron-interface/metron-config,metron-interface/metron-alerts"
+  - SCRIPT="./dev-utilities/build-utils/verify_licenses.sh"
 
 install: true
 language: java

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,10 @@ addons:
   chrome: stable
 
 env:
-  - TEST_TYPE=default
+  - SCRIPT="mvn surefire:test@unit-tests -T 2C -q -B -V"
+  - SCRIPT="mvn surefire:test@integration-tests -q -B -V"
+  - SCRIPT="mvn test --projects metron-interface/metron-config,metron-interface/metron-alerts -q -B -V"
+  - SCRIPT="build_utils/verify_licenses.sh"
 
 install: true
 language: java
@@ -35,10 +38,13 @@ before_install:
   - npm config set prefix $HOME/.npm-prefix --global
 
 install:
-  - time mvn -q -T 2C -DskipTests clean install
+  - time mvn install -T 2C -q -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 
 script:
-  - time mvn -q -T 2C surefire:test@unit-tests && time mvn -q surefire:test@integration-tests && time mvn -q test --projects metron-interface/metron-config,metron-interface/metron-alerts && time dev-utilities/build-utils/verify_licenses.sh
+  - time $SCRIPT
+
+matrix:
+  fast_finish: true
 
 before_cache:
   - rm -rf $HOME/.m2/repository/org/apache/metron

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   - time mvn -q -T 2C -DskipTests clean install
 
 script:
-  - time mvn -q -T 2C surefire:test@unit-tests && time mvn -q surefire:test@integration-tests && time mvn -q test --projects metron-interface/metron-config && time dev-utilities/build-utils/verify_licenses.sh
+  - time mvn -q -T 2C surefire:test@unit-tests && time mvn -q surefire:test@integration-tests && time mvn -q test --projects metron-interface/metron-config,metron-interface/metron-alerts && time dev-utilities/build-utils/verify_licenses.sh
 
 before_cache:
   - rm -rf $HOME/.m2/repository/org/apache/metron

--- a/metron-interface/metron-alerts/karma.conf.js
+++ b/metron-interface/metron-alerts/karma.conf.js
@@ -18,6 +18,8 @@
 // Karma configuration file, see link for more information
 // https://karma-runner.github.io/0.13/config/configuration-file.html
 
+process.env.CHROME_BIN = require('puppeteer').executablePath()
+
 module.exports = function (config) {
   config.set({
     basePath: '',
@@ -55,7 +57,18 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
+    browsers: ['Chrome','ChromeHeadless'],
+    customLaunchers: {
+      ChromeHeadless: {
+        base: 'Chrome',
+        flags: [
+          '--no-sandbox',
+          '--headless',
+          '--disable-gpu',
+          '--remote-debugging-port=9222'
+        ]
+      }
+    },
     singleRun: false
   });
 };

--- a/metron-interface/metron-alerts/package.json
+++ b/metron-interface/metron-alerts/package.json
@@ -7,7 +7,7 @@
     "build": "./node_modules/@angular/cli/bin/ng build -prod",
     "start": "ng serve",
     "lint": "tslint \"src/**/*.ts\"",
-    "test": "./node_modules/@angular/cli/bin/ng test --watch=false",
+    "test": "karma start --single-run --browsers ChromeHeadless karma.conf.js",
     "pree2e": "webdriver-manager update",
     "e2e": "protractor-flake --protractor-path=./node_modules/.bin/protractor --max-attempts=3 -- ./protractor.conf.js"
   },
@@ -58,6 +58,7 @@
     "optimist": "0.6.1",
     "protractor": "5.3.0",
     "protractor-flake": "^3.3.0",
+    "puppeteer": "^1.6.0",
     "serve-favicon": "2.4.2",
     "serve-static": "1.12.1",
     "ssh2": "^0.5.5",

--- a/metron-interface/metron-alerts/pom.xml
+++ b/metron-interface/metron-alerts/pom.xml
@@ -27,8 +27,6 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <node.version>v9.11.1</node.version>
         <npm.version>5.8.0</npm.version>
-        <maven.test.skip>false</maven.test.skip>
-        <skipTests>${maven.test.skip}</skipTests>
     </properties>
     <dependencies>
     </dependencies>
@@ -80,7 +78,6 @@
                         </goals>
                         <configuration>
                             <arguments>test</arguments>
-                            <skip>${skipTests}</skip>
                         </configuration>
                     </execution>
                 </executions>

--- a/metron-interface/metron-alerts/pom.xml
+++ b/metron-interface/metron-alerts/pom.xml
@@ -74,7 +74,7 @@
                     </execution>
                     <execution>
                         <phase>test</phase>
-                        <id>ng test</id>
+                        <id>npm test</id>
                         <goals>
                             <goal>npm</goal>
                         </goals>

--- a/metron-interface/metron-alerts/pom.xml
+++ b/metron-interface/metron-alerts/pom.xml
@@ -25,8 +25,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <node.version>v7.10.0</node.version>
-        <npm.version>4.2.0</npm.version>
+        <node.version>v9.11.1</node.version>
+        <npm.version>5.8.0</npm.version>
+        <maven.test.skip>false</maven.test.skip>
+        <skipTests>${maven.test.skip}</skipTests>
     </properties>
     <dependencies>
     </dependencies>
@@ -68,6 +70,17 @@
                         </goals>
                         <configuration>
                             <arguments>run build</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <phase>test</phase>
+                        <id>ng test</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>test</arguments>
+                            <skip>${skipTests}</skip>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Contributor Comments
Couple things happen here:

- Added a mvn test goal for the metron-alert UI tests
- Made the tests use Chrome headless in order to actually have them run properly in Travis. Also added the Chrome add-on in Travis for this.
- Updated node/npm versions to fix some issues with running the tests.  Matched the version to https://github.com/apache/metron/pull/1096
- The build started going over time, so I resurrected the build matrix from https://github.com/apache/metron/pull/854. I left out the Maven wrapper stuff.  Given that Apache's been pretty good with Travis and other projects use this capability, I'm in favor of using it now that we're cramming even more in.

### Build Matrix
As stated, a build matrix was added to the Travis build.  It breaks things into 4 sections the same as the PR it's based on.

1. Unit Tests
2. Integration Tests
3. UI tests
4. License validation

Javadoc is skipped, because it's broken (sigh).  I have the fixes in a branch, and I'd like to turn it on as follow-on.

### Testing
Make sure that `mvn test` works from metron-interface/metron-alerts.  It should not spin up an actual Chrome window and should be headless.

If you choose to push into Travis, you should see something the following in the output. This can be seen at https://travis-ci.org/justinleet/metron/jobs/404500911. The overall build matrix job can be seen at https://travis-ci.org/justinleet/metron/builds/404500908.
```
[INFO] > metron-alerts@0.5.1 test /home/travis/build/justinleet/metron/metron-interface/metron-alerts
[INFO] > karma start --single-run --browsers ChromeHeadless karma.conf.js
[INFO] 
[INFO] 16 07 2018 16:01:20.477:INFO [karma]: Karma v1.4.1 server started at http://0.0.0.0:9876/
[INFO] 16 07 2018 16:01:20.480:INFO [launcher]: Launching browser ChromeHeadless with unlimited concurrency
[INFO] 16 07 2018 16:01:20.492:INFO [launcher]: Starting browser Chrome
[INFO] 16 07 2018 16:01:44.456:INFO [HeadlessChrome 0.0.0 (Linux 0.0.0)]: Connected on socket Ts9_772t05A32OhrAAAA with id 78239511
[INFO] HeadlessChrome 0.0.0 (Linux 0.0.0): Executed 0 of 23 SUCCESS (0 secs / 0 secs)
[INFO] e 0.0.0 (Linux 0.0.0): Executed 1 of 23 SUCCESS (0 secs / 0.205 secs)
[INFO] 16 07 2018 16:01:48.411:WARN [web-server]: 404: /api/v1/global/config
[INFO] 16 07 2018 16:01:48.418:WARN [web-server]: 404: /api/v1/global/config
[INFO] e 0.0.0 (Linux 0.0.0): Executed 2 of 23 SUCCESS (0 secs / 0.41 secs)
[INFO] 16 07 2018 16:01:48.611:WARN [web-server]: 404: /api/v1/global/config
[INFO] e 0.0.0 (Linux 0.0.0): Executed 3 of 23 SUCCESS (0 secs / 0.581 secs)
[INFO] e 0.0.0 (Linux 0.0.0): Executed 4 of 23 SUCCESS (0 secs / 0.738 secs)
[INFO] e 0.0.0 (Linux 0.0.0): Executed 5 of 23 SUCCESS (0 secs / 0.783 secs)
[INFO] e 0.0.0 (Linux 0.0.0): Executed 6 of 23 SUCCESS (0 secs / 0.853 secs)
[INFO] e 0.0.0 (Linux 0.0.0): Executed 7 of 23 SUCCESS (0 secs / 0.884 secs)
[INFO] e 0.0.0 (Linux 0.0.0): Executed 8 of 23 SUCCESS (0 secs / 0.911 secs)
[INFO] e 0.0.0 (Linux 0.0.0): Executed 9 of 23 SUCCESS (0 secs / 0.936 secs)
[INFO] e 0.0.0 (Linux 0.0.0): Executed 10 of 23 SUCCESS (0 secs / 0.952 secs)
[INFO] e 0.0.0 (Linux 0.0.0): Executed 11 of 23 SUCCESS (0 secs / 1.003 secs)
[INFO] e 0.0.0 (Linux 0.0.0): Executed 12 of 23 SUCCESS (0 secs / 1.039 secs)
[INFO] e 0.0.0 (Linux 0.0.0): Executed 13 of 23 SUCCESS (0 secs / 1.04 secs)
[INFO] e 0.0.0 (Linux 0.0.0): Executed 14 of 23 SUCCESS (0 secs / 1.04 secs)
[INFO] e 0.0.0 (Linux 0.0.0): Executed 15 of 23 SUCCESS (0 secs / 1.073 secs)
[INFO] e 0.0.0 (Linux 0.0.0): Executed 16 of 23 SUCCESS (0 secs / 1.074 secs)
[INFO] e 0.0.0 (Linux 0.0.0): Executed 17 of 23 SUCCESS (0 secs / 1.075 secs)
[INFO] e 0.0.0 (Linux 0.0.0): Executed 18 of 23 SUCCESS (0 secs / 1.1 secs)
[INFO] e 0.0.0 (Linux 0.0.0): Executed 19 of 23 SUCCESS (0 secs / 1.101 secs)
[INFO] e 0.0.0 (Linux 0.0.0): Executed 20 of 23 SUCCESS (0 secs / 1.101 secs)
[INFO] e 0.0.0 (Linux 0.0.0): Executed 21 of 23 SUCCESS (0 secs / 1.101 secs)
[INFO] e 0.0.0 (Linux 0.0.0): Executed 22 of 23 SUCCESS (0 secs / 1.126 secs)
[INFO] e 0.0.0 (Linux 0.0.0): Executed 23 of 23 SUCCESS (0 secs / 1.214 secs)
[INFO] e 0.0.0 (Linux 0.0.0): Executed 23 of 23 SUCCESS (1.249 secs / 1.214 secs)
```

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
