### PR TITLE
METRON-1760: Kill PCAP job should prompt for confirmation

### DIFF
--- a/metron-interface/metron-alerts/package-lock.json
+++ b/metron-interface/metron-alerts/package-lock.json
@@ -5808,6 +5808,15 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
+    "angular-confirmation-popover": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/angular-confirmation-popover/-/angular-confirmation-popover-4.2.0.tgz",
+      "integrity": "sha512-ItCPzV52user93NRk9rF4Rp8NpawBWJdkNf8+6lH//f5i/N5HY0Aq5Hcch3xk19h9P48k0WZnfwOQL181xe4MQ==",
+      "requires": {
+        "positioning": "^1.3.1",
+        "tslib": "^1.9.0"
+      }
+    },
     "ansi-html": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
@@ -14147,6 +14156,11 @@
           "dev": true
         }
       }
+    },
+    "positioning": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/positioning/-/positioning-1.4.0.tgz",
+      "integrity": "sha512-LbN+mgAXtcDdN46xMJ3yZwjndqqYJODaO5qKmU+MVMu5tL3K2dlm1Qha/zh1k2JAFym5HDaZpnPfO4gr91VTRw=="
     },
     "posix-character-classes": {
       "version": "0.1.1",

--- a/metron-interface/metron-alerts/package.json
+++ b/metron-interface/metron-alerts/package.json
@@ -26,6 +26,7 @@
     "@types/jquery": "^3.3.4",
     "ace-builds": "^1.2.6",
     "ajv": "^6.5.1",
+    "angular-confirmation-popover": "^4.2.0",
     "bootstrap": "4.0.0-alpha.6",
     "core-js": "^2.4.1",
     "font-awesome": "^4.7.0",

--- a/metron-interface/metron-alerts/src/app/pcap/pcap-panel/pcap-panel.component.html
+++ b/metron-interface/metron-alerts/src/app/pcap/pcap-panel/pcap-panel.component.html
@@ -19,7 +19,22 @@
     <div class="progress pcap-progress-background">
       <div class="progress-bar progress-bar-animated pcap-progress" role="progressbar" attr.aria-valuenow="{{progressWidth}}" aria-valuemin="0" aria-valuemax="100" [ngStyle]="{'width': progressWidth + '%'}">{{progressWidth}}%</div>
     </div>
-    <button data-qe-id="pcap-cancel-query-button" class="pcap-cancel-query-button btn btn-primary btn-sm" (click)="cancelQuery()" [disabled]="!queryId"></button>
+    <button
+      mwlConfirmationPopover
+      [popoverMessage]="cancelConfirmMessage"
+      placement="left"
+      (confirm)="cancelQuery()"
+      cancelText="No"
+      confirmText="Yes"
+      confirmButtonType="danger"
+      appendToBody="true"
+      popoverClass="pcap-cancel-query-confirm-popover confirm-popover"
+
+      data-qe-id="pcap-cancel-query-button"
+      class="pcap-cancel-query-button btn btn-primary btn-sm"
+      [disabled]="!queryId"
+    >
+    </button>
   </div>
   <div *ngIf="errorMsg" class="alert alert-danger" role="alert" data-qe-id="error">
     {{ errorMsg }}

--- a/metron-interface/metron-alerts/src/app/pcap/pcap-panel/pcap-panel.component.spec.ts
+++ b/metron-interface/metron-alerts/src/app/pcap/pcap-panel/pcap-panel.component.spec.ts
@@ -27,6 +27,7 @@ import { By } from '../../../../node_modules/@angular/platform-browser';
 import { PcapRequest } from '../model/pcap.request';
 import { of, defer } from 'rxjs';
 import { RestError } from '../../model/rest-error';
+import { ConfirmationPopoverModule } from 'angular-confirmation-popover';
 
 @Component({
   selector: 'app-pcap-filters',
@@ -66,6 +67,9 @@ describe('PcapPanelComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
+      imports: [
+        ConfirmationPopoverModule.forRoot(),
+      ],
       declarations: [
         FakeFilterComponent,
         FakePcapListComponent,
@@ -346,7 +350,7 @@ describe('PcapPanelComponent', () => {
     expect(fixture.debugElement.query(By.css('[data-qe-id="pcap-cancel-query-button"]'))).toBeDefined();
   });
 
-  it('should hide the progress bar if the user clicks on the cancel button', fakeAsync(() => {
+  it('should hide the progress bar if the user clicks on the cancel button and confirms', fakeAsync(() => {
     component.queryRunning = true;
     component.queryId = '42';
     fixture.detectChanges();
@@ -356,6 +360,12 @@ describe('PcapPanelComponent', () => {
     const cancelBtnEl = cancelBtn.nativeElement;
 
     cancelBtnEl.click();
+    fixture.detectChanges();
+
+    const confirmButton = fixture.debugElement.query(By.css('.pcap-cancel-query-confirm-popover .btn-danger'));
+    const confirmButtonEl = confirmButton.nativeElement;
+
+    confirmButtonEl.click();
     tick();
     fixture.detectChanges();
 
@@ -377,6 +387,12 @@ describe('PcapPanelComponent', () => {
     const cancelBtnEl = cancelBtn.nativeElement;
 
     cancelBtnEl.click();
+    fixture.detectChanges();
+
+    const confirmButton = fixture.debugElement.query(By.css('.pcap-cancel-query-confirm-popover .btn-danger'));
+    const confirmButtonEl = confirmButton.nativeElement;
+
+    confirmButtonEl.click();
     tick();
     fixture.detectChanges();
 
@@ -399,6 +415,12 @@ describe('PcapPanelComponent', () => {
     const cancelBtnEl = cancelBtn.nativeElement;
 
     cancelBtnEl.click();
+    fixture.detectChanges();
+
+    const confirmButton = fixture.debugElement.query(By.css('.pcap-cancel-query-confirm-popover .btn-danger'));
+    const confirmButtonEl = confirmButton.nativeElement;
+
+    confirmButtonEl.click();
     tick();
     fixture.detectChanges();
 
@@ -438,6 +460,12 @@ describe('PcapPanelComponent', () => {
     const cancelBtnEl = cancelBtn.nativeElement;
 
     cancelBtnEl.click();
+    fixture.detectChanges();
+
+    const confirmButton = fixture.debugElement.query(By.css('.pcap-cancel-query-confirm-popover .btn-danger'));
+    const confirmButtonEl = confirmButton.nativeElement;
+
+    confirmButtonEl.click();
     tick();
     fixture.detectChanges();
 
@@ -457,6 +485,12 @@ describe('PcapPanelComponent', () => {
     const cancelBtnEl = cancelBtn.nativeElement;
 
     cancelBtnEl.click();
+    fixture.detectChanges();
+
+    const confirmButton = fixture.debugElement.query(By.css('.pcap-cancel-query-confirm-popover .btn-danger'));
+    const confirmButtonEl = confirmButton.nativeElement;
+
+    confirmButtonEl.click();
     tick();
     fixture.detectChanges();
 

--- a/metron-interface/metron-alerts/src/app/pcap/pcap-panel/pcap-panel.component.ts
+++ b/metron-interface/metron-alerts/src/app/pcap/pcap-panel/pcap-panel.component.ts
@@ -46,6 +46,7 @@ export class PcapPanelComponent implements OnInit, OnDestroy {
   pagination: PcapPagination = new PcapPagination();
   savedPcapRequest: {};
   errorMsg: string;
+  cancelConfirmMessage = 'Are you sure want to cancel the running query?';
 
   constructor(private pcapService: PcapService) { }
 

--- a/metron-interface/metron-alerts/src/app/pcap/pcap.module.ts
+++ b/metron-interface/metron-alerts/src/app/pcap/pcap.module.ts
@@ -29,6 +29,7 @@ import { PcapPanelComponent } from './pcap-panel/pcap-panel.component';
 import { PcapPacketLineComponent } from './pcap-packet-line/pcap-packet-line.component';
 import { PcapPaginationComponent } from './pcap-pagination/pcap-pagination.component';
 import { PcapService } from './service/pcap.service';
+import { ConfirmationPopoverModule } from 'angular-confirmation-popover';
 
 @NgModule({
   imports: [
@@ -37,7 +38,8 @@ import { PcapService } from './service/pcap.service';
     FormsModule,
     HttpClientModule,
     ReactiveFormsModule,
-    DatePickerModule
+    DatePickerModule,
+    ConfirmationPopoverModule.forRoot()
   ],
   declarations: [
     PcapListComponent,

--- a/metron-interface/metron-alerts/src/confirm-popover.scss
+++ b/metron-interface/metron-alerts/src/confirm-popover.scss
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+$popover-button-color-confirm: #006EA0;
+$popover-button-border-color-confirm: $popover-button-color-confirm;
+
+$popover-button-color-cancel: #333333;
+$popover-button-border-color-cancel: #0F6F9E;
+
+$popover-background-color: #0C3B43;
+$popover-border-color: #1B596C;
+
+.confirm-popover {
+  background-color: $popover-background-color;
+  border: 1px solid $popover-border-color;
+  color: #999999;
+
+  & .btn {
+    font-size: 14px;
+    cursor: pointer;
+  }
+
+  & .btn-default {
+    background-color: $popover-button-color-cancel;
+    border-color: $popover-button-border-color-cancel;
+    color: #32ABDF;
+
+    &:hover {
+      background-color: #004b6d;
+    }
+  }
+
+  & .btn-danger {
+    background-color: $popover-button-color-confirm;
+    border-color: $popover-button-border-color-confirm;
+    color: white;
+
+    &:hover {
+      background-color: #004b6d;
+      border-color: #004b6d;
+    }
+  }
+
+
+  &.popover-top {
+    &::before {
+      border-top-color: $popover-border-color;
+    }
+    &::after {
+      border-top-color: $popover-background-color;
+      bottom: -9px;
+    }
+  }
+  &.popover-right {
+    &::before {
+      border-right-color: $popover-border-color;
+    }
+    &::after {
+      border-right-color: $popover-background-color;
+      left: -9px;
+    }
+  }
+  &.popover-bottom {
+    &::before {
+      border-bottom-color: $popover-border-color;
+    }
+    &::after {
+      border-bottom-color: $popover-background-color;
+      top: -9px;
+    }
+  }
+  &.popover-left {
+    &::before {
+      border-left-color: $popover-border-color;
+    }
+    &::after {
+      border-left-color: $popover-background-color;
+      right: -9px;
+    }
+  }
+}

--- a/metron-interface/metron-alerts/src/styles.scss
+++ b/metron-interface/metron-alerts/src/styles.scss
@@ -22,6 +22,7 @@
 @import "metron-dialog.scss";
 @import "../node_modules/pikaday-time/scss/pikaday.scss";
 @import "hexagon";
+@import "confirm-popover.scss";
 
 body,
 button {


### PR DESCRIPTION
## Contributor Comments

This PR introduces a so-called `pop confirm` component appearing next to "kill query button" when the user presses it. It provides a middle step between the user interaction and the http request since the querying process can be a time consuming process and the cancel button can be pressed accidentally giving the user a hard time.

You can find the original JIRA ticket [here](https://issues.apache.org/jira/browse/METRON-1760).

I decided to not create this floating element from scratch but rather install a [component](https://www.npmjs.com/package/angular-confirmation-popover) from npm which seemed to fulfil the requirements. 
It uses Bootstrap behind the scenes but I slightly modified the css to make it fit to the current design. 
The module has the appropriate [license](https://github.com/mattlewis92/angular-confirmation-popover/blob/master/package.json#L55) and the number of potential vulnerabilities, according to `npm audit`, is zero. 

**Changes included:**

- Use the new component as a directive on the kill button in [pcap-panel.component.html](https://github.com/ruffle1986/metron/blob/METRON-1760/metron-interface/metron-alerts/src/app/pcap/pcap-panel/pcap-panel.component.html#L23). It's reusable and you can use it on any other elements as you wish by setting the `mwlConfirmationPopover ` directive. You can also add [different attributes](https://github.com/ruffle1986/metron/blob/METRON-1760/metron-interface/metron-alerts/src/app/pcap/pcap-panel/pcap-panel.component.html#L24-L31) to configure the behaviour of the component. I wouldn't go into details since they're pretty straightforward. Check out the [docs](https://mattlewis92.github.io/angular-confirmation-popover/docs/)!

- The "killing query process" had been already tested before on the ui so I had to slightly change the test units accordingly. You cannot expect the same result unless you click on the "Yes" button on the pop confirm component. 

- [Override](https://github.com/ruffle1986/metron/blob/METRON-1760/metron-interface/metron-alerts/src/confirm-popover.scss) Bootstrap's styles to make it fit to the current (dark) design. 

- Update the package lock file due to the new dependency.

This is how it looks:
![44989404-0cd06180-af8e-11e8-841f-db9517243960](https://user-images.githubusercontent.com/2196208/45558381-14babc00-b840-11e8-800d-9cbbba823d3a.png)

**Testing:**

Go to the PCAP tab and start a new query by clicking on the magnifier at the right side of the filter panel. The progress bar is supposed to appear with a cancel button on the right (a button with an "X" on it). During the process you should be able to click on the cancel button and the pop confirm component should appear next to the button to prompt the user to solidify his/her decision or give the opportunity to change his/her mind.

**In case you want to test it with real generated pcap data, you should do the following:**

Set `SAMPLE_PCAP_PATH` to where you save the files on your computer. For example: 
`export SAMPLE_PCAP_PATH=~/Projects/Metron/code/forks/merrimanr/samplePcap`

Copy the generated pcap files into full dev. To do that, make sure you’re inside your vagrant machine’s directory (e.g. centos6, etc.) and have the vagrant-scp plugin is added to vagrant. The script to install this plugin is:

```sh
vagrant plugin install vagrant-scp
```

To copy the files, run this command:

```sh
ls $SAMPLE_PCAP_PATH | xargs -I {} vagrant scp $SAMPLE_PCAP_PATH/{} /tmp
```

Login to full dev and upload these files to HDFS:

```sh
vagrant ssh
    su root (password: vagrant or root)
    su - metron -c "hdfs dfs -put /tmp/pcap* /apps/metron/pcap/input"
```

install wireshark on full dev with `yum -y install wireshark`

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [X] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [X] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [X] Have you included steps or a guide to how the change may be verified and tested manually?
- [X] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [X] Have you written or updated unit tests and or integration tests to verify your changes?
- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [X] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
