### PR TITLE
METRON-1757 Storm Profiler Serialization Exception

### DIFF
--- a/metron-analytics/metron-profiler-common/pom.xml
+++ b/metron-analytics/metron-profiler-common/pom.xml
@@ -109,26 +109,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.storm</groupId>
-            <artifactId>storm-core</artifactId>
-            <version>${global_storm_version}</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>log4j-slf4j-impl</artifactId>
-                    <groupId>org.apache.logging.log4j</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>${global_mockito_version}</version>

--- a/metron-analytics/metron-profiler-common/pom.xml
+++ b/metron-analytics/metron-profiler-common/pom.xml
@@ -55,6 +55,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>asm</groupId>
+                    <artifactId>asm</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/ProfileMeasurement.java
+++ b/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/ProfileMeasurement.java
@@ -20,6 +20,8 @@
 
 package org.apache.metron.profiler;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.metron.common.configuration.profiler.ProfileConfig;
 
 import java.io.Serializable;
@@ -173,5 +175,38 @@ public class ProfileMeasurement implements Serializable {
 
   public void setTriageValues(Map<String, Object> triageValues) {
     this.triageValues = triageValues;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ProfileMeasurement that = (ProfileMeasurement) o;
+    return new EqualsBuilder()
+            .append(profileName, that.profileName)
+            .append(entity, that.entity)
+            .append(groups, that.groups)
+            .append(period, that.period)
+            .append(definition, that.definition)
+            .append(profileValue, that.profileValue)
+            .append(triageValues, that.triageValues)
+            .isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37)
+            .append(profileName)
+            .append(entity)
+            .append(groups)
+            .append(period)
+            .append(definition)
+            .append(profileValue)
+            .append(triageValues)
+            .toHashCode();
   }
 }

--- a/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/ProfilePeriod.java
+++ b/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/ProfilePeriod.java
@@ -47,6 +47,9 @@ public class ProfilePeriod implements Serializable {
    */
   private long durationMillis;
 
+  public ProfilePeriod() {
+    // no-arg constructor required for kryo serialization in storm
+  }
 
   /**
    * @param epochMillis A timestamp contained somewhere within the profile period.

--- a/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/ProfileMeasurementTest.java
+++ b/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/ProfileMeasurementTest.java
@@ -23,6 +23,7 @@ package org.apache.metron.profiler;
 import org.adrianwalker.multilinestring.Multiline;
 import org.apache.metron.common.configuration.profiler.ProfileConfig;
 import org.apache.metron.common.utils.SerDeUtils;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -33,6 +34,7 @@ import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class ProfileMeasurementTest {
@@ -56,9 +58,9 @@ public class ProfileMeasurementTest {
   private ProfileConfig definition;
   private ProfileMeasurement measurement;
 
+  @Before
   public void setup() throws Exception {
     definition = ProfileConfig.fromJSON(profile);
-
     measurement = new ProfileMeasurement()
             .withProfileName("profile")
             .withEntity("entity")
@@ -74,6 +76,7 @@ public class ProfileMeasurementTest {
    */
   @Test
   public void testKryoSerialization() throws Exception {
+    assertNotNull(measurement);
 
     // round-trip serialization
     byte[] raw = SerDeUtils.toBytes(measurement);
@@ -88,6 +91,7 @@ public class ProfileMeasurementTest {
    */
   @Test
   public void testJavaSerialization() throws Exception {
+    assertNotNull(measurement);
 
     // serialize using java
     ByteArrayOutputStream bytes = new ByteArrayOutputStream();

--- a/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/ProfileMeasurementTest.java
+++ b/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/ProfileMeasurementTest.java
@@ -20,6 +20,9 @@
 
 package org.apache.metron.profiler;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import org.adrianwalker.multilinestring.Multiline;
 import org.apache.metron.common.configuration.profiler.ProfileConfig;
 import org.apache.metron.common.utils.SerDeUtils;
@@ -77,10 +80,23 @@ public class ProfileMeasurementTest {
   @Test
   public void testKryoSerialization() throws Exception {
     assertNotNull(measurement);
+    Kryo kryo = new Kryo();
 
-    // round-trip serialization
-    byte[] raw = SerDeUtils.toBytes(measurement);
-    Object actual = SerDeUtils.fromBytes(raw, Object.class);
+    // serialize
+    ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+    Output output = new Output(byteStream);
+    kryo.writeObject(output, measurement);
+
+    // validate serialization
+    byte[] bits = output.toBytes();
+    assertNotNull(bits);
+
+    // deserialize
+    Input input = new Input(new ByteArrayInputStream(bits));
+    ProfileMeasurement actual = kryo.readObject(input, ProfileMeasurement.class);
+
+    // validate deserialization
+    assertNotNull(actual);
     assertEquals(measurement, actual);
   }
 

--- a/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/ProfilePeriodTest.java
+++ b/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/ProfilePeriodTest.java
@@ -20,6 +20,9 @@
 
 package org.apache.metron.profiler;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import org.apache.metron.common.utils.SerDeUtils;
 import org.junit.Test;
 
@@ -31,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -137,13 +141,24 @@ public class ProfilePeriodTest {
    */
   @Test
   public void testKryoSerialization() throws Exception {
-
     ProfilePeriod expected = new ProfilePeriod(AUG2016, 1, TimeUnit.HOURS);
+    Kryo kryo = new Kryo();
 
-    // round-trip java serialization
-    byte[] raw = SerDeUtils.toBytes(expected);
-    Object actual = SerDeUtils.fromBytes(raw, Object.class);
+    // serialize
+    ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+    Output output = new Output(byteStream);
+    kryo.writeObject(output, expected);
 
+    // validate serialization
+    byte[] bits = output.toBytes();
+    assertNotNull(bits);
+
+    // deserialize
+    Input input = new Input(new ByteArrayInputStream(bits));
+    ProfileMeasurement actual = kryo.readObject(input, ProfileMeasurement.class);
+
+    // validate deserialization
+    assertNotNull(actual);
     assertEquals(expected, actual);
   }
 

--- a/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/ProfilePeriodTest.java
+++ b/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/ProfilePeriodTest.java
@@ -155,7 +155,7 @@ public class ProfilePeriodTest {
 
     // deserialize
     Input input = new Input(new ByteArrayInputStream(bits));
-    ProfileMeasurement actual = kryo.readObject(input, ProfileMeasurement.class);
+    ProfilePeriod actual = kryo.readObject(input, ProfilePeriod.class);
 
     // validate deserialization
     assertNotNull(actual);

--- a/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/hbase/SaltyRowKeyBuilderTest.java
+++ b/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/hbase/SaltyRowKeyBuilderTest.java
@@ -20,11 +20,8 @@
 
 package org.apache.metron.profiler.hbase;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.storm.tuple.Tuple;
 import org.apache.metron.profiler.ProfileMeasurement;
 import org.apache.metron.profiler.ProfilePeriod;
-import org.apache.metron.profiler.hbase.SaltyRowKeyBuilder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,9 +36,6 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests the SaltyRowKeyBuilder.
@@ -54,7 +48,6 @@ public class SaltyRowKeyBuilderTest {
 
   private SaltyRowKeyBuilder rowKeyBuilder;
   private ProfileMeasurement measurement;
-  private Tuple tuple;
 
   /**
    * Thu, Aug 25 2016 13:27:10 GMT
@@ -69,10 +62,6 @@ public class SaltyRowKeyBuilderTest {
             .withProfileName("profile")
             .withEntity("entity")
             .withPeriod(AUG2016, periodDuration, periodUnits);
-
-    // the tuple will contain the original message
-    tuple = mock(Tuple.class);
-    when(tuple.getValueByField(eq("measurement"))).thenReturn(measurement);
 
     rowKeyBuilder = new SaltyRowKeyBuilder(saltDivisor, periodDuration, periodUnits);
   }

--- a/metron-analytics/metron-profiler/README.md
+++ b/metron-analytics/metron-profiler/README.md
@@ -221,9 +221,10 @@ This section will describe the steps required to get your first "Hello, World!""
 
 Continuing the previous running example, at this point, you have seen how your profile behaves against real, live telemetry in a controlled execution environment.  The next step is to deploy your profile to the live, actively running Profiler topology.
 
-1.  Start the Stellar Shell with the `-z ZK:2181` command line argument.  This is required when deploying a new profile to the active Profiler topology.  Replace `ZK:2181` with a URL that is appropriate to your environment.
+1.  Start the Stellar Shell with the `-z` command line argument so that a connection to Zookeeper is established.  This is required when  deploying a new profile definition as shown in the steps below.
 	```
-	[root@node1 ~]# $METRON_HOME/bin/stellar -z ZK:2181
+  [root@node1 ~]# source /etc/default/metron
+	[root@node1 ~]# $METRON_HOME/bin/stellar -z $ZOOKEEPER
 	Stellar, Go!
 	[Stellar]>>>
 	[Stellar]>>> %functions CONFIG CONFIG_GET, CONFIG_PUT
@@ -280,16 +281,17 @@ Continuing the previous running example, at this point, you have seen how your p
     }
     ```
 
-1. Upload the profile definition to Zookeeper.  Change `node1:2181` to refer the actual Zookeeper host in your environment.
+1. Upload the profile definition to Zookeeper.
 
     ```
+    $ source /etc/default/metron
     $ cd $METRON_HOME
-    $ bin/zk_load_configs.sh -m PUSH -i config/zookeeper/ -z node1:2181
+    $ bin/zk_load_configs.sh -m PUSH -i config/zookeeper/ -z $ZOOKEEPER
     ```
 
     You can validate this by reading back the Metron configuration from Zookeeper using the same script. The result should look-like the following.
     ```
-    $ bin/zk_load_configs.sh -m DUMP -z node1:2181
+    $ bin/zk_load_configs.sh -m DUMP -z $ZOOKEEPER
     ...
     PROFILER Config: profiler
     {
@@ -317,7 +319,8 @@ Continuing the previous running example, at this point, you have seen how your p
 1. Use the [Profiler Client](../metron-profiler-client) to read the profile data.  The following `PROFILE_GET` command will read the data written by the `hello-world` profile. This assumes that `10.0.0.1` is one of the values for `ip_src_addr` contained within the telemetry consumed by the Profiler.
 
     ```
-    $ bin/stellar -z node1:2181
+    $ source /etc/default/metron
+    $ bin/stellar -z $ZOOKEEPER
     [Stellar]>>> PROFILE_GET( "hello-world", "10.0.0.1", PROFILE_FIXED(30, "MINUTES"))
     [451, 448]
     ```
@@ -827,7 +830,8 @@ It is assumed that the PROFILE_GET client is configured as described [here](../m
 
 Retrieve the last 30 minutes of profile measurements for a specific host.
 ```
-$ bin/stellar -z node1:2181
+$ source /etc/default/metron
+$ bin/stellar -z $ZOOKEEPER
 
 [Stellar]>>> stats := PROFILE_GET( "example4", "10.0.0.1", PROFILE_FIXED(30, "MINUTES"))
 [Stellar]>>> stats

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/profiler/ProfileResult.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/profiler/ProfileResult.java
@@ -43,7 +43,7 @@ public class ProfileResult implements Serializable {
   private ProfileTriageExpressions triageExpressions;
 
   public ProfileResult() {
-    // no-arg constructor required for kryo serialization
+    // no-arg constructor required for kryo serialization in storm
   }
 
   @JsonCreator

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/profiler/ProfileResult.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/profiler/ProfileResult.java
@@ -43,7 +43,7 @@ public class ProfileResult implements Serializable {
   private ProfileTriageExpressions triageExpressions;
 
   public ProfileResult() {
-    // default constructor required for kryo serialization
+    // no-arg constructor required for kryo serialization
   }
 
   @JsonCreator

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/profiler/ProfileResult.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/profiler/ProfileResult.java
@@ -42,6 +42,10 @@ public class ProfileResult implements Serializable {
   @JsonProperty("triage")
   private ProfileTriageExpressions triageExpressions;
 
+  public ProfileResult() {
+    // default constructor required for kryo serialization
+  }
+
   @JsonCreator
   public ProfileResult(
           @JsonProperty(value = "profile", required = true) ProfileResultExpressions profileExpressions,

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/profiler/ProfileResultExpressions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/profiler/ProfileResultExpressions.java
@@ -31,7 +31,7 @@ public class ProfileResultExpressions implements Serializable {
   private String expression;
 
   public ProfileResultExpressions() {
-    // default constructor required for kryo serialization
+    // no-arg constructor required for kryo serialization
   }
 
   @JsonCreator

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/profiler/ProfileResultExpressions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/profiler/ProfileResultExpressions.java
@@ -31,7 +31,7 @@ public class ProfileResultExpressions implements Serializable {
   private String expression;
 
   public ProfileResultExpressions() {
-    // no-arg constructor required for kryo serialization
+    // no-arg constructor required for kryo serialization in storm
   }
 
   @JsonCreator

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/profiler/ProfileResultExpressions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/profiler/ProfileResultExpressions.java
@@ -30,6 +30,10 @@ public class ProfileResultExpressions implements Serializable {
 
   private String expression;
 
+  public ProfileResultExpressions() {
+    // default constructor required for kryo serialization
+  }
+
   @JsonCreator
   public ProfileResultExpressions(String expression) {
     this.expression = expression;

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/configuration/profiler/ProfilerConfigTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/configuration/profiler/ProfilerConfigTest.java
@@ -19,18 +19,22 @@
  */
 package org.apache.metron.common.configuration.profiler;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import org.adrianwalker.multilinestring.Multiline;
+import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import org.adrianwalker.multilinestring.Multiline;
-import org.apache.metron.common.utils.SerDeUtils;
-import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests the {@link ProfilerConfig} class.
@@ -252,11 +256,24 @@ public class ProfilerConfigTest {
 
     // setup a profiler config to serialize
     ProfilerConfig expected = ProfilerConfig.fromJSON(profilesToSerialize);
+    assertNotNull(expected);
+    Kryo kryo = new Kryo();
 
-    // round-trip java serialization
-    byte[] raw = SerDeUtils.toBytes(expected);
-    Object actual = SerDeUtils.fromBytes(raw, Object.class);
+    // serialize
+    ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+    Output output = new Output(byteStream);
+    kryo.writeObject(output, expected);
 
+    // validate serialization
+    byte[] bits = output.toBytes();
+    assertNotNull(bits);
+
+    // deserialize
+    Input input = new Input(new ByteArrayInputStream(bits));
+    ProfilerConfig actual = kryo.readObject(input, ProfilerConfig.class);
+
+    // validate deserialization
+    assertNotNull(actual);
     assertEquals(expected, actual);
   }
 


### PR DESCRIPTION
### Description

* When using Kryo serialization, specifically in Storm, the class being serialized must have a no-arg constructor.

* The existing unit tests that validated Kryo serialization for the Profiler classes (that I added for #1012 ) use the `SerDeUtils` class to test Kryo serialization.  I found that this class sets up Kryo in a slightly different way from how Storm does internally.  This is one reason why the tests did not catch the missing no-arg constructor.

* The `ProfileMeasurementTest`'s setup method was missing the `@Before` annotation so it was never called.  This caused the test to validate serialization of a null, rather than an actual object.  Doh!

* Removed the 'asm' dependency from 'metron-profiler-common'.  Conflicting version of this library was causing issues with the Kryo serialization tests (once they actually tested serializing something other than nulls).  There should now be no dependency on Storm from `metron-profiler-common`, which is how it should be.

* The unit tests now catch this bug and highlighted a few other classes that needed a no-arg constructor. 

* The only piece left wanting is that I'd like to have seen the integration tests fail if Kryo serialization fails.  That was the original intent of using `topology.testing.always.try.serialize=true` for the integration test.  But that only seems to catch Java serialization problems, not Kryo for some reason.

* This serialization error will never show itself if you are running with a single worker as there is no need for Storm to serialize.  Even running the Profiler in a cluster on multiple workers, it will only show-up if Storm runs the `ProfileBuilderBolt` and the downstream bolts (`HBaseBolt` or `KafkaBolt`) on a separate worker.  This is why you may not always see the problem when running on a cluster (and why it was confusing to track down.)

### Work Around

If you are experiencing this issue, you can work around the problem by changing the following values in your `profiler.properties`.  This will cause Storm to fall-back to Java serialization when Kryo serialization fails in Storm for `org.apache.metron.common.configuration.profiler.ProfileResult`.

```
topology.fall.back.on.java.serialization=true
topology.kryo.register=[ org.apache.metron.profiler.ProfileMeasurement, \
    org.apache.metron.profiler.ProfilePeriod, \
    org.apache.metron.common.configuration.profiler.ProfileResultExpressions, \
    org.apache.metron.common.configuration.profiler.ProfileTriageExpressions, \
    org.apache.metron.common.configuration.profiler.ProfilerConfig, \
    org.apache.metron.common.configuration.profiler.ProfileConfig, \
    org.json.simple.JSONObject, \
    org.json.simple.JSONArray, \
    java.util.LinkedHashMap, \
    org.apache.metron.statistics.OnlineStatisticsProvider ]
```

### Testing

1. Spin-up Full Dev

1. Create  a profile by following the Profiler README as a guide.

1. Spin-up this change on a multi-node cluster.  Run the profiler with multiple workers.  Create the same profile as before and ensure that values can be persisted in HBase.

## Pull Request Checklist
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

