### PR TITLE
METRON-1787 Input Time Constraints for Batch Profiler

### DIFF
--- a/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/clock/EventTimeOnlyClockFactory.java
+++ b/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/clock/EventTimeOnlyClockFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.metron.profiler.clock;
+
+import org.apache.metron.common.configuration.profiler.ProfilerConfig;
+
+import java.io.Serializable;
+
+/**
+ * Creates a {@link Clock} based on the profiler configuration.  This should
+ * be used in cases where only event time is accceptable.
+ *
+ * <p>If the Profiler is configured to use event time, a {@link EventTimeClock} will
+ * be created.  Otherwise, an {@link IllegalStateException} is thrown.
+ */
+public class EventTimeOnlyClockFactory implements ClockFactory, Serializable {
+
+  /**
+   * If the Profiler is configured to use event time, a {@link EventTimeClock} is created.
+   * Otherwise, an {@link IllegalArgumentException} is thrown.
+   *
+   * @param config The profiler configuration.
+   * @return The appropriate Clock based on the profiler configuration.
+   * @throws IllegalStateException If the profiler configuration is set to system time.
+   */
+  @Override
+  public Clock createClock(ProfilerConfig config) {
+    Clock clock;
+
+    boolean isEventTime = config.getTimestampField().isPresent();
+    if(isEventTime) {
+      String timestampField = config.getTimestampField().get();
+      clock = new EventTimeClock(timestampField);
+
+    } else {
+      throw new IllegalStateException("Expected profiler to use event time.");
+    }
+
+    return clock;
+  }
+}

--- a/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/clock/EventTimeOnlyClockFactoryTest.java
+++ b/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/clock/EventTimeOnlyClockFactoryTest.java
@@ -42,7 +42,6 @@ public class EventTimeOnlyClockFactoryTest {
 
   @Test
   public void testCreateEventTimeClock() {
-
     // configure the profiler to use event time
     ProfilerConfig config = new ProfilerConfig();
     config.setTimestampField(Optional.of("timestamp"));
@@ -54,7 +53,6 @@ public class EventTimeOnlyClockFactoryTest {
 
   @Test(expected = IllegalStateException.class)
   public void testCreateProcessingTimeClock() {
-
     // the profiler uses processing time by default
     ProfilerConfig config = new ProfilerConfig();
     clockFactory.createClock(config);

--- a/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/clock/EventTimeOnlyClockFactoryTest.java
+++ b/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/clock/EventTimeOnlyClockFactoryTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.metron.profiler.clock;
+
+import org.apache.metron.common.configuration.profiler.ProfilerConfig;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests the {@link EventTimeOnlyClockFactory}.
+ */
+public class EventTimeOnlyClockFactoryTest {
+
+  private EventTimeOnlyClockFactory clockFactory;
+
+  @Before
+  public void setup() {
+    clockFactory = new EventTimeOnlyClockFactory();
+  }
+
+  @Test
+  public void testCreateEventTimeClock() {
+
+    // configure the profiler to use event time
+    ProfilerConfig config = new ProfilerConfig();
+    config.setTimestampField(Optional.of("timestamp"));
+
+    // the factory should return a clock that handles 'event time'
+    Clock clock = clockFactory.createClock(config);
+    assertTrue(clock instanceof EventTimeClock);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testCreateProcessingTimeClock() {
+
+    // the profiler uses processing time by default
+    ProfilerConfig config = new ProfilerConfig();
+    clockFactory.createClock(config);
+    fail("Expected exception");
+  }
+}

--- a/metron-analytics/metron-profiler-spark/README.md
+++ b/metron-analytics/metron-profiler-spark/README.md
@@ -267,15 +267,20 @@ The format of the input data read by the Batch Profiler.
 
 ### `profiler.batch.input.begin`
 
-*Default*: undefined
+*Default*: undefined; no time constraint
 
-Only messages with a timestamp after this will be profiled. By default, no time constraint is defined. The value is expected to follow the [ISO-8601 instant format](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_INSTANT); 2011-12-03T10:15:30Z.
+Only messages with a timestamp equal to or after this will be profiled. The Profiler will only profiles messages with a timestamp in [`profiler.batch.input.begin`, `profiler.batch.input.end`] inclusive.
+
+By default, no time constraint is defined. The value is expected to follow the [ISO-8601 instant format](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_INSTANT); 2011-12-03T10:15:30Z.
+
 
 ### `profiler.batch.input.end`
 
-*Default*: undefined
+*Default*: undefined; no time constraint
 
-Only messages with a timestamp before this will be profiled. By default, no time constraint is defined. The value is expected to follow the [ISO-8601 instant format](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_INSTANT); 2011-12-03T10:15:30Z.
+Only messages with a timestamp before or equal to this will be profiled. The Profiler will only profiles messages with a timestamp in [`profiler.batch.input.begin`, `profiler.batch.input.end`] inclusive.
+
+By default, no time constraint is defined. The value is expected to follow the [ISO-8601 instant format](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_INSTANT); 2011-12-03T10:15:30Z.
 
 ### `profiler.period.duration`
 

--- a/metron-analytics/metron-profiler-spark/README.md
+++ b/metron-analytics/metron-profiler-spark/README.md
@@ -245,6 +245,8 @@ You can store both settings for the Profiler along with settings for Spark in th
 |---                                                                            |---
 | [`profiler.batch.input.path`](#profilerbatchinputpath)                        | The path to the input data read by the Batch Profiler.
 | [`profiler.batch.input.format`](#profilerbatchinputformat)                    | The format of the input data read by the Batch Profiler.
+| [`profiler.batch.input.begin`](#profilerbatchinputend)                        | Only messages with a timestamp after this will be profiled.
+| [`profiler.batch.input.end`](#profilerbatchinputbegin)                        | Only messages with a timestamp before this will be profiled.
 | [`profiler.period.duration`](#profilerperiodduration)                         | The duration of each profile period.  
 | [`profiler.period.duration.units`](#profilerperioddurationunits)              | The units used to specify the [`profiler.period.duration`](#profilerperiodduration).
 | [`profiler.hbase.salt.divisor`](#profilerhbasesaltdivisor)                    | A salt is prepended to the row key to help prevent hot-spotting.
@@ -262,6 +264,18 @@ The path to the input data read by the Batch Profiler.
 *Default*: text
 
 The format of the input data read by the Batch Profiler.
+
+### `profiler.batch.input.begin`
+
+*Default*: undefined
+
+Only messages with a timestamp after this will be profiled. By default, no time constraint is defined. The value is expected to follow the [ISO-8601 instant format](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_INSTANT); 2011-12-03T10:15:30Z.
+
+### `profiler.batch.input.end`
+
+*Default*: undefined
+
+Only messages with a timestamp before this will be profiled. By default, no time constraint is defined. The value is expected to follow the [ISO-8601 instant format](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_INSTANT); 2011-12-03T10:15:30Z.
 
 ### `profiler.period.duration`
 

--- a/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/BatchProfilerConfig.java
+++ b/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/BatchProfilerConfig.java
@@ -46,7 +46,11 @@ public enum BatchProfilerConfig {
 
   TELEMETRY_INPUT_FORMAT("profiler.batch.input.format", "text", String.class),
 
-  TELEMETRY_INPUT_PATH("profiler.batch.input.path", "hdfs://localhost:9000/apps/metron/indexing/indexed/*/*", String.class);
+  TELEMETRY_INPUT_PATH("profiler.batch.input.path", "hdfs://localhost:9000/apps/metron/indexing/indexed/*/*", String.class),
+
+  TELEMETRY_INPUT_BEGIN("profiler.batch.input.begin", "", String.class),
+
+  TELEMETRY_INPUT_END("profiler.batch.input.end", "", String.class);
 
   /**
    * The key for the configuration value.

--- a/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/TimestampParser.java
+++ b/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/TimestampParser.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.metron.profiler.spark;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.Optional;
+
+/**
+ * Parses an input string and returns a timestamp in epoch milliseconds.
+ */
+public class TimestampParser {
+
+  /**
+   * Parses an input string and returns an optional timestamp in epoch milliseconds.
+   *
+   * @param inputString The input defining a timestamp.
+   * @return A timestamp in epoch milliseconds.
+   */
+  public Optional<Long> parse(String inputString) {
+    Optional<Long> epochMilli = Optional.empty();
+
+    // a blank is acceptable and treated as undefined
+    if (StringUtils.isNotBlank(inputString)) {
+      epochMilli = Optional.of(new DateTimeFormatterBuilder()
+              .append(DateTimeFormatter.ISO_INSTANT)
+              .toFormatter()
+              .parse(inputString, Instant::from)
+              .toEpochMilli());
+    }
+
+    return epochMilli;
+  }
+
+}

--- a/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/function/MessageRouterFunction.java
+++ b/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/function/MessageRouterFunction.java
@@ -23,6 +23,9 @@ import org.apache.metron.common.configuration.profiler.ProfilerConfig;
 import org.apache.metron.profiler.DefaultMessageRouter;
 import org.apache.metron.profiler.MessageRoute;
 import org.apache.metron.profiler.MessageRouter;
+import org.apache.metron.profiler.clock.Clock;
+import org.apache.metron.profiler.clock.ClockFactory;
+import org.apache.metron.profiler.clock.EventTimeOnlyClockFactory;
 import org.apache.metron.stellar.dsl.Context;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.json.simple.JSONObject;
@@ -54,9 +57,27 @@ public class MessageRouterFunction implements FlatMapFunction<String, MessageRou
    */
   private ProfilerConfig profilerConfig;
 
+  /**
+   * Responsible for creating the {@link Clock}.
+   */
+  private ClockFactory clockFactory;
+
+  /**
+   * Only messages with a timestamp after this will be routed.
+   */
+  private Long begin;
+
+  /**
+   * Only messages with a timestamp before this will be routed.
+   */
+  private Long end;
+
   public MessageRouterFunction(ProfilerConfig profilerConfig, Map<String, String> globals) {
     this.profilerConfig = profilerConfig;
     this.globals = globals;
+    this.clockFactory = new EventTimeOnlyClockFactory();
+    this.begin = Long.MIN_VALUE;
+    this.end = Long.MAX_VALUE;
   }
 
   /**
@@ -70,8 +91,7 @@ public class MessageRouterFunction implements FlatMapFunction<String, MessageRou
    */
   @Override
   public Iterator<MessageRoute> call(String jsonMessage) throws Exception {
-    List<MessageRoute> routes;
-
+    List<MessageRoute> routes = Collections.emptyList();
     JSONParser parser = new JSONParser();
     Context context = TaskUtils.getContext(globals);
     MessageRouter router = new DefaultMessageRouter(context);
@@ -80,17 +100,52 @@ public class MessageRouterFunction implements FlatMapFunction<String, MessageRou
     Optional<JSONObject> message = toMessage(jsonMessage, parser);
     if(message.isPresent()) {
 
-      // find all routes
-      routes = router.route(message.get(), profilerConfig, context);
-      LOG.trace("Found {} route(s) for a message", routes.size());
+      // extract the timestamp from the message
+      Clock clock = clockFactory.createClock(profilerConfig);
+      Optional<Long> timestampOpt = clock.currentTimeMillis(message.get());
+      if (timestampOpt.isPresent()) {
+
+        // timestamp must be in [begin, end]
+        Long timestamp = timestampOpt.get();
+        if(timestamp >= begin && timestamp <= end) {
+          routes = router.route(message.get(), profilerConfig, context);
+          LOG.trace("Found {} route(s) for a message", routes.size());
+
+        } else {
+          LOG.trace("Ignoring message; timestamp={} not in [{},{}]", timestamp, prettyPrint(begin), prettyPrint(end));
+        }
+
+      } else {
+        LOG.trace("No timestamp in message. Message will be ignored.");
+      }
 
     } else {
-      // the message is not valid and must be ignored
-      routes = Collections.emptyList();
-      LOG.trace("No route possible. Unable to parse message.");
+      LOG.trace("Unable to parse message. Message will be ignored");
     }
 
     return routes.iterator();
+  }
+
+  /**
+   * Set a time constraint.
+   *
+   * @param begin Only messages with a timestamp after this will be routed.
+   * @return The message router function
+   */
+  public MessageRouterFunction withBegin(Long begin) {
+    this.begin = begin;
+    return this;
+  }
+
+  /**
+   * Set a time constraint.
+   *
+   * @param end Only messages with a timestamp before this will be routed.
+   * @return The message router function
+   */
+  public MessageRouterFunction withEnd(Long end) {
+    this.end = end;
+    return this;
   }
 
   /**
@@ -109,5 +164,27 @@ public class MessageRouterFunction implements FlatMapFunction<String, MessageRou
       LOG.warn(String.format("Unable to parse message, message will be ignored; message='%s'", json), e);
       return Optional.empty();
     }
+  }
+
+  /**
+   * Pretty prints a Long value for use when logging these values.
+   *
+   * <p>Long.MIN_VALUE and Long.MAX_VALUE will occur frequently and is difficult to grok in the logs.  Instead
+   * Long.MIN_VALUE is rendered as "MIN". Long.MAX_VALUE is srendered as "MAX". All other values are rendered
+   * directly.
+   *
+   * @param value The value to pretty print.
+   * @return
+   */
+  private String prettyPrint(Long value) {
+    String result;
+    if(value == Long.MIN_VALUE) {
+      result = "MIN";
+    } else if(value == Long.MAX_VALUE) {
+      result = "MAX";
+    } else {
+      result = value.toString();
+    }
+    return result;
   }
 }

--- a/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/TimestampParserTest.java
+++ b/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/TimestampParserTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.metron.profiler.spark;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.format.DateTimeParseException;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class TimestampParserTest {
+
+  private TimestampParser parser;
+
+  @Before
+  public void setup() {
+    parser = new TimestampParser();
+  }
+
+  @Test
+  public void testEmpty() {
+    Optional<Long> millis = parser.parse("");
+    assertFalse(millis.isPresent());
+  }
+
+  @Test
+  public void testBlank() {
+    Optional<Long> millis = parser.parse("      ");
+    assertFalse(millis.isPresent());
+  }
+
+  @Test
+  public void testIsoInstantFormat() {
+    // ISO-8601 instant format
+    Optional<Long> millis = parser.parse("2011-12-03T10:15:30Z");
+    assertTrue(millis.isPresent());
+    assertEquals(1322907330000L, millis.get().longValue());
+  }
+
+  @Test(expected = DateTimeParseException.class)
+  public void testInvalidFormat() {
+    parser.parse("1537502400000");
+    fail("Expected exception");
+  }
+}


### PR DESCRIPTION
This allows the user to define a 'begin' and/or 'end' time constraints to the telemetry that is consumed by the Batch Profiler.  See the README for an explanation of these values and how to use them.

This is a pull request for the `feature/METRON-1699-create-batch-profiler` feature branch.

## Testing

1. Spin-up a development environment.

1. Allow some amount of telemetry to accumulate in HDFS.
    ```
    [root@node1 ~]# hdfs dfs -cat /apps/metron/indexing/indexed/*/* | wc -l
    945
    ```

1. Stop Indexing, Enrichment, Parsers, Profiler, Elasticsearch and Kibana.

1. Install Spark 2 using Ambari.

1. Tell Spark how to talk with HBase.
    ```
    SPARK_HOME=/usr/hdp/current/spark2-client
    cp /usr/hdp/current/hbase-client/conf/hbase-site.xml $SPARK_HOME/conf/
    ```
  
1. Create the Spark History directory in HDFS.
    ```
    export HADOOP_USER_NAME=hdfs
    hdfs dfs -mkdir /spark2-history
    ```

1. Fix-up the Spark logging.
    ```
    SPARK_HOME=/usr/hdp/current/spark2-client
    cp $SPARK_HOME/conf/log4j.properties.template $SPARK_HOME/conf/log4j.properties
    sed -i 's/INFO/ERROR/' $SPARK_HOME/conf/log4j.properties
    sed -i 's/WARN/ERROR/' $SPARK_HOME/conf/log4j.properties
    echo "" >> $SPARK_HOME/conf/log4j.properties
    echo "log4j.logger.org.apache.metron.profiler.spark=DEBUG" >> $SPARK_HOME/conf/log4j.properties
    ```

1. Create a profile.

    ```
    [root@node1 ~]# cat $METRON_HOME/config/zookeeper/profiler.json
    {
      "profiles": [
        {
          "profile": "hello-world",
          "foreach": "'global'",
          "init":    { "count": "0" },
          "update":  { "count": "count + 1" },
          "result":  "count"
        }
      ],
      "timestampField": "timestamp"
    }
    ``` 
  
1. Edit the Batch Profiler properties. Update the input path and add a time constraint that will filter out all of the telemetry.  Here we set the `profiler.batch.input.begin` to a time in the future.  We would expect the Profiler to not process any of the telemetry in this case.
    ```
    [root@node1 ~]# cat $METRON_HOME/config/batch-profiler.properties

    spark.app.name=Batch Profiler
    spark.master=local
    spark.sql.shuffle.partitions=4

    profiler.batch.input.path=hdfs://localhost:8020/apps/metron/indexing/indexed/*/*
    profiler.batch.input.format=text

    profiler.batch.input.begin=2029-12-03T10:15:30Z
    profiler.batch.input.end=

    profiler.period.duration=15
    profiler.period.duration.units=MINUTES
    ```

1. Run the Batch Profiler. Notice that in this case that even though it "Found 945 telemetry record(s)" it "Generated 0 message route(s)" because all of the messages were filtered based on the time constraint that was added.
    ```
    [root@node1 0.6.0]# cd $METRON_HOME
    [root@node1 0.6.0]# bin/start_batch_profiler.sh
    18/09/21 20:50:00 INFO BatchProfilerCLI: Loading profiles from '/usr/metron/0.6.0/config/zookeeper/profiler.json'
    18/09/21 20:50:00 INFO BatchProfilerCLI: Loaded 1 profile(s)
    18/09/21 20:50:01 DEBUG BatchProfiler: Building 1 profile(s)
    18/09/21 20:50:01 DEBUG BatchProfiler: Loading telemetry from 'hdfs://localhost:8020/apps/metron/indexing/indexed/*/*'
    18/09/21 20:50:09 DEBUG BatchProfiler: Found 945 telemetry record(s)
    18/09/21 20:50:10 DEBUG BatchProfiler: Generated 0 message route(s)
    18/09/21 20:50:12 DEBUG BatchProfiler: Produced 0 profile measurement(s)
    ...
    18/09/21 20:50:12 DEBUG BatchProfiler: 0 profile measurement(s) written to HBase
    18/09/21 20:50:12 INFO BatchProfilerCLI: Profiler produced 0 profile measurement(s)
    ```

1. Launch the Spark shell
    ```
    export SPARK_MAJOR_VERSION=2
    export HADOOP_USER_NAME=hdfs
    spark-shell
    ```

1. Find out how much telemetry you have captured and a reasonable place to 'cut' the data.  Grab the last timestamp in the list.
    ```
    scala> val msgs = spark.read.json("hdfs://localhost:8020/apps/metron/indexing/indexed/*/*")
    msgs: org.apache.spark.sql.DataFrame = [AA: boolean, RA: boolean ... 91 more fields]

    scala> msgs.select("timestamp").sort().show()
    18/09/21 20:54:34 WARN Utils: Truncated the string representation of a plan since it was too large. This behavior can be adjusted by setting 'spark.debug.maxToStringFields' in SparkEnv.conf.
    +-------------+
    |    timestamp|
    +-------------+
    |1537558303064|
    |1537558303771|
    |1537558303424|
    |1537558303256|
    |1537558303077|
    |1537558303916|
    |1537558303317|
    |1537558303476|
    |1537558303002|
    |1537558303359|
    |1537558311990|
    |1537558311894|
    |1537558311313|
    |1537558311608|
    |1537558311787|
    |1537558311883|
    |1537558311927|
    |1537558311070|
    |1537558311062|
    |1537558311594|
    +-------------+
    only showing top 20 rows
    ```

1. Grab one of those timestamps and convert it to a time in UTC.  That will exclude some of the data, but not all. We should get some messages, but not all of them.  Finding this time will just depend on your data.

1. Edit the Batch Profiler properties. Set the `profiler.batch.input.begin` to the time that cuts your data.  Remember that the time is specified in UTC as spelled out in the README.
    ```
    [root@node1 ~]# cat $METRON_HOME/config/batch-profiler.properties

    spark.app.name=Batch Profiler
    spark.master=local
    spark.sql.shuffle.partitions=4

    profiler.batch.input.path=hdfs://localhost:8020/apps/metron/indexing/indexed/*/*
    profiler.batch.input.format=text

    profiler.batch.input.begin=2018-09-21T19:31:51Z
    profiler.batch.input.end=

    profiler.period.duration=15
    profiler.period.duration.units=MINUTES
    ```

1. Run the Batch Profiler.  Here you can see that while we have 945 messages, the Profiler only created the profile with 925 of them.
    ```
    [root@node1 0.6.0]# bin/start_batch_profiler.sh
    ...
    18/09/21 20:58:38 INFO BatchProfilerCLI: Loading profiles from '/usr/metron/0.6.0/config/zookeeper/profiler.json'
    18/09/21 20:58:38 INFO BatchProfilerCLI: Loaded 1 profile(s)
    18/09/21 20:58:40 DEBUG BatchProfiler: Building 1 profile(s)
    18/09/21 20:58:40 DEBUG BatchProfiler: Loading telemetry from 'hdfs://localhost:8020/apps/metron/indexing/indexed/*/*'
    18/09/21 20:58:49 DEBUG BatchProfiler: Found 945 telemetry record(s)
    ... 
    20:58:50 DEBUG BatchProfiler: Generated 925 message route(s)
    18/09/21 20:58:52 DEBUG ProfileBuilderFunction: Building a profile for group 'hello-world-global-1708398' from 925 message(s)
    18/09/21 20:58:53 DEBUG ProfileBuilderFunction: Profile measurement created; profile=hello-world, entity=global, period=1708398, value=925
    18/09/21 20:58:53 DEBUG BatchProfiler: Produced 1 profile measurement(s)
    ...
    18/09/21 20:58:56 DEBUG BatchProfiler: 1 profile measurement(s) written to HBase
    18/09/21 20:58:56 INFO BatchProfilerCLI: Profiler produced 1 profile measurement(s)
    ```

1. You can confirm this using the REPL too.  There was 1 profile measurement written with a value of 925.
    ```
    [Stellar]>>> PROFILE_GET("hello-world","global",PROFILE_FIXED(1, "DAYS"))
    [925]
    ```

## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron 
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

