### PR TITLE
METRON-1784: Re-allow remote ssh and scp in Centos full dev

### DIFF
--- a/metron-deployment/ansible/roles/enable-remote-ssh/defaults/main.yml
+++ b/metron-deployment/ansible/roles/enable-remote-ssh/defaults/main.yml
@@ -15,10 +15,4 @@
 #  limitations under the License.
 #
 ---
-- hosts: all
-  roles:
-    - { role: libselinux-python, tags: libselinux-python }
-    - { role: enable-swap,       tags: enable-swap }
-    - { role: enable-remote-ssh, tags: enable-remote-ssh }
-
-- include: ../../../ansible/playbooks/metron_full_install.yml
+sshd_config_file: /etc/ssh/sshd_config

--- a/metron-deployment/ansible/roles/enable-remote-ssh/tasks/main.yml
+++ b/metron-deployment/ansible/roles/enable-remote-ssh/tasks/main.yml
@@ -15,10 +15,19 @@
 #  limitations under the License.
 #
 ---
-- hosts: all
-  roles:
-    - { role: libselinux-python, tags: libselinux-python }
-    - { role: enable-swap,       tags: enable-swap }
-    - { role: enable-remote-ssh, tags: enable-remote-ssh }
+- name: Comment password auth no
+  lineinfile:
+    dest: "{{ sshd_config_file }}"
+    regexp: "^PasswordAuthentication no"
+    line: "#PasswordAuthentication no"
 
-- include: ../../../ansible/playbooks/metron_full_install.yml
+- name: Uncomment password auth yes
+  lineinfile:
+    dest: "{{ sshd_config_file }}"
+    regexp: "^#PasswordAuthentication yes"
+    line: "PasswordAuthentication yes"
+
+- name: Restart service sshd, in all cases
+  service:
+    name: sshd
+    state: restarted


### PR DESCRIPTION
## Contributor Comments

https://issues.apache.org/jira/browse/METRON-1784

Tired of having to manually modify sshd_config in full dev for Centos to re-enable remote ssh and scp manually? Then this PR is for you!

Somewhere along the way the default image for Centos shifted the sshd_config defaults to disallow remote logins. This reverts that back to the way we had it before to make it easier to transfer files, login, etc. I also modified the role + tags so that you can run just the specific task by providing the tag - see testing example below.

**Testing**

I modified the main playbook.yml for Centos such that you can also test this via ansible tags against a running instance without tearing it down completely, should you choose.

- Switch to `metron/metron-deployment/development/centos6`
- Run `vagrant up` if you don't already have a full dev instance running, or alternatively `vagrant --ansible-tags="enable-remote-ssh" provision` to run the tag/role for an existing instance.
- Verify that you can now ssh into the box.
  - cd into some other directory
  - ssh root@node1
  - enter password and it should succeed. Previously you would get a `root@node1: Permission denied (publickey,gssapi-keyex,gssapi-with-mic).` exception

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- n/a Have you written or updated unit tests and or integration tests to verify your changes?
- n/a If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- n/a Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
