### PR TITLE
METRON-1508 In Ubuntu14 Dev Indexing Fails to Write to Elasticsearch

### DIFF
--- a/metron-deployment/ansible/roles/ambari_config/vars/single_node_vm.yml
+++ b/metron-deployment/ansible/roles/ambari_config/vars/single_node_vm.yml
@@ -91,7 +91,7 @@ configurations:
       # Storm expects ambari metrics to be available in 2.6.  We do *not* install ambari metrics in full-dev, so we need to revert to the old consumer
       storm.cluster.metrics.consumer.register: '[{"class": "org.apache.storm.metric.LoggingMetricsConsumer"}]'
       topology.metrics.consumer.register: '[{"class": "org.apache.storm.metric.LoggingMetricsConsumer", "parallelism.hint": 1, "whitelist": ["kafkaOffset\\..+/", "__complete-latency", "__process-latency", "__receive\\.population$", "__sendqueue\\.population$", "__execute-count", "__emit-count", "__ack-count", "__fail-count", "memory/heap\\.usedBytes$", "memory/nonHeap\\.usedBytes$", "GC/.+\\.count$", "GC/.+\\.timeMs$"]}]'
-      # Storm expects ambari metrics to be available in 2.6 and ambari metrics pulls data via JMX, but since we don't use ambari metrics here, we don't have the javaagent around to use and thus that must be removed from nimbus, supervisor and worker properties 
+      # Storm expects ambari metrics to be available in 2.6 and ambari metrics pulls data via JMX, but since we don't use ambari metrics here, we don't have the javaagent around to use and thus that must be removed from nimbus, supervisor and worker properties
       nimbus.childopts: '-Xmx1024m _JAAS_PLACEHOLDER'
       supervisor.childopts: '-Xmx256m _JAAS_PLACEHOLDER'
       worker.childopts: "-Xmx768m _JAAS_PLACEHOLDER"
@@ -116,7 +116,7 @@ configurations:
 required_configurations:
   - metron-env:
       storm_rest_addr: "http://{{ groups.ambari_slave[0] }}:8744"
-      es_hosts: "{{ groups.search | join(',') }}"
+      es_hosts: "{{ elasticsearch_hosts }}"
       zeppelin_server_url: "{{ groups.zeppelin[0] }}:9995"
       solr_zookeeper_url: "{{ groups.search[0] }}:9983"
   - metron-rest-env:

--- a/metron-deployment/development/centos6/ansible/inventory/group_vars/all
+++ b/metron-deployment/development/centos6/ansible/inventory/group_vars/all
@@ -46,6 +46,7 @@ pycapa_home: "/opt/pycapa"
 snort_version: "2.9.8.0-1"
 snort_alert_csv_path: "/var/log/snort/alert.csv"
 threat_intel_bulk_load: False
+elasticsearch_hosts: "{{ groups.search | join(',') }}"
 
 # data directories - only required to override defaults
 zookeeper_data_dir: "/data1/hadoop/zookeeper"

--- a/metron-deployment/development/ubuntu14/ansible/inventory/group_vars/all
+++ b/metron-deployment/development/ubuntu14/ansible/inventory/group_vars/all
@@ -46,6 +46,7 @@ pycapa_home: "/opt/pycapa"
 snort_version: "2.9.8.0-1"
 snort_alert_csv_path: "/var/log/snort/alert.csv"
 threat_intel_bulk_load: False
+elasticsearch_hosts: "localhost"
 
 # data directories - only required to override defaults
 zookeeper_data_dir: "/data1/hadoop/zookeeper"

--- a/metron-deployment/packaging/ambari/elasticsearch-mpack/src/main/resources/common-services/ELASTICSEARCH/5.6.2/configuration/elastic-site.xml
+++ b/metron-deployment/packaging/ambari/elasticsearch-mpack/src/main/resources/common-services/ELASTICSEARCH/5.6.2/configuration/elastic-site.xml
@@ -111,7 +111,7 @@
         <value>0</value>
         <description>expected_data_nodes</description>
     </property>
-    <!--  Index -->  
+    <!--  Index -->
     <property>
         <name>index_merge_scheduler_max_thread_count</name>
         <value>5</value>
@@ -171,7 +171,7 @@
         <name>cluster_routing_allocation_disk_threshold_enabled</name>
         <value>true</value>
         <description>Property used when multiple drives are used to understand if thresholding is active</description>
-    </property>   
+    </property>
    <property>
         <name>cluster_routing_allocation_disk_watermark_low</name>
         <value>.97</value>
@@ -185,7 +185,7 @@
     <property>
         <name>network_host</name>
         <value>[ _local_, _site_ ]</value>
-        <description>Network interface(s) ES will bind to within each node. "_site_" or a more specific external address is required for all multi-node clusters, and also recommended for single-node installs to allow access to ES reports from non-local hosts. Always include the square brackets. See https://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-network.html for ES documentation.</description>
+        <description>Network interface(s) ES will bind to within each node. "_site_" or a more specific external address is required for all multi-node clusters, and also recommended for single-node installs to allow access to ES reports from non-local hosts. Always include the square brackets. See https://www.elastic.co/guide/en/elasticsearch/reference/5.6/modules-network.html for ES documentation.</description>
     </property>
     <property>
         <name>network_publish_host</name>
@@ -193,6 +193,6 @@
         <value-attributes>
             <empty-value-valid>true</empty-value-valid>
         </value-attributes>
-        <description>Network address ES will publish for client and peer use. Empty value causes it to pick from the values in network_host, which works in most simple environments. MUST set explicitly for MULTI-HOMED SYSTEMS. See https://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-network.html for ES documentation.</description>
+        <description>Network address ES will publish for client and peer use. Empty value causes it to pick from the values in network_host, which works in most simple environments. MUST set explicitly for MULTI-HOMED SYSTEMS. See https://www.elastic.co/guide/en/elasticsearch/reference/5.6/modules-network.html for ES documentation.</description>
     </property>
 </configuration>


### PR DESCRIPTION
### The Problem

When spinning up the Ubuntu 14 development environment, the indexing topology fails to write to Elasticsearch.  The indexing topology reports the following error.

```
2018-04-04 15:51:05.707 o.a.s.d.executor Thread-6-indexingBolt-executor[3 3] [ERROR] 
org.elasticsearch.client.transport.NoNodeAvailableException: None of the configured nodes are available: [{#transport#-1}{rZcTXccfSPq4fH4IRLQ0zg}{node1}{127.0.1.1:9300}]
	at org.elasticsearch.client.transport.TransportClientNodesService.ensureNodesAreAvailable(TransportClientNodesService.java:347) ~[stormjar.jar:?]
	at org.elasticsearch.client.transport.TransportClientNodesService.execute(TransportClientNodesService.java:245) ~[stormjar.jar:?]
	at org.elasticsearch.client.transport.TransportProxyClient.execute(TransportProxyClient.java:59) ~[stormjar.jar:?]
	at org.elasticsearch.client.transport.TransportClient.doExecute(TransportClient.java:363) ~[stormjar.jar:?]
	at org.elasticsearch.client.support.AbstractClient.execute(AbstractClient.java:408) ~[stormjar.jar:?]
	at org.elasticsearch.action.ActionRequestBuilder.execute(ActionRequestBuilder.java:80) ~[stormjar.jar:?]
	at org.elasticsearch.action.ActionRequestBuilder.execute(ActionRequestBuilder.java:54) ~[stormjar.jar:?]
	at org.apache.metron.elasticsearch.writer.ElasticsearchWriter.write(ElasticsearchWriter.java:92) ~[stormjar.jar:?]
	at org.apache.metron.writer.BulkWriterComponent.flush(BulkWriterComponent.java:239) [stormjar.jar:?]
	at org.apache.metron.writer.BulkWriterComponent.write(BulkWriterComponent.java:217) [stormjar.jar:?]
	at org.apache.metron.writer.bolt.BulkMessageWriterBolt.execute(BulkMessageWriterBolt.java:236) [stormjar.jar:?]
	at org.apache.storm.daemon.executor$fn__7590$tuple_action_fn__7592.invoke(executor.clj:730) [storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
	at org.apache.storm.daemon.executor$mk_task_receiver$fn__7511.invoke(executor.clj:462) [storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
	at org.apache.storm.disruptor$clojure_handler$reify__7166.onEvent(disruptor.clj:40) [storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
	at org.apache.storm.utils.DisruptorQueue.consumeBatchToCursor(DisruptorQueue.java:472) [storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
	at org.apache.storm.utils.DisruptorQueue.consumeBatchWhenAvailable(DisruptorQueue.java:451) [storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
	at org.apache.storm.disruptor$consume_batch_when_available.invoke(disruptor.clj:73) [storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
	at org.apache.storm.daemon.executor$fn__7590$fn__7603$fn__7656.invoke(executor.clj:849) [storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
	at org.apache.storm.util$async_loop$fn__553.invoke(util.clj:484) [storm-core-1.1.0.2.6.4.0-91.jar:1.1.0.2.6.4.0-91]
	at clojure.lang.AFn.run(AFn.java:22) [clojure-1.7.0.jar:?]
	at java.lang.Thread.run(Thread.java:745) [?:1.8.0_112]
```

### Why?

In Ubuntu, Elasticsearch is not setup to bind to `node1:9300`. When the index topology spins-up and attempts to connect, it fails with this exception.  Simply binding to `localhost:9300` fixes this problem in the Ubuntu development environment.

### The Fix

I extracted the `es_hosts` variable from `single_node_vm.yml` in a way that allows each development environment (Ubuntu and CentOS) to define this value independently.  This allows CentOS to continue to use `node1:9300` as it always has and Ubuntu can use `localhost:9300` as it needs to.

This change only impacts the way the development environments are deployed.  This does not impact any of the production deployment tooling.

### Testing

#### Test with CentOS 

1. Spin-up the CentOS development environment.  
   ```
    cd metron-deployment/development/centos6
    vagrant up
    ```
 1. The value of Metron > Index Settings > Elasticsearch Hosts should be "node1".
 1. Alerts should be visible within the Alerts UI.
 1. Run the service check in Ambari (Metron > Service Actions > Run Service Check).

#### Test with Ubuntu

1. Spin-up the Ubuntu development environment. 
    ```
    cd metron-deployment/development/ubuntu14
    vagrant up
    ```
 1. The value of Metron > Index Settings > Elasticsearch Hosts should be "localhost".
 1. Alerts should be visible within the Alerts UI.
 1. Run the service check in Ambari (Metron > Service Actions > Run Service Check).


## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

