### PR TITLE
METRON-1703 Make Core Profiler Components Serializable [Feature Branch]

### DIFF
--- a/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/DefaultMessageDistributor.java
+++ b/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/DefaultMessageDistributor.java
@@ -20,25 +20,27 @@
 
 package org.apache.metron.profiler;
 
-import static java.lang.String.format;
-
 import com.google.common.base.Ticker;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
-import java.lang.invoke.MethodHandles;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.metron.common.configuration.profiler.ProfileConfig;
 import org.apache.metron.stellar.dsl.Context;
 import org.json.simple.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.String.format;
 
 /**
  * The default implementation of a {@link MessageDistributor}.
@@ -57,7 +59,7 @@ import org.slf4j.LoggerFactory;
  * lost.
  *
  */
-public class DefaultMessageDistributor implements MessageDistributor {
+public class DefaultMessageDistributor implements MessageDistributor, Serializable {
 
   protected static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
@@ -73,7 +75,7 @@ public class DefaultMessageDistributor implements MessageDistributor {
    * messages.  Once it has not received messages for a period of time, it is
    * moved to the expired cache.
    */
-  private transient Cache<Integer, ProfileBuilder> activeCache;
+  private Cache<Integer, ProfileBuilder> activeCache;
 
   /**
    * A cache of expired profiles.
@@ -84,7 +86,7 @@ public class DefaultMessageDistributor implements MessageDistributor {
    * can flush the state of the expired profile.  If the client does not flush
    * the expired profiles, this state will be lost forever.
    */
-  private transient Cache<Integer, ProfileBuilder> expiredCache;
+  private Cache<Integer, ProfileBuilder> expiredCache;
 
   /**
    * Create a new message distributor.
@@ -287,7 +289,7 @@ public class DefaultMessageDistributor implements MessageDistributor {
   /**
    * A listener that is notified when profiles expire from the active cache.
    */
-  private class ActiveCacheRemovalListener implements RemovalListener<Integer, ProfileBuilder> {
+  private class ActiveCacheRemovalListener implements RemovalListener<Integer, ProfileBuilder>, Serializable {
 
     @Override
     public void onRemoval(RemovalNotification<Integer, ProfileBuilder> notification) {
@@ -305,7 +307,7 @@ public class DefaultMessageDistributor implements MessageDistributor {
   /**
    * A listener that is notified when profiles expire from the active cache.
    */
-  private class ExpiredCacheRemovalListener implements RemovalListener<Integer, ProfileBuilder> {
+  private class ExpiredCacheRemovalListener implements RemovalListener<Integer, ProfileBuilder>, Serializable {
 
     @Override
     public void onRemoval(RemovalNotification<Integer, ProfileBuilder> notification) {

--- a/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/DefaultMessageRouter.java
+++ b/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/DefaultMessageRouter.java
@@ -30,6 +30,7 @@ import org.json.simple.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,7 +45,7 @@ import static java.lang.String.format;
  * A single telemetry message may need to take multiple routes.  This is the case
  * when a message is needed by more than one profile.
  */
-public class DefaultMessageRouter implements MessageRouter {
+public class DefaultMessageRouter implements MessageRouter, Serializable {
 
   protected static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/MessageRoute.java
+++ b/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/MessageRoute.java
@@ -22,6 +22,8 @@ package org.apache.metron.profiler;
 
 import org.apache.metron.common.configuration.profiler.ProfileConfig;
 
+import java.io.Serializable;
+
 /**
  * Defines the 'route' a message must take through the Profiler.
  *
@@ -33,7 +35,7 @@ import org.apache.metron.common.configuration.profiler.ProfileConfig;
  *
  * @see MessageRouter
  */
-public class MessageRoute {
+public class MessageRoute implements Serializable {
 
   /**
    * The definition of the profile on this route.

--- a/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/clock/DefaultClockFactory.java
+++ b/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/clock/DefaultClockFactory.java
@@ -21,6 +21,8 @@ package org.apache.metron.profiler.clock;
 
 import org.apache.metron.common.configuration.profiler.ProfilerConfig;
 
+import java.io.Serializable;
+
 /**
  * Creates a {@link Clock} based on the profiler configuration.
  *
@@ -29,7 +31,7 @@ import org.apache.metron.common.configuration.profiler.ProfilerConfig;
  *
  * <p>The default implementation of a {@link ClockFactory}.
  */
-public class DefaultClockFactory implements ClockFactory {
+public class DefaultClockFactory implements ClockFactory, Serializable {
 
   /**
    * @param config The profiler configuration.

--- a/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/clock/EventTimeClock.java
+++ b/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/clock/EventTimeClock.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Optional;
+import java.io.Serializable;
 
 /**
  * A {@link Clock} that advances based on event time.
@@ -33,7 +34,7 @@ import java.util.Optional;
  * Event time is advanced by the timestamps contained within telemetry messages, rather
  * than the system clock.
  */
-public class EventTimeClock implements Clock {
+public class EventTimeClock implements Clock, Serializable {
 
   protected static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 


### PR DESCRIPTION

All of the core Profiler components are now tagged as Serializable.  This allows users to use Java serialization if desired, when running the Profiler in Spark.

This is a pull request against the `METRON-1699-create-batch-profiler` feature branch.

## Testing

1. Launch the development environment.
2. Ensure alerts are created in the Alerts UI.
3. Ensure the Service Check in Ambari passes.
4. Follow the instructions in the Profiler README to create a simple profile using the Profiler topology in Storm.


## Pull Request Checklist

- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?