### PR TITLE
METRON-1775 Transient exception could prevent expired profiles from being flushed

### DIFF
--- a/metron-analytics/metron-profiler/src/main/java/org/apache/metron/profiler/bolt/ProfileBuilderBolt.java
+++ b/metron-analytics/metron-profiler/src/main/java/org/apache/metron/profiler/bolt/ProfileBuilderBolt.java
@@ -20,6 +20,7 @@
 
 package org.apache.metron.profiler.bolt;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -372,15 +373,21 @@ public class ProfileBuilderBolt extends BaseWindowedBolt implements Reloadable {
    * that their state is not lost.
    */
   protected void flushExpired() {
+    List<ProfileMeasurement> measurements = null;
+    try {
+      // flush the expired profiles
+      synchronized (messageDistributor) {
+        measurements = messageDistributor.flushExpired();
+        emitMeasurements(measurements);
+      }
 
-    // flush the expired profiles
-    List<ProfileMeasurement> measurements;
-    synchronized (messageDistributor) {
-      measurements = messageDistributor.flushExpired();
-      emitMeasurements(measurements);
+    } catch(Throwable t) {
+      // need to catch the exception, otherwise subsequent executions would be suppressed.
+      // see java.util.concurrent.ScheduledExecutorService#scheduleAtFixedRate
+      LOG.error("Failed to flush expired profiles", t);
     }
 
-    LOG.debug("Flushed expired profiles and found {} measurement(s).", measurements.size());
+    LOG.debug("Flushed expired profiles and found {} measurement(s).", CollectionUtils.size(measurements));
   }
 
   /**

--- a/metron-analytics/metron-profiler/src/main/java/org/apache/metron/profiler/bolt/ProfileBuilderBolt.java
+++ b/metron-analytics/metron-profiler/src/main/java/org/apache/metron/profiler/bolt/ProfileBuilderBolt.java
@@ -362,7 +362,6 @@ public class ProfileBuilderBolt extends BaseWindowedBolt implements Reloadable {
     }
 
     LOG.debug("Flushed active profiles and found {} measurement(s).", measurements.size());
-
   }
 
   /**

--- a/metron-analytics/metron-profiler/src/test/java/org/apache/metron/profiler/bolt/ProfileBuilderBoltTest.java
+++ b/metron-analytics/metron-profiler/src/test/java/org/apache/metron/profiler/bolt/ProfileBuilderBoltTest.java
@@ -263,9 +263,7 @@ public class ProfileBuilderBoltTest extends BaseBoltTest {
     // the bolt will use the bad emitter when flushExpired() is called
     ProfileBuilderBolt bolt = (ProfileBuilderBolt) new ProfileBuilderBolt()
             .withEmitter(badEmitter)
-            .withMessageDistributor(distributor)
-            .withFlushSignal(flushSignal)
-            .withTumblingWindow(new BaseWindowedBolt.Duration(5, TimeUnit.SECONDS));
+            .withMessageDistributor(distributor);
 
     // the exception thrown by the emitter should not bubble up
     bolt.flushExpired();

--- a/metron-analytics/metron-profiler/src/test/java/org/apache/metron/profiler/bolt/ProfileBuilderBoltTest.java
+++ b/metron-analytics/metron-profiler/src/test/java/org/apache/metron/profiler/bolt/ProfileBuilderBoltTest.java
@@ -50,6 +50,7 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -245,6 +246,29 @@ public class ProfileBuilderBoltTest extends BaseBoltTest {
     verify(outputCollector, times(1)).emit(eq("destination1"), any());
     verify(outputCollector, times(1)).emit(eq("destination2"), any());
     verify(outputCollector, times(1)).emit(eq("destination3"), any());
+  }
+
+  @Test
+  public void testExceptionWhenFlushingExpiredProfiles() throws Exception {
+    // create an emitter that will throw an exception when emit() called
+    ProfileMeasurementEmitter badEmitter = mock(ProfileMeasurementEmitter.class);
+    doThrow(new RuntimeException("flushExpired() should catch this exception"))
+            .when(badEmitter)
+            .emit(any(), any());
+
+    // create a distributor that will return a profile measurement
+    MessageDistributor distributor = mock(MessageDistributor.class);
+    when(distributor.flushExpired()).thenReturn(Collections.singletonList(measurement));
+
+    // the bolt will use the bad emitter when flushExpired() is called
+    ProfileBuilderBolt bolt = (ProfileBuilderBolt) new ProfileBuilderBolt()
+            .withEmitter(badEmitter)
+            .withMessageDistributor(distributor)
+            .withFlushSignal(flushSignal)
+            .withTumblingWindow(new BaseWindowedBolt.Duration(5, TimeUnit.SECONDS));
+
+    // the exception thrown by the emitter should not bubble up
+    bolt.flushExpired();
   }
 
   /**


### PR DESCRIPTION
In the Storm Profiler, the ProfileBuilderBolt uses a separate thread to flush expired profiles.  Expired profiles are those that have not received a message for an extended period of time.  That period of time is called the profile time-to-live (profiler.ttl).  This is done to avoid potential memory leaks.

This separate thread is scheduled using `java.util.concurrent.ScheduledExecutorService#scheduleAtFixedRate`.  The documentation for `scheduleAtFixedRate` says that if an exception is thrown, subsequent executions will be suppressed.  We do not want this to happen.  If an exception occurs, we need to log it and continue, ensuring that expired profiles will continue to flush.

I have no direct proof that this has caused a problem, but it certainly is a potential issue that should be addressed.

## Testing

There is not an easy way to manually trigger this in a development environment.  I have added a unit test to exercise the problem.

## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [ ] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
