### PR TITLE
METRON-1696: Create the HDFS directory for pcap sequence files and add required privileges to metron user

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/params_linux.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/params_linux.py
@@ -161,6 +161,8 @@ metron_topic_retention = config['configurations']['metron-env']['metron_topic_re
 local_grok_patterns_dir = format("{metron_home}/patterns")
 hdfs_grok_patterns_dir = format("{metron_apps_hdfs_dir}/patterns")
 
+hdfs_pcap_sequencefiles_dir = format("{metron_apps_hdfs_dir}/pcap")
+
 # for create_hdfs_directory
 security_enabled = config['configurations']['cluster-env']['security_enabled']
 hdfs_user_keytab = config['configurations']['hadoop-env']['hdfs_user_keytab']

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/parser_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/parser_commands.py
@@ -94,12 +94,15 @@ class ParserCommands:
 
     def init_pcap(self):
         Logger.info("Creating HDFS location for pcap sequence files")
+        # Non Kerberized Metron runs under 'storm', requiring write under the 'hadoop' group.
+        # Kerberized Metron runs under it's own user.
+        ownership = 0755 if self.__params.security_enabled else 0775
         self.__params.HdfsResource(self.__params.hdfs_pcap_sequencefiles_dir,
                                type="directory",
                                action="create_on_execute",
                                owner=self.__params.metron_user,
-                               group=self.__params.metron_group,
-                               mode=0755,
+                               group=self.__params.hadoop_group,
+                               mode=ownership,
                                )
 
     def get_parser_list(self):

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/parser_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/parser_commands.py
@@ -76,6 +76,7 @@ class ParserCommands:
 
     def init_parsers(self):
         self.init_grok_patterns()
+        self.init_pcap()
         Logger.info("Done initializing parser configuration")
 
     def init_grok_patterns(self):
@@ -90,6 +91,16 @@ class ParserCommands:
                                    mode=0755,
                                    source=self.__params.local_grok_patterns_dir,
                                    recursive_chown = True)
+
+    def init_pcap(self):
+        Logger.info("Creating HDFS location for pcap sequence files")
+        self.__params.HdfsResource(self.__params.hdfs_pcap_sequencefiles_dir,
+                               type="directory",
+                               action="create_on_execute",
+                               owner=self.__params.metron_user,
+                               group=self.__params.metron_group,
+                               mode=0755,
+                               )
 
     def get_parser_list(self):
         return self.__parser_list
@@ -227,6 +238,9 @@ class ParserCommands:
 
         Logger.info('Checking Kafka topics for Parsers')
         metron_service.check_kafka_topics(self.__params, self.__get_topics())
+
+        Logger.info("Checking for pcap sequence files directory in HDFS for PCAP")
+        metron_service.check_hdfs_dir_exists(self.__params, self.__params.hdfs_pcap_sequencefiles_dir)
 
         if self.__params.security_enabled:
             Logger.info('Checking Kafka ACLs for Parsers')


### PR DESCRIPTION

## Contributor Comments
PCAP parser fails to write pacap sequence file to hdfs on kerberized cluster due to insufficient privileges to hdfs folder for 'metron' user. Create the HDFS directory for PCAP sequence files and add the required privileges to metron user.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [ ] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [ ] Have you included steps or a guide to how the change may be verified and tested manually?
- [ ] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
