### PR TITLE
METRON-1777: Fix Elasticsearch X-Pack sample pom in documentation

### DIFF
--- a/metron-deployment/Kerberos-manual-setup.md
+++ b/metron-deployment/Kerberos-manual-setup.md
@@ -650,10 +650,6 @@ X-Pack
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                   </exclusion>
-                  <exclusion> <!-- this is causing a weird build error if not excluded - Error creating shaded jar: null: IllegalArgumentException -->
-                        <groupId>org.apache.logging.log4j</groupId>
-                        <artifactId>log4j-api</artifactId>
-                    </exclusion>
                 </exclusions>
               </dependency>
         </dependencies>
@@ -662,7 +658,7 @@ X-Pack
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>2.4.3</version>
+                    <version>3.2.0</version>
                     <configuration>
                         <createDependencyReducedPom>true</createDependencyReducedPom>
                     </configuration>

--- a/metron-deployment/Kerberos-manual-setup.md
+++ b/metron-deployment/Kerberos-manual-setup.md
@@ -568,7 +568,7 @@ X-Pack
     Add the `es.client.settings` to global.json
 
     ```
-    /usr/metron/0.6.0/config/zookeeper/global.json ->
+    $METRON_HOME/config/zookeeper/global.json ->
 
       "es.client.settings" : {
           "es.client.class" : "org.elasticsearch.xpack.client.PreBuiltXPackTransportClient",
@@ -728,7 +728,8 @@ X-Pack
 1. Once you've built the `elasticsearch-xpack-shaded-5.6.2.jar`, it needs to be made available to Storm when you submit the topology. Create a contrib directory for indexing and put the jar file in this directory.
 
     ```
-    /usr/metron/0.6.0/indexing_contrib/elasticsearch-xpack-shaded-5.6.2.jar
+    mkdir $METRON_HOME/indexing_contrib
+    cp elasticsearch-xpack-shaded-5.6.2.jar $METRON_HOME/indexing_contrib/elasticsearch-xpack-shaded-5.6.2.jar
     ```
 
 1. Now you can restart the Elasticsearch topology. Note, you should perform this step manually, as follows.

--- a/metron-deployment/Kerberos-manual-setup.md
+++ b/metron-deployment/Kerberos-manual-setup.md
@@ -30,7 +30,7 @@ This document provides instructions for kerberizing Metron's Vagrant-based devel
 * [Start Metron](#start-metron)
 * [Push Data](#push-data)
 * [More Information](#more-information)
-* [Elasticseach X-Pack](#x-pack)
+* [Elasticseach X-Pack](#X-Pack)
 
 Setup
 -----


### PR DESCRIPTION
## Contributor Comments

https://issues.apache.org/jira/browse/METRON-1777

This addresses issues in the example pom for constructing the X-Pack client that we provide in the kerberos/security README. There is a bug in the shade plugin version that we had been using that appears to be fixed in the latest version, 3.2.0, whereby attempting to shade a jar with log4j-api would cause the build to fail with a nondescript error message as follows:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:2.4.3:shade (default) on project elasticsearch-xpack-shaded: Error creating shaded jar: null: IllegalArgumentException -> [Help 1]
```

Excluding the log4j-api caused some issues when managing  the classpath between the REST application and indexing topology. Upgrading the plugin version now allows the log4j-api packages to be appropriately shaded and relocated. Note, much of this classpath drama should hopefully be ameliorated by transitioning from the Java low level client to the newer REST api provided by Elasticsearch.

Validated in full dev with X-Pack enabled.

**Testing**

You can manually validate this doc change by following the README and setting up X-Pack for Elasticsearch. You should continue to see data published to Elasticsearch by the indexing topology as normal. Also, the Alerts UI should be able to display alerts as normal.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- n/a Have you written or updated unit tests and or integration tests to verify your changes?
- n/a If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
