### PR TITLE
METRON-1706: HbaseClient.mutate should return the number of mutations [Feature Branch]

### DIFF
--- a/metron-platform/metron-hbase/src/main/java/org/apache/metron/hbase/client/HBaseClient.java
+++ b/metron-platform/metron-hbase/src/main/java/org/apache/metron/hbase/client/HBaseClient.java
@@ -133,9 +133,11 @@ public class HBaseClient implements Closeable {
 
   /**
    * Submits all queued Mutations.
+   * @return The number of mutation submitted.
    */
-  public void mutate() {
-    Object[] result = new Object[mutations.size()];
+  public int mutate() {
+    int mutationCount = mutations.size();
+    Object[] result = new Object[mutationCount];
     try {
       table.batch(mutations, result);
       mutations.clear();
@@ -144,6 +146,8 @@ public class HBaseClient implements Closeable {
       LOG.warn("Error performing a mutation to HBase.", e);
       throw new RuntimeException(e);
     }
+
+    return mutationCount;
   }
 
   /**

--- a/metron-platform/metron-hbase/src/test/java/org/apache/metron/hbase/client/HBaseClientTest.java
+++ b/metron-platform/metron-hbase/src/test/java/org/apache/metron/hbase/client/HBaseClientTest.java
@@ -85,6 +85,8 @@ public class HBaseClientTest {
     // create the table
     table = util.createTable(Bytes.toBytes(tableName), WidgetMapper.CF);
     util.waitTableEnabled(table.getName());
+    // setup the client
+    client = new HBaseClient((c,t) -> table, table.getConfiguration(), tableName);
   }
 
   @AfterClass
@@ -105,9 +107,6 @@ public class HBaseClientTest {
 
   @Before
   public void setupTuples() throws Exception {
-
-    // setup the client
-    client = new HBaseClient((c,t) -> table, table.getConfiguration(), tableName);
 
     // create a mapper
     mapper = new WidgetMapper();


### PR DESCRIPTION
The `HbaseClient.mutate` method should return the number of mutations.

This is a pull request against the METRON-1699-create-batch-profiler feature branch.


## Testing

1. Launch the development environment.
1. Ensure alerts are created in the Alerts UI.
1. Ensure the Service Check in Ambari passes.

## Pull Request Checklist

- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?