### PR TITLE
METRON-1751 Storm Profiler dies when consuming null message

### DIFF
--- a/metron-analytics/metron-profiler/src/main/java/org/apache/metron/profiler/bolt/ProfileSplitterBolt.java
+++ b/metron-analytics/metron-profiler/src/main/java/org/apache/metron/profiler/bolt/ProfileSplitterBolt.java
@@ -144,9 +144,9 @@ public class ProfileSplitterBolt extends ConfiguredProfilerBolt {
     try {
       doExecute(input);
 
-    } catch (IllegalArgumentException | ParseException | UnsupportedEncodingException e) {
-      LOG.error("Unexpected error", e);
-      collector.reportError(e);
+    } catch (Throwable t) {
+      LOG.error("Unexpected error", t);
+      collector.reportError(t);
 
     } finally {
       collector.ack(input);
@@ -157,22 +157,25 @@ public class ProfileSplitterBolt extends ConfiguredProfilerBolt {
 
     // retrieve the input message
     byte[] data = input.getBinary(0);
+    if(data == null) {
+      LOG.debug("Received null message. Nothing to do.");
+      return;
+    }
     JSONObject message = (JSONObject) parser.parse(new String(data, "UTF8"));
 
     // ensure there is a valid profiler configuration
     ProfilerConfig config = getProfilerConfig();
-    if(config != null && config.getProfiles().size() > 0) {
-
-      // what time is it?
-      Clock clock = clockFactory.createClock(config);
-      Optional<Long> timestamp = clock.currentTimeMillis(message);
-
-      // route the message.  if a message does not contain the timestamp field, it cannot be routed.
-      timestamp.ifPresent(ts -> routeMessage(input, message, config, ts));
-
-    } else {
-      LOG.debug("No Profiler configuration found.  Nothing to do.");
+    if(config == null || getProfilerConfig().getProfiles().size() == 0) {
+      LOG.debug("No Profiler configuration found. Nothing to do.");
+      return;
     }
+
+    // what time is it?
+    Clock clock = clockFactory.createClock(config);
+    Optional<Long> timestamp = clock.currentTimeMillis(message);
+
+    // route the message.  if a message does not contain the timestamp field, it cannot be routed.
+    timestamp.ifPresent(ts -> routeMessage(input, message, config, ts));
   }
 
   /**

--- a/metron-analytics/metron-profiler/src/test/java/org/apache/metron/profiler/bolt/ProfileSplitterBoltTest.java
+++ b/metron-analytics/metron-profiler/src/test/java/org/apache/metron/profiler/bolt/ProfileSplitterBoltTest.java
@@ -404,6 +404,22 @@ public class ProfileSplitterBoltTest extends BaseBoltTest {
             .emit(any(Values.class));
   }
 
+  @Test
+  public void testWithNullMessage() throws Exception {
+
+    // ensure the tuple returns null to mimic a null message in kafka
+    when(tuple.getBinary(0)).thenReturn(null);
+
+    ProfilerConfig config = toProfilerConfig(profileWithOnlyIfInvalid);
+    ProfileSplitterBolt bolt = createBolt(config);
+    bolt.execute(tuple);
+
+    // a tuple should NOT be emitted for the downstream profile builder
+    verify(outputCollector, times(0))
+            .emit(any(Values.class));
+
+  }
+
   /**
    * Creates a ProfilerConfig based on a string containing JSON.
    *


### PR DESCRIPTION
The Storm Profiler dies if a null message is consumed from the input Kafka topic.  The Profiler should skip past any null messages and continue processing.

## Testing

1. Create a "hello-world" profile using the Storm Profiler as outlined in the README.

1. Push a null message on to the "indexing" Kafka topic.

1. Make sure the Storm topology does not die and that a profile measurement is flushed.

## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

