### PR TITLE
METRON-1704 Message Timestamp Logic Should be Shared [Feature Branch]

### DIFF
--- a/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/DefaultMessageDistributor.java
+++ b/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/DefaultMessageDistributor.java
@@ -146,16 +146,14 @@ public class DefaultMessageDistributor implements MessageDistributor {
   /**
    * Distribute a message along a MessageRoute.
    *
-   * @param message The message that needs distributed.
-   * @param timestamp The timestamp of the message.
    * @param route The message route.
    * @param context The Stellar execution context.
    */
   @Override
-  public void distribute(JSONObject message, long timestamp, MessageRoute route, Context context) {
+  public void distribute(MessageRoute route, Context context) {
     try {
       ProfileBuilder builder = getBuilder(route, context);
-      builder.apply(message, timestamp);
+      builder.apply(route.getMessage(), route.getTimestamp());
 
     } catch(ExecutionException e) {
       LOG.error("Unexpected error", e);

--- a/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/DefaultMessageRouter.java
+++ b/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/DefaultMessageRouter.java
@@ -22,6 +22,9 @@ package org.apache.metron.profiler;
 
 import org.apache.metron.common.configuration.profiler.ProfileConfig;
 import org.apache.metron.common.configuration.profiler.ProfilerConfig;
+import org.apache.metron.profiler.clock.Clock;
+import org.apache.metron.profiler.clock.ClockFactory;
+import org.apache.metron.profiler.clock.DefaultClockFactory;
 import org.apache.metron.stellar.common.DefaultStellarStatefulExecutor;
 import org.apache.metron.stellar.common.StellarStatefulExecutor;
 import org.apache.metron.stellar.dsl.Context;
@@ -53,10 +56,16 @@ public class DefaultMessageRouter implements MessageRouter {
    */
   private StellarStatefulExecutor executor;
 
+  /**
+   * Responsible for creating the {@link Clock}.
+   */
+  private ClockFactory clockFactory;
+
   public DefaultMessageRouter(Context context) {
     this.executor = new DefaultStellarStatefulExecutor();
     StellarFunctions.initialize(context);
     executor.setContext(context);
+    clockFactory = new DefaultClockFactory();
   }
 
   /**
@@ -73,7 +82,8 @@ public class DefaultMessageRouter implements MessageRouter {
 
     // attempt to route the message to each of the profiles
     for (ProfileConfig profile: config.getProfiles()) {
-      Optional<MessageRoute> route = routeToProfile(message, profile);
+      Clock clock = clockFactory.createClock(config);
+      Optional<MessageRoute> route = routeToProfile(message, profile, clock);
       route.ifPresent(routes::add);
     }
 
@@ -86,20 +96,24 @@ public class DefaultMessageRouter implements MessageRouter {
    * @param profile The profile that may need the message.
    * @return A MessageRoute if the message is needed by the profile.
    */
-  private Optional<MessageRoute> routeToProfile(JSONObject message, ProfileConfig profile) {
+  private Optional<MessageRoute> routeToProfile(JSONObject message, ProfileConfig profile, Clock clock) {
     Optional<MessageRoute> route = Optional.empty();
 
     // allow the profile to access the fields defined within the message
     @SuppressWarnings("unchecked")
     final Map<String, Object> state = (Map<String, Object>) message;
-
     try {
       // is this message needed by this profile?
       if (executor.execute(profile.getOnlyif(), state, Boolean.class)) {
 
-        // what is the name of the entity in this message?
-        String entity = executor.execute(profile.getForeach(), state, String.class);
-        route = Optional.of(new MessageRoute(profile, entity));
+        // what time is is? could be either system or event time
+        Optional<Long> timestamp = clock.currentTimeMillis(message);
+        if(timestamp.isPresent()) {
+
+          // what is the name of the entity in this message?
+          String entity = executor.execute(profile.getForeach(), state, String.class);
+          route = Optional.of(new MessageRoute(profile, entity, message, timestamp.get()));
+        }
       }
 
     } catch(Throwable e) {
@@ -109,5 +123,13 @@ public class DefaultMessageRouter implements MessageRouter {
     }
 
     return route;
+  }
+
+  public void setExecutor(StellarStatefulExecutor executor) {
+    this.executor = executor;
+  }
+
+  public void setClockFactory(ClockFactory clockFactory) {
+    this.clockFactory = clockFactory;
   }
 }

--- a/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/MessageDistributor.java
+++ b/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/MessageDistributor.java
@@ -43,12 +43,10 @@ public interface MessageDistributor {
   /**
    * Distribute a message along a {@link MessageRoute}.
    *
-   * @param message The message that needs distributed.
-   * @param timestamp The timestamp of the message.
    * @param route The message route.
    * @param context The Stellar execution context.
    */
-  void distribute(JSONObject message, long timestamp, MessageRoute route, Context context);
+  void distribute(MessageRoute route, Context context);
 
   /**
    * Flush all active profiles.

--- a/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/MessageRoute.java
+++ b/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/MessageRoute.java
@@ -20,7 +20,11 @@
 
 package org.apache.metron.profiler;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.metron.common.configuration.profiler.ProfileConfig;
+import org.json.simple.JSONObject;
 
 /**
  * Defines the 'route' a message must take through the Profiler.
@@ -46,14 +50,26 @@ public class MessageRoute {
   private String entity;
 
   /**
+   * The message taking this route.
+   */
+  private JSONObject message;
+
+  /**
+   * The timestamp of the message.
+   */
+  private Long timestamp;
+
+  /**
    * Create a {@link MessageRoute}.
    *
    * @param profileDefinition The profile definition.
-   * @param entity The entity.
+   * @param entity            The entity.
    */
-  public MessageRoute(ProfileConfig profileDefinition, String entity) {
+  public MessageRoute(ProfileConfig profileDefinition, String entity, JSONObject message, Long timestamp) {
     this.entity = entity;
     this.profileDefinition = profileDefinition;
+    this.message = message;
+    this.timestamp = timestamp;
   }
 
   public String getEntity() {
@@ -70,5 +86,49 @@ public class MessageRoute {
 
   public void setProfileDefinition(ProfileConfig profileDefinition) {
     this.profileDefinition = profileDefinition;
+  }
+
+  public JSONObject getMessage() {
+    return message;
+  }
+
+  public void setMessage(JSONObject message) {
+    this.message = message;
+  }
+
+  public Long getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(Long timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    MessageRoute that = (MessageRoute) o;
+    return new EqualsBuilder()
+            .append(profileDefinition, that.profileDefinition)
+            .append(entity, that.entity)
+            .append(message, that.message)
+            .append(timestamp, that.timestamp)
+            .isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37)
+            .append(profileDefinition)
+            .append(entity)
+            .append(message)
+            .append(timestamp)
+            .toHashCode();
   }
 }

--- a/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/StandAloneProfiler.java
+++ b/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/StandAloneProfiler.java
@@ -112,26 +112,14 @@ public class StandAloneProfiler {
    * @param message The message to apply.
    */
   public void apply(JSONObject message) {
-
-    // what time is it?
-    Clock clock = clockFactory.createClock(config);
-    Optional<Long> timestamp = clock.currentTimeMillis(message);
-
-    // can only route the message, if we have a timestamp
-    if(timestamp.isPresent()) {
-
-      // route the message to the correct profile builders
-      List<MessageRoute> routes = router.route(message, config, context);
-      for (MessageRoute route : routes) {
-        distributor.distribute(message, timestamp.get(), route, context);
-      }
-
-      routeCount += routes.size();
-      messageCount += 1;
-
-    } else {
-      LOG.warn("No timestamp available for the message. The message will be ignored.");
+    // route the message to the correct profile builders
+    List<MessageRoute> routes = router.route(message, config, context);
+    for (MessageRoute route : routes) {
+      distributor.distribute(route, context);
     }
+
+    routeCount += routes.size();
+    messageCount += 1;
   }
 
   /**

--- a/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/DefaultMessageDistributorTest.java
+++ b/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/DefaultMessageDistributorTest.java
@@ -123,10 +123,10 @@ public class DefaultMessageDistributorTest {
     long timestamp = 100;
     ProfileConfig definition = createDefinition(profileOne);
     String entity = (String) messageOne.get("ip_src_addr");
-    MessageRoute route = new MessageRoute(definition, entity);
+    MessageRoute route = new MessageRoute(definition, entity, messageOne, timestamp);
 
     // distribute one message and flush
-    distributor.distribute(messageOne, timestamp, route, context);
+    distributor.distribute(route, context);
     List<ProfileMeasurement> measurements = distributor.flush();
 
     // expect one measurement coming from one profile
@@ -144,12 +144,12 @@ public class DefaultMessageDistributorTest {
     String entity = (String) messageOne.get("ip_src_addr");
 
     // distribute one message to the first profile
-    MessageRoute routeOne = new MessageRoute(createDefinition(profileOne), entity);
-    distributor.distribute(messageOne, timestamp, routeOne, context);
+    MessageRoute routeOne = new MessageRoute(createDefinition(profileOne), entity, messageOne, timestamp);
+    distributor.distribute(routeOne, context);
 
     // distribute another message to the second profile, but same entity
-    MessageRoute routeTwo = new MessageRoute(createDefinition(profileTwo), entity);
-    distributor.distribute(messageOne, timestamp, routeTwo, context);
+    MessageRoute routeTwo = new MessageRoute(createDefinition(profileTwo), entity, messageOne, timestamp);
+    distributor.distribute(routeTwo, context);
 
     // expect 2 measurements; 1 for each profile
     List<ProfileMeasurement> measurements = distributor.flush();
@@ -164,13 +164,13 @@ public class DefaultMessageDistributorTest {
 
     // distribute one message
     String entityOne = (String) messageOne.get("ip_src_addr");
-    MessageRoute routeOne = new MessageRoute(createDefinition(profileOne), entityOne);
-    distributor.distribute(messageOne, timestamp, routeOne, context);
+    MessageRoute routeOne = new MessageRoute(createDefinition(profileOne), entityOne, messageOne, timestamp);
+    distributor.distribute(routeOne, context);
 
     // distribute another message with a different entity
     String entityTwo = (String) messageTwo.get("ip_src_addr");
-    MessageRoute routeTwo =  new MessageRoute(createDefinition(profileTwo), entityTwo);
-    distributor.distribute(messageTwo, timestamp, routeTwo, context);
+    MessageRoute routeTwo =  new MessageRoute(createDefinition(profileTwo), entityTwo, messageTwo, timestamp);
+    distributor.distribute(routeTwo, context);
 
     // expect 2 measurements; 1 for each entity
     List<ProfileMeasurement> measurements = distributor.flush();
@@ -190,7 +190,7 @@ public class DefaultMessageDistributorTest {
     // setup
     ProfileConfig definition = createDefinition(profileOne);
     String entity = (String) messageOne.get("ip_src_addr");
-    MessageRoute route = new MessageRoute(definition, entity);
+    MessageRoute route = new MessageRoute(definition, entity, messageOne, System.currentTimeMillis());
     distributor = new DefaultMessageDistributor(
             periodDurationMillis,
             profileTimeToLiveMillis,
@@ -198,7 +198,7 @@ public class DefaultMessageDistributorTest {
             ticker);
 
     // distribute one message
-    distributor.distribute(messageOne, 1000000, route, context);
+    distributor.distribute(route, context);
 
     // advance time to just shy of the profile TTL
     ticker.advanceTime(profileTimeToLiveMillis - 1000, MILLISECONDS);
@@ -220,7 +220,7 @@ public class DefaultMessageDistributorTest {
     // setup
     ProfileConfig definition = createDefinition(profileOne);
     String entity = (String) messageOne.get("ip_src_addr");
-    MessageRoute route = new MessageRoute(definition, entity);
+    MessageRoute route = new MessageRoute(definition, entity, messageOne, System.currentTimeMillis());
     distributor = new DefaultMessageDistributor(
             periodDurationMillis,
             profileTimeToLiveMillis,
@@ -228,7 +228,7 @@ public class DefaultMessageDistributorTest {
             ticker);
 
     // distribute one message
-    distributor.distribute(messageOne, 100000, route, context);
+    distributor.distribute(route, context);
 
     // advance time to just beyond the period duration
     ticker.advanceTime(profileTimeToLiveMillis + 1000, MILLISECONDS);
@@ -251,7 +251,7 @@ public class DefaultMessageDistributorTest {
     // setup
     ProfileConfig definition = createDefinition(profileOne);
     String entity = (String) messageOne.get("ip_src_addr");
-    MessageRoute route = new MessageRoute(definition, entity);
+    MessageRoute route = new MessageRoute(definition, entity, messageOne, System.currentTimeMillis());
     distributor = new DefaultMessageDistributor(
             periodDurationMillis,
             profileTimeToLiveMillis,
@@ -259,7 +259,7 @@ public class DefaultMessageDistributorTest {
             ticker);
 
     // distribute one message
-    distributor.distribute(messageOne, 1000000, route, context);
+    distributor.distribute(route, context);
 
     // advance time a couple of hours
     ticker.advanceTime(2, HOURS);

--- a/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/DefaultMessageRouterTest.java
+++ b/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/DefaultMessageRouterTest.java
@@ -57,6 +57,17 @@ public class DefaultMessageRouterTest {
 
   /**
    * {
+   *   "ip_src_addr": "10.0.0.1",
+   *   "value": "22",
+   *   "timestamp": 1531250226659
+   * }
+   */
+  @Multiline
+  private String inputWithTimestamp;
+  private JSONObject messageWithTimestamp;
+
+  /**
+   * {
    *   "profiles": [ ]
    * }
    */
@@ -175,6 +186,23 @@ public class DefaultMessageRouterTest {
   @Multiline
   private String goodAndBad;
 
+  /**
+   * {
+   *   "profiles": [
+   *      {
+   *        "profile": "profile-one",
+   *        "foreach": "ip_src_addr",
+   *        "init":   { "x": "0" },
+   *        "update": { "x": "x + 1" },
+   *        "result": "x"
+   *      }
+   *   ],
+   *   "timestampField": "timestamp"
+   * }
+   */
+  @Multiline
+  private String profileWithEventTime;
+
   private DefaultMessageRouter router;
   private Context context;
 
@@ -193,6 +221,7 @@ public class DefaultMessageRouterTest {
     JSONParser parser = new JSONParser();
     this.messageOne = (JSONObject) parser.parse(inputOne);
     this.messageTwo = (JSONObject) parser.parse(inputTwo);
+    this.messageWithTimestamp = (JSONObject) parser.parse(inputWithTimestamp);
   }
 
   @Test
@@ -267,5 +296,31 @@ public class DefaultMessageRouterTest {
     MessageRoute route1 = routes.get(0);
     assertEquals("good-profile", route1.getProfileDefinition().getProfile());
     assertEquals(messageOne.get("ip_src_addr"), route1.getEntity());
+  }
+
+  /**
+   *
+   */
+  @Test
+  public void testMessageWithTimestamp() throws Exception {
+    List<MessageRoute> routes = router.route(messageWithTimestamp, createConfig(profileWithEventTime), context);;
+
+    assertEquals(1, routes.size());
+    MessageRoute route1 = routes.get(0);
+    assertEquals("profile-one", route1.getProfileDefinition().getProfile());
+    assertEquals(messageWithTimestamp.get("ip_src_addr"), route1.getEntity());
+    assertEquals(messageWithTimestamp.get("timestamp"), route1.getTimestamp());
+  }
+
+  /**
+   * If the timestamp of a message cannot be determined, it should not be routed.
+   *
+   * <p>This might happen when using event time and the message is missing the timestamp field.
+   */
+  @Test
+  public void testMessageWithMissingTimestamp() throws Exception {
+    // messageOne does not contain a timestamp
+    List<MessageRoute> routes = router.route(messageOne, createConfig(profileWithEventTime), context);
+    assertEquals(0, routes.size());
   }
 }

--- a/metron-analytics/metron-profiler/src/main/java/org/apache/metron/profiler/bolt/ProfileBuilderBolt.java
+++ b/metron-analytics/metron-profiler/src/main/java/org/apache/metron/profiler/bolt/ProfileBuilderBolt.java
@@ -363,9 +363,9 @@ public class ProfileBuilderBolt extends BaseWindowedBolt implements Reloadable {
     activeFlushSignal.update(timestamp);
     
     // distribute the message
-    MessageRoute route = new MessageRoute(definition, entity);
+    MessageRoute route = new MessageRoute(definition, entity, message, timestamp);
     synchronized (messageDistributor) {
-      messageDistributor.distribute(message, timestamp, route, getStellarContext());
+      messageDistributor.distribute(route, getStellarContext());
     }
 
     LOG.debug("Message distributed: profile={}, entity={}, timestamp={}", definition.getProfile(), entity, timestamp);

--- a/metron-analytics/metron-profiler/src/test/java/org/apache/metron/profiler/bolt/ProfileBuilderBoltTest.java
+++ b/metron-analytics/metron-profiler/src/test/java/org/apache/metron/profiler/bolt/ProfileBuilderBoltTest.java
@@ -127,7 +127,7 @@ public class ProfileBuilderBoltTest extends BaseBoltTest {
     bolt.execute(tupleWindow);
 
     // the message should have been extracted from the tuple and passed to the MessageDistributor
-    verify(distributor).distribute(eq(message1), eq(timestamp1), any(MessageRoute.class), any());
+    verify(distributor).distribute(any(MessageRoute.class), any());
   }
 
 

--- a/metron-analytics/metron-profiler/src/test/java/org/apache/metron/profiler/bolt/ProfileSplitterBoltTest.java
+++ b/metron-analytics/metron-profiler/src/test/java/org/apache/metron/profiler/bolt/ProfileSplitterBoltTest.java
@@ -23,6 +23,7 @@ package org.apache.metron.profiler.bolt;
 import org.adrianwalker.multilinestring.Multiline;
 import org.apache.metron.common.configuration.profiler.ProfileConfig;
 import org.apache.metron.common.configuration.profiler.ProfilerConfig;
+import org.apache.metron.profiler.DefaultMessageRouter;
 import org.apache.metron.profiler.clock.FixedClockFactory;
 import org.apache.metron.common.utils.JSONUtils;
 import org.apache.metron.test.bolt.BaseBoltTest;
@@ -428,7 +429,9 @@ public class ProfileSplitterBoltTest extends BaseBoltTest {
     bolt.prepare(new HashMap<>(), topologyContext, outputCollector);
 
     // set the clock factory AFTER calling prepare to use the fixed clock factory
-    bolt.setClockFactory(new FixedClockFactory(timestamp));
+    DefaultMessageRouter router = new DefaultMessageRouter(bolt.getStellarContext());
+    router.setClockFactory(new FixedClockFactory(timestamp));
+    bolt.setRouter(router);
 
     return bolt;
   }


### PR DESCRIPTION
The Profiler can operate using either processing time or event time.  This is controlled by the user by defining the "timestampField" option in their Profiler configuration.

There is logic that determines the timestamp of a message.  If the Profiler is configured to use processing time, then system time is returned by this logic.  If the Profiler is configured to use event time, then the timestamp is extracted from a message field.

This logic is currently duplicated across both ports of the Profiler; the REPL and Storm.  This should be pulled into `metron-profiler-common/` so that the logic can be shared and also used by the Spark port.

This is a pull request against the `METRON-1699-create-batch-profiler` feature branch.

## Testing

1. Launch the development environment.
1. Ensure alerts are created in the Alerts UI.
1. Ensure the Service Check in Ambari passes.
1. Follow the instructions in the Profiler README to create a basic profile in the REPL.
1. Follow the instructions in the Profiler README to create a simple profile using the Profiler topology in Storm.

## Pull Request Checklist

- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?