### PR TITLE
METRON-1738: Pcap directories should have correct permissions

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/params_linux.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/params_linux.py
@@ -392,6 +392,7 @@ pcap_final_output_path = config['configurations']['metron-rest-env']['pcap_final
 pcap_page_size = config['configurations']['metron-rest-env']['pcap_page_size']
 pcap_yarn_queue = config['configurations']['metron-rest-env']['pcap_yarn_queue']
 pcap_configured_flag_file = status_params.pcap_configured_flag_file
+pcap_perm_configured_flag_file = status_params.pcap_perm_configured_flag_file
 
 # MapReduce
 metron_user_hdfs_dir = '/user/' + metron_user

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/status_params.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/status_params.py
@@ -120,6 +120,7 @@ metron_keytab_path = config['configurations']['metron-env']['metron_service_keyt
 
 # Pcap
 pcap_configured_flag_file = metron_zookeeper_config_path + '/../metron_pcap_configured'
+pcap_perm_configured_flag_file = metron_zookeeper_config_path + '/../metron_pcap_perm_configured'
 
 # MapReduce
 metron_user_hdfs_dir_configured_flag_file = metron_zookeeper_config_path + '/../metron_user_hdfs_dir_configured'

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/rest_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/rest_commands.py
@@ -118,26 +118,29 @@ class RestCommands:
 
     def init_pcap(self):
         Logger.info("Creating HDFS locations for Pcap")
+        # Non Kerberized Metron runs under 'storm', requiring write under the 'hadoop' group.
+        # Kerberized Metron runs under it's own user.
+        ownership = 0755 if self.__params.security_enabled else 0775
         self.__params.HdfsResource(self.__params.pcap_base_path,
                                    type="directory",
                                    action="create_on_execute",
                                    owner=self.__params.metron_user,
-                                   group=self.__params.metron_group,
-                                   mode=0755,
+                                   group=self.__params.hadoop_group,
+                                   mode=ownership,
                                    )
         self.__params.HdfsResource(self.__params.pcap_base_interim_result_path,
                                    type="directory",
                                    action="create_on_execute",
                                    owner=self.__params.metron_user,
-                                   group=self.__params.metron_group,
-                                   mode=0755,
+                                   group=self.__params.hadoop_group,
+                                   mode=ownership,
                                    )
         self.__params.HdfsResource(self.__params.pcap_final_output_path,
                                    type="directory",
                                    action="create_on_execute",
                                    owner=self.__params.metron_user,
-                                   group=self.__params.metron_group,
-                                   mode=0755,
+                                   group=self.__params.hadoop_group,
+                                   mode=ownership,
                                    )
 
     def create_metron_user_hdfs_dir(self):

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/rest_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/rest_commands.py
@@ -38,6 +38,7 @@ class RestCommands:
     __hbase_configured = False
     __hbase_acl_configured = False
     __pcap_configured = False
+    __pcap_perm_configured = False
     __metron_user_hdfs_dir_configured = False
 
     def __init__(self, params):
@@ -49,6 +50,7 @@ class RestCommands:
         self.__hbase_configured = os.path.isfile(self.__params.rest_hbase_configured_flag_file)
         self.__hbase_acl_configured = os.path.isfile(self.__params.rest_hbase_acl_configured_flag_file)
         self.__pcap_configured = os.path.isfile(self.__params.pcap_configured_flag_file)
+        self.__pcap_perm_configured = os.path.isfile(self.__params.pcap_perm_configured_flag_file)
         self.__metron_user_hdfs_dir_configured = os.path.isfile(self.__params.metron_user_hdfs_dir_configured_flag_file)
         Directory(params.metron_rest_pid_dir,
                   mode=0755,
@@ -81,6 +83,9 @@ class RestCommands:
     def is_pcap_configured(self):
         return self.__pcap_configured
 
+    def is_pcap_perm_configured(self):
+        return self.__pcap_perm_configured
+
     def is_metron_user_hdfs_dir_configured(self):
         return self.__metron_user_hdfs_dir_configured
 
@@ -98,6 +103,9 @@ class RestCommands:
 
     def set_pcap_configured(self):
         metron_service.set_configured(self.__params.metron_user, self.__params.pcap_configured_flag_file, "Setting Pcap configured to True")
+
+    def set_pcap_perm_configured(self):
+        metron_service.set_configured(self.__params.metron_user, self.__params.pcap_perm_configured_flag_file, "Setting Pcap perm configured to True")
 
     def set_metron_user_hdfs_dir_configured(self):
         metron_service.set_configured(self.__params.metron_user, self.__params.metron_user_hdfs_dir_configured_flag_file, "Setting Metron user HDFS directory configured to True")

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/rest_master.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/rest_master.py
@@ -60,6 +60,11 @@ class RestMaster(Script):
         if params.security_enabled and not commands.is_kafka_acl_configured():
             commands.init_kafka_acls()
             commands.set_kafka_acl_configured()
+        if params.security_enabled and not commands.is_pcap_perm_configured():
+            # If we Kerberize the cluster, we need to call this again, to remove write perms from hadoop group
+            # If we start off Kerberized, it just does the same thing twice.
+            commands.init_pcap()
+            commands.set_pcap_perm_configured()
 
     def start(self, env, upgrade_type=None):
         from params import params


### PR DESCRIPTION
## Contributor Comments
This PR corrects the Pcap HDFS directory permissions.  When a cluster is not Kerberized, the Pcap topology runs as the Storm user.  In this case the Pcap directories should have write permission for the `hadoop` group.  When a cluster is Kerberized, the directories should have write permission for the `metron` user.

This PR duplicates the effort in https://github.com/apache/metron/pull/1134 and borrows code from there.  The difference is that the changes were applied to the Ambari REST component instead.  Credit for this should be given to @MohanDV.

I have not tested this in full dev yet.  To test in full dev, follow the steps for running the pcap topology and generating pcap data with pycapa.  Data should be written to the input directory without error.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
