### PR TITLE
METRON-1735: Empty print status option causes NPE

### DIFF
--- a/metron-platform/metron-pcap-backend/src/main/java/org/apache/metron/pcap/query/CliParser.java
+++ b/metron-platform/metron-pcap-backend/src/main/java/org/apache/metron/pcap/query/CliParser.java
@@ -126,6 +126,9 @@ public class CliParser {
         //no-op
       }
     }
+    if (commandLine.hasOption("yarn_queue")) {
+      config.setYarnQueue(commandLine.getOptionValue("yarn_queue"));
+    }
   }
 
   public void printHelp(String msg, Options opts) {

--- a/metron-platform/metron-pcap-backend/src/main/java/org/apache/metron/pcap/query/CliParser.java
+++ b/metron-platform/metron-pcap-backend/src/main/java/org/apache/metron/pcap/query/CliParser.java
@@ -55,7 +55,6 @@ public class CliParser {
     options.addOption(newOption("rpf", "records_per_file", true, String.format("Number of records to include in each output pcap file (defaults to %s)", NUM_RECORDS_PER_FILE_DEFAULT)));
     options.addOption(newOption("et", "end_time", true, "Packet end time range. Default is current system time."));
     options.addOption(newOption("df", "date_format", true, "Date format to use for parsing start_time and end_time. Default is to use time in millis since the epoch."));
-    options.addOption(newOption("ps", "print_status", false, "Print the status of the job as it runs"));
     options.addOption(newOption("yq", "yarn_queue", true, "Yarn queue this job will be submitted to"));
     return options;
   }
@@ -126,12 +125,6 @@ public class CliParser {
       } catch (NumberFormatException nfe) {
         //no-op
       }
-    }
-    if (commandLine.hasOption("print_status")) {
-      config.setPrintJobStatus(true);
-    }
-    if (commandLine.hasOption("yarn_queue")) {
-      config.setYarnQueue(commandLine.getOptionValue("yarn_queue"));
     }
   }
 

--- a/metron-platform/metron-pcap-backend/src/test/java/org/apache/metron/pcap/query/PcapCliTest.java
+++ b/metron-platform/metron-pcap-backend/src/test/java/org/apache/metron/pcap/query/PcapCliTest.java
@@ -172,8 +172,7 @@ public class PcapCliTest {
             "-protocol", "6",
             "-include_reverse",
             "-num_reducers", "10",
-            "-records_per_file", "1000",
-            "-ps"
+            "-records_per_file", "1000"
     };
     Map<String, String> query = new HashMap<String, String>() {{
       put(Constants.Fields.SRC_ADDR.getName(), "192.168.1.1");
@@ -217,7 +216,6 @@ public class PcapCliTest {
             "-include_reverse",
             "-num_reducers", "10",
             "-records_per_file", "1000",
-            "-ps",
             "-yq", "pcap"
     };
     Map<String, String> query = new HashMap<String, String>() {{
@@ -295,8 +293,7 @@ public class PcapCliTest {
             "-base_path", "/base/path",
             "-base_output_path", "/base/output/path",
             "-query", "some query string",
-            "-records_per_file", "1000",
-            "-ps"
+            "-records_per_file", "1000"
     };
 
     String query = "some query string";

--- a/metron-platform/metron-pcap/src/main/java/org/apache/metron/pcap/config/PcapConfig.java
+++ b/metron-platform/metron-pcap/src/main/java/org/apache/metron/pcap/config/PcapConfig.java
@@ -42,7 +42,7 @@ public class PcapConfig extends AbstractMapDecorator<String, Object>{
   public PcapConfig(PrefixStrategy prefixStrategy) {
     this();
     setShowHelp(false);
-    setPrintJobStatus(false);
+    setPrintJobStatus(true);
     setBasePath("");
     setBaseInterimResultPath("");
     setStartTimeMs(-1L);

--- a/metron-platform/metron-pcap/src/main/java/org/apache/metron/pcap/mr/PcapJob.java
+++ b/metron-platform/metron-pcap/src/main/java/org/apache/metron/pcap/mr/PcapJob.java
@@ -463,12 +463,20 @@ public class PcapJob<T> implements Statusable<Path> {
     return new JobStatus(jobStatus);
   }
 
+  protected void setJobStatus(JobStatus jobStatus) {
+    this.jobStatus = jobStatus;
+  }
+
+  protected void setMrJob(Job mrJob) {
+    this.mrJob = mrJob;
+  }
+
   /**
    * Synchronous call blocks until completion.
    */
   @Override
   public Pageable<Path> get() throws JobException, InterruptedException {
-    if (PcapOptions.PRINT_JOB_STATUS.get(configuration, Boolean.class)) {
+    if (PcapOptions.PRINT_JOB_STATUS.getOrDefault(configuration, Boolean.class, false) && mrJob != null) {
       try {
         mrJob.monitorAndPrintJob();
       } catch (IOException e) {
@@ -484,10 +492,6 @@ public class PcapJob<T> implements Statusable<Path> {
       }
       Thread.sleep(completeCheckInterval);
     }
-  }
-
-  public void monitorJob() throws IOException, InterruptedException {
-    mrJob.monitorAndPrintJob();
   }
 
   private synchronized Pageable<Path> getFinalResults() {
@@ -520,5 +524,9 @@ public class PcapJob<T> implements Statusable<Path> {
   @Override
   public Map<String, Object> getConfiguration() {
     return new HashMap<>(this.configuration);
+  }
+
+  protected void setConfiguration(Map<String, Object> configuration) {
+    this.configuration = configuration;
   }
 }

--- a/metron-platform/metron-pcap/src/test/java/org/apache/metron/pcap/mr/PcapJobTest.java
+++ b/metron-platform/metron-pcap/src/test/java/org/apache/metron/pcap/mr/PcapJobTest.java
@@ -21,6 +21,9 @@ package org.apache.metron.pcap.mr;
 import static java.lang.Long.toUnsignedString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -285,6 +288,22 @@ public class PcapJobTest {
     Assert.assertThat(status.getState(), equalTo(State.SUCCEEDED));
     Assert.assertThat(status.getPercentComplete(), equalTo(100.0));
     Assert.assertThat(status.getJobId(), equalTo(jobIdVal));
+  }
+
+  @Test
+  public void get_should_print_status() throws Exception {
+    Map<String, Object> configuration = new HashMap<>();
+    testJob.setConfiguration(configuration);
+    testJob.setMrJob(mrJob);
+    testJob.setJobStatus(new JobStatus().withState(State.SUCCEEDED));
+
+    testJob.get();
+    verify(mrJob, times(0)).monitorAndPrintJob();
+
+    PcapOptions.PRINT_JOB_STATUS.put(configuration, true);
+    testJob.get();
+    verify(mrJob, times(1)).monitorAndPrintJob();
+    verifyNoMoreInteractions(mrJob);
   }
 
 }


### PR DESCRIPTION
## Contributor Comments
This is a regression in the feature branch introduced by https://github.com/apache/metron/pull/1138.  The default behavior of PcapJob is that it should not print status by default and not fail when that setting is missing.  

### Changed Included

- Changed the default behavior of the Pcap CLI to print status by default
- Removed the print status flag from the CLI
- Fixed bug in getting print status option in PcapJob
- Added getter/setting methods to PcapJob for testing purposes
- Added test cases

### Testing
Still testing in full dev.

- You should get result in the Pcap UI now
- The print status option in the CLI should be missing
- The CLI should print status every time

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
