### PR TITLE
METRON-1794 Include User Details When Escalating Alerts

### DIFF
--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/MetronRestConstants.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/MetronRestConstants.java
@@ -53,6 +53,9 @@ public class MetronRestConstants {
   public static final String KAFKA_BROKER_URL_SPRING_PROPERTY = "kafka.broker.url";
   public static final String KAFKA_TOPICS_ESCALATION_PROPERTY = "kafka.topics.escalation";
 
+  public static final String METRON_ESCALATION_USER_FIELD = "metron_escalation_user";
+  public static final String METRON_ESCALATION_TIMESTAMP_FIELD = "metron_escalation_timestamp";
+
   public static final String KERBEROS_ENABLED_SPRING_PROPERTY = "kerberos.enabled";
   public static final String KERBEROS_PRINCIPLE_SPRING_PROPERTY = "kerberos.principal";
   public static final String KERBEROS_KEYTAB_SPRING_PROPERTY = "kerberos.keytab";

--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/service/impl/AlertsUIServiceImpl.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/service/impl/AlertsUIServiceImpl.java
@@ -19,25 +19,31 @@ package org.apache.metron.rest.service.impl;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.metron.common.system.Clock;
+import org.apache.metron.common.utils.JSONUtils;
+import org.apache.metron.hbase.client.UserSettingsClient;
+import org.apache.metron.rest.RestException;
+import org.apache.metron.rest.model.AlertsUIUserSettings;
+import org.apache.metron.rest.security.SecurityUtils;
+import org.apache.metron.rest.service.AlertsUIService;
+import org.apache.metron.rest.service.KafkaService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.metron.common.utils.JSONUtils;
-import org.apache.metron.rest.MetronRestConstants;
-import org.apache.metron.rest.RestException;
-import org.apache.metron.rest.model.AlertsUIUserSettings;
-import org.apache.metron.hbase.client.UserSettingsClient;
-import org.apache.metron.rest.security.SecurityUtils;
-import org.apache.metron.rest.service.AlertsUIService;
-import org.apache.metron.rest.service.KafkaService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
-import org.springframework.stereotype.Service;
+import static org.apache.metron.rest.MetronRestConstants.KAFKA_TOPICS_ESCALATION_PROPERTY;
+import static org.apache.metron.rest.MetronRestConstants.METRON_ESCALATION_TIMESTAMP_FIELD;
+import static org.apache.metron.rest.MetronRestConstants.METRON_ESCALATION_USER_FIELD;
 
 /**
  * The default service layer implementation of {@link AlertsUIService}.
@@ -47,6 +53,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class AlertsUIServiceImpl implements AlertsUIService {
 
+  static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   public static final String ALERT_USER_SETTING_TYPE = "metron-alerts-ui";
   public static ThreadLocal<ObjectMapper> _mapper = ThreadLocal.withInitial(() ->
           new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL));
@@ -54,6 +61,7 @@ public class AlertsUIServiceImpl implements AlertsUIService {
   private Environment environment;
   private final KafkaService kafkaService;
   private UserSettingsClient userSettingsClient;
+  private Clock clock;
 
   @Autowired
   public AlertsUIServiceImpl(final KafkaService kafkaService,
@@ -62,15 +70,25 @@ public class AlertsUIServiceImpl implements AlertsUIService {
     this.kafkaService = kafkaService;
     this.environment = environment;
     this.userSettingsClient = userSettingsClient;
+    this.clock = new Clock();
   }
 
   @Override
   public void escalateAlerts(List<Map<String, Object>> alerts) throws RestException {
+    String user = SecurityUtils.getCurrentUser();
+    String topic = environment.getProperty(KAFKA_TOPICS_ESCALATION_PROPERTY);
+    Long now = clock.currentTimeMillis();
+    LOG.debug("Escalating {} alert(s): user={}, topic={}, timestamp={}", alerts.size(), user, topic, now);
+
     try {
       for (Map<String, Object> alert : alerts) {
-        kafkaService.produceMessage(
-            environment.getProperty(MetronRestConstants.KAFKA_TOPICS_ESCALATION_PROPERTY),
-            JSONUtils.INSTANCE.toJSON(alert, false));
+        // attribute the escalation to the current user
+        alert.put(METRON_ESCALATION_USER_FIELD, user);
+        alert.put(METRON_ESCALATION_TIMESTAMP_FIELD, now);
+
+        // serialize the alert and push it to the escalation topic
+        String message = JSONUtils.INSTANCE.toJSON(alert, false);
+        kafkaService.produceMessage(topic, message);
       }
     } catch (JsonProcessingException e) {
       throw new RestException(e);
@@ -127,5 +145,16 @@ public class AlertsUIServiceImpl implements AlertsUIService {
       success = false;
     }
     return success;
+  }
+
+  /**
+   * Set the {@link Clock} used by this service.
+   *
+   * <p>Calling this method is only needed to override the default behavior. This is useful when testing.
+   *
+   * @param clock
+   */
+  public void setClock(Clock clock) {
+    this.clock = clock;
   }
 }

--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/service/impl/AlertsUIServiceImpl.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/service/impl/AlertsUIServiceImpl.java
@@ -78,7 +78,7 @@ public class AlertsUIServiceImpl implements AlertsUIService {
     String user = SecurityUtils.getCurrentUser();
     String topic = environment.getProperty(KAFKA_TOPICS_ESCALATION_PROPERTY);
     Long now = clock.currentTimeMillis();
-    LOG.debug("Escalating {} alert(s): user={}, topic={}, timestamp={}", alerts.size(), user, topic, now);
+    LOG.info("Escalating {} alert(s): user={}, topic={}, timestamp={}", alerts.size(), user, topic, now);
 
     try {
       for (Map<String, Object> alert : alerts) {

--- a/metron-interface/metron-rest/src/test/java/org/apache/metron/rest/service/impl/AlertsUIServiceImplTest.java
+++ b/metron-interface/metron-rest/src/test/java/org/apache/metron/rest/service/impl/AlertsUIServiceImplTest.java
@@ -118,41 +118,16 @@ public class AlertsUIServiceImplTest {
 
     // create an alert along with the expected escalation message that is sent to kafka
     final Map<String, Object> alert1 = mapOf(field, value1);
-    String escalationMessage1 = escalatedMessage(field, value1, user1, clock.currentTimeMillis());
+    String escalationMessage1 = escalationMessage(field, value1, user1, clock.currentTimeMillis());
 
     final Map<String, Object> alert2 = mapOf(field, value2);
-    String escalationMessage2 = escalatedMessage(field, value2, user1, clock.currentTimeMillis());
+    String escalationMessage2 = escalationMessage(field, value2, user1, clock.currentTimeMillis());
 
     // escalate the alerts and validate
     alertsUIService.escalateAlerts(Arrays.asList(alert1, alert2));
     verify(kafkaService).produceMessage(escalationTopic, escalationMessage1);
     verify(kafkaService).produceMessage(escalationTopic, escalationMessage2);
     verifyZeroInteractions(kafkaService);
-  }
-
-  private Map<String, Object> mapOf(String key, Object value) {
-    Map<String, Object> map = new HashMap<>();
-    map.put(key, value);
-    return map;
-  }
-
-  /**
-   * Defines what the message sent to Kafka should look-like when an alert is escalated.
-   *
-   * @param field The field name.
-   * @param value The value of the field.
-   * @param user The user who escalated the alert.
-   * @param timestamp When the alert was escalated.
-   * @return The escalated message.
-   */
-  private String escalatedMessage(String field, String value, String user, Long timestamp) {
-    return String.format("{\"%s\":\"%s\",\"%s\":\"%s\",\"%s\":%d}",
-            field,
-            value,
-            MetronRestConstants.METRON_ESCALATION_USER_FIELD,
-            user,
-            MetronRestConstants.METRON_ESCALATION_TIMESTAMP_FIELD,
-            timestamp);
   }
 
   @Test
@@ -213,5 +188,30 @@ public class AlertsUIServiceImplTest {
 
     verify(userSettingsClient, times(2)).delete(user1, AlertsUIServiceImpl.ALERT_USER_SETTING_TYPE);
     verifyNoMoreInteractions(userSettingsClient);
+  }
+
+  /**
+   * Defines what the message sent to Kafka should look-like when an alert is escalated.
+   *
+   * @param field The field name.
+   * @param value The value of the field.
+   * @param user The user who escalated the alert.
+   * @param timestamp When the alert was escalated.
+   * @return The escalated message.
+   */
+  private String escalationMessage(String field, String value, String user, Long timestamp) {
+    return String.format("{\"%s\":\"%s\",\"%s\":\"%s\",\"%s\":%d}",
+            field,
+            value,
+            MetronRestConstants.METRON_ESCALATION_USER_FIELD,
+            user,
+            MetronRestConstants.METRON_ESCALATION_TIMESTAMP_FIELD,
+            timestamp);
+  }
+
+  private Map<String, Object> mapOf(String key, Object value) {
+    Map<String, Object> map = new HashMap<>();
+    map.put(key, value);
+    return map;
   }
 }

--- a/metron-interface/metron-rest/src/test/java/org/apache/metron/rest/service/impl/AlertsUIServiceImplTest.java
+++ b/metron-interface/metron-rest/src/test/java/org/apache/metron/rest/service/impl/AlertsUIServiceImplTest.java
@@ -41,6 +41,7 @@ import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.adrianwalker.multilinestring.Multiline;
+import org.apache.metron.common.system.FakeClock;
 import org.apache.metron.rest.MetronRestConstants;
 import org.apache.metron.rest.model.AlertsUIUserSettings;
 import org.apache.metron.hbase.client.UserSettingsClient;
@@ -79,9 +80,10 @@ public class AlertsUIServiceImplTest {
   private KafkaService kafkaService;
   private Environment environment;
   private UserSettingsClient userSettingsClient;
-  private AlertsUIService alertsUIService;
+  private AlertsUIServiceImpl alertsUIService;
   private String user1 = "user1";
   private String user2 = "user2";
+  private FakeClock clock;
 
   @SuppressWarnings("unchecked")
   @Before
@@ -90,6 +92,11 @@ public class AlertsUIServiceImplTest {
     environment = mock(Environment.class);
     userSettingsClient = mock(UserSettingsClient.class);
     alertsUIService = new AlertsUIServiceImpl(kafkaService, environment, userSettingsClient);
+
+    // use a fake clock for testing
+    clock = new FakeClock();
+    clock.elapseSeconds(1000);
+    alertsUIService.setClock(clock);
 
     // assume user1 is logged in for tests
     Authentication authentication = Mockito.mock(Authentication.class);
@@ -100,22 +107,52 @@ public class AlertsUIServiceImplTest {
   }
 
   @Test
-  public void produceMessageShouldProperlyProduceMessage() throws Exception {
-    String escalationTopic = "escalation";
-    final Map<String, Object> message1 = new HashMap<>();
-    message1.put("field", "value1");
-    final Map<String, Object> message2 = new HashMap<>();
-    message2.put("field", "value2");
-    List<Map<String, Object>> messages = Arrays.asList(message1, message2);
+  public void escalateAlertShouldSendMessageToKafka() throws Exception {
+    final String field = "field";
+    final String value1 = "value1";
+    final String value2 = "value2";
+
+    // define the escalation topic
+    final String escalationTopic = "escalation";
     when(environment.getProperty(MetronRestConstants.KAFKA_TOPICS_ESCALATION_PROPERTY)).thenReturn(escalationTopic);
 
-    alertsUIService.escalateAlerts(messages);
+    // create an alert along with the expected escalation message that is sent to kafka
+    final Map<String, Object> alert1 = mapOf(field, value1);
+    String escalationMessage1 = escalatedMessage(field, value1, user1, clock.currentTimeMillis());
 
-    String expectedMessage1 = "{\"field\":\"value1\"}";
-    String expectedMessage2 = "{\"field\":\"value2\"}";
-    verify(kafkaService).produceMessage("escalation", expectedMessage1);
-    verify(kafkaService).produceMessage("escalation", expectedMessage2);
+    final Map<String, Object> alert2 = mapOf(field, value2);
+    String escalationMessage2 = escalatedMessage(field, value2, user1, clock.currentTimeMillis());
+
+    // escalate the alerts and validate
+    alertsUIService.escalateAlerts(Arrays.asList(alert1, alert2));
+    verify(kafkaService).produceMessage(escalationTopic, escalationMessage1);
+    verify(kafkaService).produceMessage(escalationTopic, escalationMessage2);
     verifyZeroInteractions(kafkaService);
+  }
+
+  private Map<String, Object> mapOf(String key, Object value) {
+    Map<String, Object> map = new HashMap<>();
+    map.put(key, value);
+    return map;
+  }
+
+  /**
+   * Defines what the message sent to Kafka should look-like when an alert is escalated.
+   *
+   * @param field The field name.
+   * @param value The value of the field.
+   * @param user The user who escalated the alert.
+   * @param timestamp When the alert was escalated.
+   * @return The escalated message.
+   */
+  private String escalatedMessage(String field, String value, String user, Long timestamp) {
+    return String.format("{\"%s\":\"%s\",\"%s\":\"%s\",\"%s\":%d}",
+            field,
+            value,
+            MetronRestConstants.METRON_ESCALATION_USER_FIELD,
+            user,
+            MetronRestConstants.METRON_ESCALATION_TIMESTAMP_FIELD,
+            timestamp);
   }
 
   @Test

--- a/metron-interface/metron-rest/src/test/resources/log4j.properties
+++ b/metron-interface/metron-rest/src/test/resources/log4j.properties
@@ -14,3 +14,6 @@ log4j.rootLogger=ERROR, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd'T'HH:mm:ss.SSS} %-5p [%c] - %m%n
+
+# uncomment the following line to enable debug
+#log4j.logger.org.apache.metron.rest=DEBUG


### PR DESCRIPTION
When an alert is escalated in the Alerts UI, the escalation should be attributable to a user.  This PR ensures that an escalation can be attributed to the user who initiated the escalation.

## Changes

When an alert is escalated, the alert is serialized and pushed to the escalation topic in Kafka.  The username and a timestamp should be appended to this escalation message.  The following two fields contain this information.
* `metron_escalation_user`: The name of the user who escalated the alert.
* `metron_escalation_timestamp`: A timestamp in epoch milliseconds indicating when the alert was escalated.

This does not change the alert stored in the Indexer; Elasticsearch or Solr.

This adds some logging around alert escalation.

## Testing

1. Spin-up the development environment.

1. Login to the Alerts UI.

1. Select an alert then click on Actions > Escalate.

    ![screen shot 2018-09-27 at 1 43 03 pm](https://user-images.githubusercontent.com/2475409/46164286-9c9ac000-c25b-11e8-978c-5fb2976d1abc.png)

1. Launch the Stellar REPL.
    ```
    source /etc/default/metron
    $METRON_HOME/bin/stellar -z $ZOOKEEPER
    ```

1. Retrieve the alert from the topic.
    ```
    [Stellar]>>> KAFKA_SEEK(topic, 0,0)
    {"source":{"bro_timestamp":"1538068463.909267","ip_dst_port":8080,"threatinteljoinbolt:joiner:ts":"1538068464723","enrichmentsplitterbolt:splitter:begin:ts":"1538068464711","enrichmentjoinbolt:joiner:ts":"1538068464716","adapter:geoadapter:begin:ts":"1538068464714","uid":"CUrRne3iLIxXavQtci","trans_depth":183,"protocol":"http","source:type":"bro","adapter:threatinteladapter:end:ts":"1538068464721","original_string":"HTTP | id.orig_p:50451 method:GET request_body_len:0 id.resp_p:8080 uri:/api/v1/clusters/metron_cluster?fields=Clusters/health_report,Clusters/total_hosts,alerts_summary_hosts&minimal_response=true&_=1484169141927 tags:[] uid:CUrRne3iLIxXavQtci referrer:http://node1:8080/ trans_depth:183 host:node1 id.orig_h:192.168.66.1 response_body_len:0 user_agent:Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 Safari/537.36 ts:1538068463.909267 id.resp_h:192.168.66.121","ip_dst_addr":"192.168.66.121","adapter:hostfromjsonlistadapter:end:ts":"1538068464714","host":"node1","adapter:geoadapter:end:ts":"1538068464714","ip_src_addr":"192.168.66.1","threatintelsplitterbolt:splitter:end:ts":"1538068464719","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 Safari/537.36","timestamp":1538068463909,"method":"GET","enrichmentsplitterbolt:splitter:end:ts":"1538068464711","request_body_len":0,"adapter:hostfromjsonlistadapter:begin:ts":"1538068464714","uri":"/api/v1/clusters/metron_cluster?fields=Clusters/health_report,Clusters/total_hosts,alerts_summary_hosts&minimal_response=true&_=1484169141927","tags":[],"referrer":"http://node1:8080/","ip_src_port":50451,"threatintelsplitterbolt:splitter:begin:ts":"1538068464719","adapter:threatinteladapter:begin:ts":"1538068464721","guid":"a382fe8a-ee4c-4458-af24-d941b555ac7a","response_body_len":0,"alert_status":"ESCALATE"},"metron_escalation_user":"user","metron_escalation_timestamp":1538068536386}
    ```

1. Confirm that the message has the new `metron_escalation_user` and `metron_escalation_timestamp` field.  Just to be clear, here is the same JSON pretty-printed.
    ```
    {
      "source": {
        "bro_timestamp": "1538068463.909267",
        "ip_dst_port": 8080,
        "threatinteljoinbolt:joiner:ts": "1538068464723",
        "enrichmentsplitterbolt:splitter:begin:ts": "1538068464711",
        "enrichmentjoinbolt:joiner:ts": "1538068464716",
        "adapter:geoadapter:begin:ts": "1538068464714",
        "uid": "CUrRne3iLIxXavQtci",
        "trans_depth": 183,
        "protocol": "http",
        "source:type": "bro",
        "adapter:threatinteladapter:end:ts": "1538068464721",
        "original_string": "HTTP | id.orig_p:50451 method:GET request_body_len:0 id.resp_p:8080 uri:/api/v1/clusters/metron_cluster?fields=Clusters/health_report,Clusters/total_hosts,alerts_summary_hosts&minimal_response=true&_=1484169141927 tags:[] uid:CUrRne3iLIxXavQtci referrer:http://node1:8080/ trans_depth:183 host:node1 id.orig_h:192.168.66.1 response_body_len:0 user_agent:Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 Safari/537.36 ts:1538068463.909267 id.resp_h:192.168.66.121",
        "ip_dst_addr": "192.168.66.121",
        "adapter:hostfromjsonlistadapter:end:ts": "1538068464714",
        "host": "node1",
        "adapter:geoadapter:end:ts": "1538068464714",
        "ip_src_addr": "192.168.66.1",
        "threatintelsplitterbolt:splitter:end:ts": "1538068464719",
        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 Safari/537.36",
        "timestamp": 1538068463909,
        "method": "GET",
        "enrichmentsplitterbolt:splitter:end:ts": "1538068464711",
        "request_body_len": 0,
        "adapter:hostfromjsonlistadapter:begin:ts": "1538068464714",
        "uri": "/api/v1/clusters/metron_cluster?fields=Clusters/health_report,Clusters/total_hosts,alerts_summary_hosts&minimal_response=true&_=1484169141927",
        "tags": [],
        "referrer": "http://node1:8080/",
        "ip_src_port": 50451,
        "threatintelsplitterbolt:splitter:begin:ts": "1538068464719",
        "adapter:threatinteladapter:begin:ts": "1538068464721",
        "guid": "a382fe8a-ee4c-4458-af24-d941b555ac7a",
        "response_body_len": 0,
        "alert_status": "ESCALATE"
      },
      "metron_escalation_user": "user",
      "metron_escalation_timestamp": 1538068536386
    }
    ```

## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
