### PR TITLE
METRON-1809 Support Column Oriented Input with Batch Profiler

### DIFF
--- a/metron-analytics/metron-profiler-spark/README.md
+++ b/metron-analytics/metron-profiler-spark/README.md
@@ -234,6 +234,31 @@ The Profiler can consume archived telemetry stored in a variety of input formats
 
 1. If additional options are required for your input format, then use the [`--reader`](#--reader) command-line argument when launching the Batch Profiler as [described here](#advanced-usage).
 
+### Common Formats
+
+The following examples highlight the configuration values needed to read telemetry stored in common formats.  These values should be defined in the Profiler properties (see `--config`).
+
+#### JSON
+```
+profiler.batch.input.reader=TEXT
+profiler.batch.input.format=text
+profiler.batch.input.path=/path/to/*.json
+```
+
+#### ORC
+```
+profiler.batch.input.reader=COLUMNAR
+profiler.batch.input.format=org.apache.spark.sql.execution.datasources.orc
+profiler.batch.input.path=/path/to/orc/
+```
+
+#### Parquet
+```
+profiler.batch.input.reader=COLUMNAR
+profiler.batch.input.format=parquet
+profiler.batch.input.path=/path/to/parquet/
+```
+
 
 ## Configuring the Profiler
 
@@ -245,7 +270,7 @@ You can store both settings for the Profiler along with settings for Spark in th
 |---                                                                            |---
 | [`profiler.batch.input.path`](#profilerbatchinputpath)                        | The path to the input data read by the Batch Profiler.
 | [`profiler.batch.input.format`](#profilerbatchinputformat)                    | The format of the input data read by the Batch Profiler.
-| [`profiler.batch.input.reader`](#profiler.batch.input.reader)                 | The telemetry reader used to read the input data.
+| [`profiler.batch.input.reader`](#profilerbatchinputreader)                    | The telemetry reader used to read the input data.
 | [`profiler.batch.input.begin`](#profilerbatchinputend)                        | Only messages with a timestamp after this will be profiled.
 | [`profiler.batch.input.end`](#profilerbatchinputbegin)                        | Only messages with a timestamp before this will be profiled.
 | [`profiler.period.duration`](#profilerperiodduration)                         | The duration of each profile period.  
@@ -268,9 +293,13 @@ The format of the input data read by the Batch Profiler.
 
 ### `profiler.batch.input.reader`
 
-*Default*: TEXT_READER
+*Default*: TEXT
 
-The format of the input data read by the Batch Profiler.
+Defines how the input data is treated when read.  There are two options.
+
+ * `TEXT` Consumes input data stored as raw text.  Should be used for JSON and CSV formatted input data.
+ 
+ * `COLUMNAR` Consumes input data stored in columnar formats.  Should be used for ORC and Parquet formatted input data.
 
 ### `profiler.batch.input.begin`
 

--- a/metron-analytics/metron-profiler-spark/README.md
+++ b/metron-analytics/metron-profiler-spark/README.md
@@ -245,6 +245,7 @@ You can store both settings for the Profiler along with settings for Spark in th
 |---                                                                            |---
 | [`profiler.batch.input.path`](#profilerbatchinputpath)                        | The path to the input data read by the Batch Profiler.
 | [`profiler.batch.input.format`](#profilerbatchinputformat)                    | The format of the input data read by the Batch Profiler.
+| [`profiler.batch.input.reader`](#profiler.batch.input.reader)                 | The telemetry reader used to read the input data.
 | [`profiler.batch.input.begin`](#profilerbatchinputend)                        | Only messages with a timestamp after this will be profiled.
 | [`profiler.batch.input.end`](#profilerbatchinputbegin)                        | Only messages with a timestamp before this will be profiled.
 | [`profiler.period.duration`](#profilerperiodduration)                         | The duration of each profile period.  
@@ -262,6 +263,12 @@ The path to the input data read by the Batch Profiler.
 ### `profiler.batch.input.format`
 
 *Default*: text
+
+The format of the input data read by the Batch Profiler.
+
+### `profiler.batch.input.reader`
+
+*Default*: TEXT_READER
 
 The format of the input data read by the Batch Profiler.
 

--- a/metron-analytics/metron-profiler-spark/README.md
+++ b/metron-analytics/metron-profiler-spark/README.md
@@ -284,7 +284,7 @@ The path to the input data read by the Batch Profiler.
 
 ### `profiler.batch.input.reader`
 
-*Default*: TEXT
+*Default*: json
 
 Defines how the input data is treated when read.  The value is not case sensitive so `JSON` and `json` are equivalent.
 

--- a/metron-analytics/metron-profiler-spark/README.md
+++ b/metron-analytics/metron-profiler-spark/README.md
@@ -240,21 +240,19 @@ The following examples highlight the configuration values needed to read telemet
 
 ##### JSON
 ```
-profiler.batch.input.reader=TEXT
+profiler.batch.input.reader=json
 profiler.batch.input.path=/path/to/json/
 ```
 
 ##### [Apache ORC](https://orc.apache.org/)
 ```
-profiler.batch.input.reader=COLUMNAR
-profiler.batch.input.format=org.apache.spark.sql.execution.datasources.orc
+profiler.batch.input.reader=orc
 profiler.batch.input.path=/path/to/orc/
 ```
 
 ##### [Apache Parquet](http://parquet.apache.org/)
 ```
-profiler.batch.input.reader=COLUMNAR
-profiler.batch.input.format=parquet
+profiler.batch.input.reader=parquet
 profiler.batch.input.path=/path/to/parquet/
 ```
 

--- a/metron-analytics/metron-profiler-spark/README.md
+++ b/metron-analytics/metron-profiler-spark/README.md
@@ -162,13 +162,13 @@ ${SPARK_HOME}/bin/spark-submit \
 
 The Batch Profiler accepts the following arguments when run from the command line as shown above.  All arguments following the Profiler jar are passed to the Profiler.  All argument preceeding the Profiler jar are passed to Spark.
 
-| Argument         | Description
-|---               |---
-| -p, --profiles   | Path to the profile definitions.
-| -c, --config     | Path to the profiler properties file.
-| -g, --globals    | Path to the Stellar global config file.
-| -r, --reader     | Path to properties for the DataFrameReader.
-| -h, --help       | Print the help text.
+| Argument                              | Description
+|---                                    |---
+| [`-p`, `--profiles`](#--profiles)     | Path to the profile definitions.
+| [`-c`, `--config`](#--config)         | Path to the profiler properties file.
+| [`-g`, `--globals`](#--globals)       | Path to the Stellar global config file.
+| [`-r`, `--reader`](#--reader)         | Path to properties for the DataFrameReader.
+| `-h`, `--help`                        | Print the help text.
 
 #### `--profiles`
 
@@ -236,22 +236,22 @@ The Profiler can consume archived telemetry stored in a variety of input formats
 
 #### Common Formats
 
-The following examples highlight the configuration values needed to read telemetry stored in common formats.  These values should be defined in the Profiler properties (see `--config`).
+The following examples highlight the configuration values needed to read telemetry stored in common formats.  These values should be defined in the Profiler properties (see [`--config`](#--config)).
 
 ##### JSON
 ```
 profiler.batch.input.reader=TEXT
-profiler.batch.input.path=/path/to/*.json
+profiler.batch.input.path=/path/to/json/
 ```
 
-##### ORC
+##### [Apache ORC](https://orc.apache.org/)
 ```
 profiler.batch.input.reader=COLUMNAR
 profiler.batch.input.format=org.apache.spark.sql.execution.datasources.orc
 profiler.batch.input.path=/path/to/orc/
 ```
 
-##### Parquet
+##### [Apache Parquet](http://parquet.apache.org/)
 ```
 profiler.batch.input.reader=COLUMNAR
 profiler.batch.input.format=parquet
@@ -297,9 +297,9 @@ The format of the input data read by the Batch Profiler.
 Defines how the input data is treated when read.  There are two options.
 
  * `TEXT` Consumes input data stored as raw text.  Should be used for JSON and CSV formatted input data.
- 
+
  * `COLUMNAR` Consumes input data stored in columnar formats.  Should be used for ORC and Parquet formatted input data.
- 
+
 See [Common Formats](#common-formats) for further information.
 
 ### `profiler.batch.input.begin`

--- a/metron-analytics/metron-profiler-spark/README.md
+++ b/metron-analytics/metron-profiler-spark/README.md
@@ -241,7 +241,6 @@ The following examples highlight the configuration values needed to read telemet
 ##### JSON
 ```
 profiler.batch.input.reader=TEXT
-profiler.batch.input.format=text
 profiler.batch.input.path=/path/to/*.json
 ```
 

--- a/metron-analytics/metron-profiler-spark/README.md
+++ b/metron-analytics/metron-profiler-spark/README.md
@@ -234,25 +234,25 @@ The Profiler can consume archived telemetry stored in a variety of input formats
 
 1. If additional options are required for your input format, then use the [`--reader`](#--reader) command-line argument when launching the Batch Profiler as [described here](#advanced-usage).
 
-### Common Formats
+#### Common Formats
 
 The following examples highlight the configuration values needed to read telemetry stored in common formats.  These values should be defined in the Profiler properties (see `--config`).
 
-#### JSON
+##### JSON
 ```
 profiler.batch.input.reader=TEXT
 profiler.batch.input.format=text
 profiler.batch.input.path=/path/to/*.json
 ```
 
-#### ORC
+##### ORC
 ```
 profiler.batch.input.reader=COLUMNAR
 profiler.batch.input.format=org.apache.spark.sql.execution.datasources.orc
 profiler.batch.input.path=/path/to/orc/
 ```
 
-#### Parquet
+##### Parquet
 ```
 profiler.batch.input.reader=COLUMNAR
 profiler.batch.input.format=parquet
@@ -300,6 +300,8 @@ Defines how the input data is treated when read.  There are two options.
  * `TEXT` Consumes input data stored as raw text.  Should be used for JSON and CSV formatted input data.
  
  * `COLUMNAR` Consumes input data stored in columnar formats.  Should be used for ORC and Parquet formatted input data.
+ 
+See [Common Formats](#common-formats) for further information.
 
 ### `profiler.batch.input.begin`
 

--- a/metron-analytics/metron-profiler-spark/README.md
+++ b/metron-analytics/metron-profiler-spark/README.md
@@ -266,8 +266,8 @@ You can store both settings for the Profiler along with settings for Spark in th
 | Setting                                                                       | Description
 |---                                                                            |---
 | [`profiler.batch.input.path`](#profilerbatchinputpath)                        | The path to the input data read by the Batch Profiler.
-| [`profiler.batch.input.format`](#profilerbatchinputformat)                    | The format of the input data read by the Batch Profiler.
 | [`profiler.batch.input.reader`](#profilerbatchinputreader)                    | The telemetry reader used to read the input data.
+| [`profiler.batch.input.format`](#profilerbatchinputformat)                    | The format of the input data read by the Batch Profiler.
 | [`profiler.batch.input.begin`](#profilerbatchinputend)                        | Only messages with a timestamp after this will be profiled.
 | [`profiler.batch.input.end`](#profilerbatchinputbegin)                        | Only messages with a timestamp before this will be profiled.
 | [`profiler.period.duration`](#profilerperiodduration)                         | The duration of each profile period.  
@@ -282,23 +282,25 @@ You can store both settings for the Profiler along with settings for Spark in th
 
 The path to the input data read by the Batch Profiler.
 
-### `profiler.batch.input.format`
-
-*Default*: text
-
-The format of the input data read by the Batch Profiler.
-
 ### `profiler.batch.input.reader`
 
 *Default*: TEXT
 
-Defines how the input data is treated when read.  There are two options.
+Defines how the input data is treated when read.  The value is not case sensitive so `JSON` and `json` are equivalent.
 
- * `TEXT` Consumes input data stored as raw text.  Should be used for JSON and CSV formatted input data.
-
- * `COLUMNAR` Consumes input data stored in columnar formats.  Should be used for ORC and Parquet formatted input data.
+ * `json`: Read text/json formatted telemetry
+ * `orc`: Read [Apache ORC](https://orc.apache.org/) formatted telemetry
+ * `parquet`: Read [Apache Parquet](http://parquet.apache.org/) formatted telemetry
+ * `text` Consumes input data stored as raw text. Should be defined along with [`profiler.batch.input.format`](#profilerbatchinputformat). Only use if the input format is not directly supported like `json`.
+ * `columnar` Consumes input data stored in columnar formats. Should be defined along with [`profiler.batch.input.format`](#profilerbatchinputformat).  Only use if the input format is not directly supported like `json`.
 
 See [Common Formats](#common-formats) for further information.
+
+### `profiler.batch.input.format`
+
+*Default*: text
+
+The format of the input data read by the Batch Profiler. This is optional and not required in most cases. For example, this property is not required when [`profiler.batch.input.reader`](#profilerbatchinputreader)  is `json`, `orc`, or `parquet`.
 
 ### `profiler.batch.input.begin`
 

--- a/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/BatchProfiler.java
+++ b/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/BatchProfiler.java
@@ -79,9 +79,7 @@ public class BatchProfiler implements Serializable {
 
     LOG.debug("Building {} profile(s)", profiles.getProfiles().size());
     Map<String, String> globals = Maps.fromProperties(globalProperties);
-
-    // TODO make sure all telemetry input properties come from the same property file
-
+    
     // fetch the archived telemetry using the input reader
     TelemetryReader reader = TelemetryReaders.create(TELEMETRY_INPUT_READER.get(profilerProps, String.class));
     Dataset<String> telemetry = reader.read(spark, profilerProps, readerProps);

--- a/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/BatchProfiler.java
+++ b/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/BatchProfiler.java
@@ -26,6 +26,8 @@ import org.apache.metron.profiler.spark.function.GroupByPeriodFunction;
 import org.apache.metron.profiler.spark.function.HBaseWriterFunction;
 import org.apache.metron.profiler.spark.function.MessageRouterFunction;
 import org.apache.metron.profiler.spark.function.ProfileBuilderFunction;
+import org.apache.metron.profiler.spark.reader.TelemetryReader;
+import org.apache.metron.profiler.spark.reader.TelemetryReaders;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.SparkSession;
@@ -40,8 +42,7 @@ import java.util.Properties;
 
 import static org.apache.metron.profiler.spark.BatchProfilerConfig.TELEMETRY_INPUT_BEGIN;
 import static org.apache.metron.profiler.spark.BatchProfilerConfig.TELEMETRY_INPUT_END;
-import static org.apache.metron.profiler.spark.BatchProfilerConfig.TELEMETRY_INPUT_FORMAT;
-import static org.apache.metron.profiler.spark.BatchProfilerConfig.TELEMETRY_INPUT_PATH;
+import static org.apache.metron.profiler.spark.BatchProfilerConfig.TELEMETRY_INPUT_READER;
 import static org.apache.spark.sql.functions.sum;
 
 /**
@@ -54,6 +55,7 @@ public class BatchProfiler implements Serializable {
   protected static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private TimestampParser timestampParser;
+  private TelemetryReader reader;
 
   public BatchProfiler() {
     this.timestampParser = new TimestampParser();
@@ -77,17 +79,12 @@ public class BatchProfiler implements Serializable {
 
     LOG.debug("Building {} profile(s)", profiles.getProfiles().size());
     Map<String, String> globals = Maps.fromProperties(globalProperties);
-    String inputFormat = TELEMETRY_INPUT_FORMAT.get(profilerProps, String.class);
-    String inputPath = TELEMETRY_INPUT_PATH.get(profilerProps, String.class);
-    LOG.debug("Loading telemetry from '{}'", inputPath);
 
-    // fetch the archived telemetry
-    Dataset<String> telemetry = spark
-            .read()
-            .options(Maps.fromProperties(readerProps))
-            .format(inputFormat)
-            .load(inputPath)
-            .as(Encoders.STRING());
+    // TODO make sure all telemetry input properties come from the same property file
+
+    // fetch the archived telemetry using the input reader
+    TelemetryReader reader = TelemetryReaders.create(TELEMETRY_INPUT_READER.get(readerProps, String.class));
+    Dataset<String> telemetry = reader.read(spark, readerProps);
     LOG.debug("Found {} telemetry record(s)", telemetry.cache().count());
 
     // find all routes for each message

--- a/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/BatchProfiler.java
+++ b/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/BatchProfiler.java
@@ -83,8 +83,8 @@ public class BatchProfiler implements Serializable {
     // TODO make sure all telemetry input properties come from the same property file
 
     // fetch the archived telemetry using the input reader
-    TelemetryReader reader = TelemetryReaders.create(TELEMETRY_INPUT_READER.get(readerProps, String.class));
-    Dataset<String> telemetry = reader.read(spark, readerProps);
+    TelemetryReader reader = TelemetryReaders.create(TELEMETRY_INPUT_READER.get(profilerProps, String.class));
+    Dataset<String> telemetry = reader.read(spark, profilerProps, readerProps);
     LOG.debug("Found {} telemetry record(s)", telemetry.cache().count());
 
     // find all routes for each message

--- a/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/BatchProfilerConfig.java
+++ b/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/BatchProfilerConfig.java
@@ -25,6 +25,7 @@ import org.apache.metron.stellar.common.utils.ConversionUtils;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.apache.metron.profiler.spark.reader.TelemetryReaders.JSON;
 import static org.apache.metron.profiler.spark.reader.TelemetryReaders.TEXT;
 
 /**
@@ -46,9 +47,9 @@ public enum BatchProfilerConfig {
 
   HBASE_WRITE_DURABILITY("profiler.hbase.durability", Durability.USE_DEFAULT, Durability.class),
 
-  TELEMETRY_INPUT_READER("profiler.batch.input.reader", TEXT.toString(), String.class),
+  TELEMETRY_INPUT_READER("profiler.batch.input.reader", JSON.toString(), String.class),
 
-  TELEMETRY_INPUT_FORMAT("profiler.batch.input.format", "text", String.class),
+  TELEMETRY_INPUT_FORMAT("profiler.batch.input.format", "", String.class),
 
   TELEMETRY_INPUT_PATH("profiler.batch.input.path", "hdfs://localhost:8020/apps/metron/indexing/indexed/*/*", String.class),
 

--- a/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/BatchProfilerConfig.java
+++ b/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/BatchProfilerConfig.java
@@ -25,6 +25,8 @@ import org.apache.metron.stellar.common.utils.ConversionUtils;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.apache.metron.profiler.spark.reader.TelemetryReaders.TEXT_READER;
+
 /**
  * Defines the configuration values recognized by the Batch Profiler.
  */
@@ -44,9 +46,11 @@ public enum BatchProfilerConfig {
 
   HBASE_WRITE_DURABILITY("profiler.hbase.durability", Durability.USE_DEFAULT, Durability.class),
 
+  TELEMETRY_INPUT_READER("profiler.batch.input.reader", TEXT_READER.toString(), String.class),
+
   TELEMETRY_INPUT_FORMAT("profiler.batch.input.format", "text", String.class),
 
-  TELEMETRY_INPUT_PATH("profiler.batch.input.path", "hdfs://localhost:9000/apps/metron/indexing/indexed/*/*", String.class),
+  TELEMETRY_INPUT_PATH("profiler.batch.input.path", "hdfs://localhost:8020/apps/metron/indexing/indexed/*/*", String.class),
 
   TELEMETRY_INPUT_BEGIN("profiler.batch.input.begin", "", String.class),
 

--- a/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/BatchProfilerConfig.java
+++ b/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/BatchProfilerConfig.java
@@ -25,7 +25,7 @@ import org.apache.metron.stellar.common.utils.ConversionUtils;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.apache.metron.profiler.spark.reader.TelemetryReaders.TEXT_READER;
+import static org.apache.metron.profiler.spark.reader.TelemetryReaders.TEXT;
 
 /**
  * Defines the configuration values recognized by the Batch Profiler.
@@ -46,7 +46,7 @@ public enum BatchProfilerConfig {
 
   HBASE_WRITE_DURABILITY("profiler.hbase.durability", Durability.USE_DEFAULT, Durability.class),
 
-  TELEMETRY_INPUT_READER("profiler.batch.input.reader", TEXT_READER.toString(), String.class),
+  TELEMETRY_INPUT_READER("profiler.batch.input.reader", TEXT.toString(), String.class),
 
   TELEMETRY_INPUT_FORMAT("profiler.batch.input.format", "text", String.class),
 

--- a/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/reader/ColumnEncodedTelemetryReader.java
+++ b/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/reader/ColumnEncodedTelemetryReader.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.metron.profiler.spark.reader;
+
+import com.google.common.collect.Maps;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.SparkSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Properties;
+
+import static org.apache.metron.profiler.spark.BatchProfilerConfig.TELEMETRY_INPUT_FORMAT;
+import static org.apache.metron.profiler.spark.BatchProfilerConfig.TELEMETRY_INPUT_PATH;
+
+/**
+ * Reads in a {@link Dataset} then converts all of the {@link Dataset}'s column
+ * into a single JSON-formatted string.
+ *
+ * <p>This {@link TelemetryReader} is useful for any column-oriented format that
+ * is supported by Spark.  For example, ORC and Parquet.
+ */
+public class ColumnEncodedTelemetryReader implements TelemetryReader {
+
+  protected static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  @Override
+  public Dataset<String> read(SparkSession spark, Properties properties) {
+    String inputFormat = TELEMETRY_INPUT_FORMAT.get(properties, String.class);
+    String inputPath = TELEMETRY_INPUT_PATH.get(properties, String.class);
+    LOG.debug("Loading telemetry; inputPath={}, inputFormat={}", inputPath, inputFormat);
+
+    return spark
+            .read()
+            .options(Maps.fromProperties(properties))
+            .format(inputFormat)
+            .load(inputPath)
+            .toJSON();
+  }
+}

--- a/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/reader/ColumnEncodedTelemetryReader.java
+++ b/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/reader/ColumnEncodedTelemetryReader.java
@@ -42,10 +42,36 @@ public class ColumnEncodedTelemetryReader implements TelemetryReader {
 
   protected static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
+  /**
+   * The input format to use when reading telemetry.
+   */
+  private String inputFormat;
+
+  /**
+   * Creates a {@link ColumnEncodedTelemetryReader}.
+   *
+   * <p>The input format used to read the telemetry is defined by the
+   * BatchProfilerConfig.TELEMETRY_INPUT_PATH property.
+   */
+  public ColumnEncodedTelemetryReader() {
+    this.inputFormat = null;
+  }
+
+  /**
+   * Creates a {@link ColumnEncodedTelemetryReader}.
+   *
+   * @param inputFormat The input format to use when reading telemetry.
+   */
+  public ColumnEncodedTelemetryReader(String inputFormat) {
+    this.inputFormat = inputFormat;
+  }
+
   @Override
   public Dataset<String> read(SparkSession spark, Properties profilerProps, Properties readerProps) {
-    String inputFormat = TELEMETRY_INPUT_FORMAT.get(profilerProps, String.class);
     String inputPath = TELEMETRY_INPUT_PATH.get(profilerProps, String.class);
+    if(inputFormat == null) {
+      inputFormat = TELEMETRY_INPUT_FORMAT.get(profilerProps, String.class);
+    }
     LOG.debug("Loading telemetry; inputPath={}, inputFormat={}", inputPath, inputFormat);
 
     return spark

--- a/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/reader/ColumnEncodedTelemetryReader.java
+++ b/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/reader/ColumnEncodedTelemetryReader.java
@@ -43,14 +43,14 @@ public class ColumnEncodedTelemetryReader implements TelemetryReader {
   protected static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @Override
-  public Dataset<String> read(SparkSession spark, Properties properties) {
-    String inputFormat = TELEMETRY_INPUT_FORMAT.get(properties, String.class);
-    String inputPath = TELEMETRY_INPUT_PATH.get(properties, String.class);
+  public Dataset<String> read(SparkSession spark, Properties profilerProps, Properties readerProps) {
+    String inputFormat = TELEMETRY_INPUT_FORMAT.get(profilerProps, String.class);
+    String inputPath = TELEMETRY_INPUT_PATH.get(profilerProps, String.class);
     LOG.debug("Loading telemetry; inputPath={}, inputFormat={}", inputPath, inputFormat);
 
     return spark
             .read()
-            .options(Maps.fromProperties(properties))
+            .options(Maps.fromProperties(readerProps))
             .format(inputFormat)
             .load(inputPath)
             .toJSON();

--- a/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/reader/TelemetryReader.java
+++ b/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/reader/TelemetryReader.java
@@ -22,13 +22,14 @@ package org.apache.metron.profiler.spark.reader;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.SparkSession;
 
+import java.io.Serializable;
 import java.util.Properties;
 
 /**
  * A {@link TelemetryReader} is responsible for creating a {@link Dataset} containing
  * telemetry that can be consumed by the {@link org.apache.metron.profiler.spark.BatchProfiler}.
  */
-public interface TelemetryReader {
+public interface TelemetryReader extends Serializable {
 
   /**
    * Read in the telemetry

--- a/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/reader/TelemetryReader.java
+++ b/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/reader/TelemetryReader.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.metron.profiler.spark.reader;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.SparkSession;
+
+import java.util.Properties;
+
+/**
+ * A {@link TelemetryReader} is responsible for creating a {@link Dataset} containing
+ * telemetry that can be consumed by the {@link org.apache.metron.profiler.spark.BatchProfiler}.
+ */
+public interface TelemetryReader {
+
+  /**
+   * Read in the telemetry
+   *
+   * @param spark The spark session.
+   * @param properties Additional properties for reading in the telemetry.
+   * @return A {@link Dataset} containing archived telemetry.
+   */
+  Dataset<String> read(SparkSession spark, Properties properties);
+}

--- a/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/reader/TelemetryReaders.java
+++ b/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/reader/TelemetryReaders.java
@@ -19,6 +19,7 @@
 
 package org.apache.metron.profiler.spark.reader;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.SparkSession;
 import org.slf4j.Logger;
@@ -33,6 +34,33 @@ import java.util.function.Supplier;
  * {@link org.apache.metron.profiler.spark.BatchProfilerConfig#TELEMETRY_INPUT_READER}.
  */
 public enum TelemetryReaders implements TelemetryReader {
+
+  /**
+   * A {@link TelemetryReader} that is able to consume text/json formatted data.
+   *
+   * <p>This serves as a configuration short-cut for users. The user only needs to define the
+   * {@link org.apache.metron.profiler.spark.BatchProfilerConfig#TELEMETRY_INPUT_READER} property
+   * with this value to consume text/json.
+   */
+  JSON(() -> new TextEncodedTelemetryReader("text")),
+
+  /**
+   * A {@link TelemetryReader} that is able to consume Apache ORC formatted data.
+   *
+   * <p>This serves as a configuration short-cut for users. The user only needs to define the
+   * {@link org.apache.metron.profiler.spark.BatchProfilerConfig#TELEMETRY_INPUT_READER} property
+   * with this value to consume Apache ORC formatted data.
+   */
+  ORC(() -> new ColumnEncodedTelemetryReader("org.apache.spark.sql.execution.datasources.orc")),
+
+  /**
+   * A {@link TelemetryReader} that is able to consume Apache Parquet formatted data.
+   *
+   * <p>This serves as a configuration short-cut for users. The user only needs to define the
+   * {@link org.apache.metron.profiler.spark.BatchProfilerConfig#TELEMETRY_INPUT_READER} property
+   * with this value to consume Apache Parquet formatted data.
+   */
+  PARQUET(() -> new ColumnEncodedTelemetryReader("parquet")),
 
   /**
    * Use a {@link TextEncodedTelemetryReader} by defining the property value as 'TEXT'.
@@ -63,7 +91,8 @@ public enum TelemetryReaders implements TelemetryReader {
     LOG.debug("Creating telemetry reader: telemetryReader={}", propertyValue);
     TelemetryReader reader = null;
     try {
-      TelemetryReaders strategy = TelemetryReaders.valueOf(propertyValue);
+      String key = StringUtils.upperCase(propertyValue);
+      TelemetryReaders strategy = TelemetryReaders.valueOf(key);
       reader = strategy.supplier.get();
 
     } catch(IllegalArgumentException e) {

--- a/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/reader/TelemetryReaders.java
+++ b/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/reader/TelemetryReaders.java
@@ -1,0 +1,69 @@
+package org.apache.metron.profiler.spark.reader;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.SparkSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Properties;
+import java.util.function.Supplier;
+
+/**
+ * Allows a user to easily define the value of the property
+ * {@link org.apache.metron.profiler.spark.BatchProfilerConfig#TELEMETRY_INPUT_READER}.
+ */
+public enum TelemetryReaders implements TelemetryReader {
+
+  /**
+   * Use a {@link TextEncodedTelemetryReader} by defining the property value as 'TEXT_READER'.
+   */
+  TEXT_READER(() -> new TextEncodedTelemetryReader()),
+
+  /**
+   * Use a {@link ColumnEncodedTelemetryReader} by defining the property value as 'COLUMN_READER'.
+   */
+  COLUMN_READER(() -> new ColumnEncodedTelemetryReader());
+
+  static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private Supplier<TelemetryReader> supplier;
+
+  private TelemetryReaders(Supplier<TelemetryReader> supplier) {
+    this.supplier = supplier;
+  }
+
+  /**
+   * Returns a {@link TelemetryReader} based on a property value.
+   *
+   * @param propertyValue The property value.
+   * @return A {@link TelemetryReader}
+   * @throws IllegalArgumentException If the property value is invalid.
+   */
+  public static TelemetryReader create(String propertyValue) {
+    LOG.debug("Using telemetry reader: {}", propertyValue);
+    TelemetryReader reader = null;
+    try {
+      TelemetryReaders strategy = TelemetryReaders.valueOf(propertyValue);
+      reader = strategy.supplier.get();
+
+    } catch(IllegalArgumentException e) {
+      LOG.error("Unexpected telemetry reader: " + propertyValue, e);
+      throw e;
+    }
+
+    return reader;
+  }
+
+  /**
+   * Uses the underlying {@link TelemetryReader} to read in the input telemetry.
+   *
+   * @param spark The spark session.
+   * @param properties Additional properties for reading in the telemetry.
+   * @return A {@link TelemetryReader}.
+   */
+  @Override
+  public Dataset<String> read(SparkSession spark, Properties properties) {
+    return supplier.get().read(spark, properties);
+  }
+}

--- a/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/reader/TelemetryReaders.java
+++ b/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/reader/TelemetryReaders.java
@@ -16,14 +16,14 @@ import java.util.function.Supplier;
 public enum TelemetryReaders implements TelemetryReader {
 
   /**
-   * Use a {@link TextEncodedTelemetryReader} by defining the property value as 'TEXT_READER'.
+   * Use a {@link TextEncodedTelemetryReader} by defining the property value as 'TEXT'.
    */
-  TEXT_READER(() -> new TextEncodedTelemetryReader()),
+  TEXT(() -> new TextEncodedTelemetryReader()),
 
   /**
-   * Use a {@link ColumnEncodedTelemetryReader} by defining the property value as 'COLUMN_READER'.
+   * Use a {@link ColumnEncodedTelemetryReader} by defining the property value as 'COLUMNAR'.
    */
-  COLUMN_READER(() -> new ColumnEncodedTelemetryReader());
+  COLUMNAR(() -> new ColumnEncodedTelemetryReader());
 
   static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
@@ -41,29 +41,22 @@ public enum TelemetryReaders implements TelemetryReader {
    * @throws IllegalArgumentException If the property value is invalid.
    */
   public static TelemetryReader create(String propertyValue) {
-    LOG.debug("Using telemetry reader: {}", propertyValue);
+    LOG.debug("Creating telemetry reader: telemetryReader={}", propertyValue);
     TelemetryReader reader = null;
     try {
       TelemetryReaders strategy = TelemetryReaders.valueOf(propertyValue);
       reader = strategy.supplier.get();
 
     } catch(IllegalArgumentException e) {
-      LOG.error("Unexpected telemetry reader: " + propertyValue, e);
+      LOG.error("Unexpected telemetry reader: telemetryReader=" + propertyValue, e);
       throw e;
     }
 
     return reader;
   }
 
-  /**
-   * Uses the underlying {@link TelemetryReader} to read in the input telemetry.
-   *
-   * @param spark The spark session.
-   * @param properties Additional properties for reading in the telemetry.
-   * @return A {@link TelemetryReader}.
-   */
   @Override
-  public Dataset<String> read(SparkSession spark, Properties properties) {
-    return supplier.get().read(spark, properties);
+  public Dataset<String> read(SparkSession spark, Properties profilerProps, Properties readerProps) {
+    return supplier.get().read(spark, profilerProps, readerProps);
   }
 }

--- a/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/reader/TelemetryReaders.java
+++ b/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/reader/TelemetryReaders.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.apache.metron.profiler.spark.reader;
 
 import org.apache.spark.sql.Dataset;

--- a/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/reader/TextEncodedTelemetryReader.java
+++ b/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/reader/TextEncodedTelemetryReader.java
@@ -41,10 +41,36 @@ public class TextEncodedTelemetryReader implements TelemetryReader {
 
   protected static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
+  /**
+   * The input format to use when reading telemetry.
+   */
+  private String inputFormat;
+
+  /**
+   * Creates a {@link TextEncodedTelemetryReader}.
+   *
+   * <p>The input format used to read the telemetry is defined by the
+   * BatchProfilerConfig.TELEMETRY_INPUT_PATH property.
+   */
+  public TextEncodedTelemetryReader() {
+    this.inputFormat = null;
+  }
+
+  /**
+   * Creates a {@link TextEncodedTelemetryReader}.
+   *
+   * @param inputFormat The input format to use when reading telemetry.
+   */
+  public TextEncodedTelemetryReader(String inputFormat) {
+    this.inputFormat = inputFormat;
+  }
+
   @Override
   public Dataset<String> read(SparkSession spark, Properties profilerProps, Properties readerProps) {
-    String inputFormat = TELEMETRY_INPUT_FORMAT.get(profilerProps, String.class);
     String inputPath = TELEMETRY_INPUT_PATH.get(profilerProps, String.class);
+    if(inputFormat == null) {
+      inputFormat = TELEMETRY_INPUT_FORMAT.get(profilerProps, String.class);
+    }
     LOG.debug("Loading telemetry; inputPath={}, inputFormat={}", inputPath, inputFormat);
 
     return spark

--- a/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/reader/TextEncodedTelemetryReader.java
+++ b/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/reader/TextEncodedTelemetryReader.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.metron.profiler.spark.reader;
+
+import com.google.common.collect.Maps;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.SparkSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Properties;
+
+import static org.apache.metron.profiler.spark.BatchProfilerConfig.TELEMETRY_INPUT_FORMAT;
+import static org.apache.metron.profiler.spark.BatchProfilerConfig.TELEMETRY_INPUT_PATH;
+
+/**
+ * A {@link TelemetryReader} that consumes telemetry stored as raw text.
+ *
+ * <p>This {@link TelemetryReader} is useful for any text-encoded formats like JSON and CSV.
+ */
+public class TextEncodedTelemetryReader implements TelemetryReader {
+
+  protected static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  @Override
+  public Dataset<String> read(SparkSession spark, Properties properties) {
+    String inputFormat = TELEMETRY_INPUT_FORMAT.get(properties, String.class);
+    String inputPath = TELEMETRY_INPUT_PATH.get(properties, String.class);
+    LOG.debug("Loading telemetry; inputPath={}, inputFormat={}", inputPath, inputFormat);
+
+    return spark
+            .read()
+            .options(Maps.fromProperties(properties))
+            .format(inputFormat)
+            .load(inputPath)
+            .as(Encoders.STRING());
+  }
+}

--- a/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/reader/TextEncodedTelemetryReader.java
+++ b/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/reader/TextEncodedTelemetryReader.java
@@ -42,14 +42,14 @@ public class TextEncodedTelemetryReader implements TelemetryReader {
   protected static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @Override
-  public Dataset<String> read(SparkSession spark, Properties properties) {
-    String inputFormat = TELEMETRY_INPUT_FORMAT.get(properties, String.class);
-    String inputPath = TELEMETRY_INPUT_PATH.get(properties, String.class);
+  public Dataset<String> read(SparkSession spark, Properties profilerProps, Properties readerProps) {
+    String inputFormat = TELEMETRY_INPUT_FORMAT.get(profilerProps, String.class);
+    String inputPath = TELEMETRY_INPUT_PATH.get(profilerProps, String.class);
     LOG.debug("Loading telemetry; inputPath={}, inputFormat={}", inputPath, inputFormat);
 
     return spark
             .read()
-            .options(Maps.fromProperties(properties))
+            .options(Maps.fromProperties(readerProps))
             .format(inputFormat)
             .load(inputPath)
             .as(Encoders.STRING());

--- a/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/BatchProfilerIntegrationTest.java
+++ b/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/BatchProfilerIntegrationTest.java
@@ -230,7 +230,9 @@ public class BatchProfilerIntegrationTest {
             .save(pathToCSV);
 
     // tell the profiler to use the CSV input data
+    // CSV is an example of needing to define both the reader and the input format
     profilerProperties.put(TELEMETRY_INPUT_PATH.getKey(), pathToCSV);
+    profilerProperties.put(TELEMETRY_INPUT_READER.getKey(), "text");
     profilerProperties.put(TELEMETRY_INPUT_FORMAT.getKey(), "csv");
 
     // set a reader property; tell the reader to expect a header

--- a/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/BatchProfilerIntegrationTest.java
+++ b/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/BatchProfilerIntegrationTest.java
@@ -162,9 +162,8 @@ public class BatchProfilerIntegrationTest {
   @Test
   public void testBatchProfilerWithJSON() throws Exception {
     // the input telemetry is text/json stored in the local filesystem
-    profilerProperties.put(TELEMETRY_INPUT_READER.getKey(), TEXT.toString());
+    profilerProperties.put(TELEMETRY_INPUT_READER.getKey(), JSON.toString());
     profilerProperties.put(TELEMETRY_INPUT_PATH.getKey(), "src/test/resources/telemetry.json");
-    profilerProperties.put(TELEMETRY_INPUT_FORMAT.getKey(), "text");
 
     BatchProfiler profiler = new BatchProfiler();
     profiler.run(spark, profilerProperties, getGlobals(), readerProperties, getProfile());
@@ -185,9 +184,8 @@ public class BatchProfilerIntegrationTest {
             .save(pathToORC);
 
     // tell the profiler to use the ORC input data
-    profilerProperties.put(TELEMETRY_INPUT_READER.getKey(), COLUMNAR.toString());
+    profilerProperties.put(TELEMETRY_INPUT_READER.getKey(), ORC.toString());
     profilerProperties.put(TELEMETRY_INPUT_PATH.getKey(), pathToORC);
-    profilerProperties.put(TELEMETRY_INPUT_FORMAT.getKey(), "org.apache.spark.sql.execution.datasources.orc");
 
     BatchProfiler profiler = new BatchProfiler();
     profiler.run(spark, profilerProperties, getGlobals(), readerProperties, getProfile());
@@ -208,9 +206,8 @@ public class BatchProfilerIntegrationTest {
             .save(inputPath);
 
     // tell the profiler to use the ORC input data
-    profilerProperties.put(TELEMETRY_INPUT_READER.getKey(), COLUMNAR.toString());
+    profilerProperties.put(TELEMETRY_INPUT_READER.getKey(), PARQUET.toString());
     profilerProperties.put(TELEMETRY_INPUT_PATH.getKey(), inputPath);
-    profilerProperties.put(TELEMETRY_INPUT_FORMAT.getKey(), "parquet");
 
     BatchProfiler profiler = new BatchProfiler();
     profiler.run(spark, profilerProperties, getGlobals(), readerProperties, getProfile());

--- a/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/BatchProfilerIntegrationTest.java
+++ b/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/BatchProfilerIntegrationTest.java
@@ -162,9 +162,9 @@ public class BatchProfilerIntegrationTest {
   @Test
   public void testBatchProfilerWithJSON() throws Exception {
     // the input telemetry is text/json stored in the local filesystem
-    readerProperties.put(TELEMETRY_INPUT_READER.getKey(), TEXT_READER.toString());
-    readerProperties.put(TELEMETRY_INPUT_PATH.getKey(), "src/test/resources/telemetry.json");
-    readerProperties.put(TELEMETRY_INPUT_FORMAT.getKey(), "text");
+    profilerProperties.put(TELEMETRY_INPUT_READER.getKey(), TEXT.toString());
+    profilerProperties.put(TELEMETRY_INPUT_PATH.getKey(), "src/test/resources/telemetry.json");
+    profilerProperties.put(TELEMETRY_INPUT_FORMAT.getKey(), "text");
 
     BatchProfiler profiler = new BatchProfiler();
     profiler.run(spark, profilerProperties, getGlobals(), readerProperties, getProfile());
@@ -185,9 +185,9 @@ public class BatchProfilerIntegrationTest {
             .save(pathToORC);
 
     // tell the profiler to use the ORC input data
-    readerProperties.put(TELEMETRY_INPUT_READER.getKey(), COLUMN_READER.toString());
-    readerProperties.put(TELEMETRY_INPUT_PATH.getKey(), pathToORC);
-    readerProperties.put(TELEMETRY_INPUT_FORMAT.getKey(), "org.apache.spark.sql.execution.datasources.orc");
+    profilerProperties.put(TELEMETRY_INPUT_READER.getKey(), COLUMNAR.toString());
+    profilerProperties.put(TELEMETRY_INPUT_PATH.getKey(), pathToORC);
+    profilerProperties.put(TELEMETRY_INPUT_FORMAT.getKey(), "org.apache.spark.sql.execution.datasources.orc");
 
     BatchProfiler profiler = new BatchProfiler();
     profiler.run(spark, profilerProperties, getGlobals(), readerProperties, getProfile());
@@ -208,9 +208,9 @@ public class BatchProfilerIntegrationTest {
             .save(inputPath);
 
     // tell the profiler to use the ORC input data
-    readerProperties.put(TELEMETRY_INPUT_READER.getKey(), COLUMN_READER.toString());
-    readerProperties.put(TELEMETRY_INPUT_PATH.getKey(), inputPath);
-    readerProperties.put(TELEMETRY_INPUT_FORMAT.getKey(), "parquet");
+    profilerProperties.put(TELEMETRY_INPUT_READER.getKey(), COLUMNAR.toString());
+    profilerProperties.put(TELEMETRY_INPUT_PATH.getKey(), inputPath);
+    profilerProperties.put(TELEMETRY_INPUT_FORMAT.getKey(), "parquet");
 
     BatchProfiler profiler = new BatchProfiler();
     profiler.run(spark, profilerProperties, getGlobals(), readerProperties, getProfile());
@@ -233,8 +233,8 @@ public class BatchProfilerIntegrationTest {
             .save(pathToCSV);
 
     // tell the profiler to use the CSV input data
-    readerProperties.put(TELEMETRY_INPUT_PATH.getKey(), pathToCSV);
-    readerProperties.put(TELEMETRY_INPUT_FORMAT.getKey(), "csv");
+    profilerProperties.put(TELEMETRY_INPUT_PATH.getKey(), pathToCSV);
+    profilerProperties.put(TELEMETRY_INPUT_FORMAT.getKey(), "csv");
 
     // set a reader property; tell the reader to expect a header
     readerProperties.put("header", "true");
@@ -248,8 +248,8 @@ public class BatchProfilerIntegrationTest {
   @Test
   public void testBatchProfilerWithEndTimeConstraint() throws Exception {
     // the input telemetry is text/json stored in the local filesystem
-    readerProperties.put(TELEMETRY_INPUT_PATH.getKey(), "src/test/resources/telemetry.json");
-    readerProperties.put(TELEMETRY_INPUT_FORMAT.getKey(), "text");
+    profilerProperties.put(TELEMETRY_INPUT_PATH.getKey(), "src/test/resources/telemetry.json");
+    profilerProperties.put(TELEMETRY_INPUT_FORMAT.getKey(), "text");
 
     // there are 40 messages before "2018-07-07T15:51:48Z" in the test data
     profilerProperties.put(TELEMETRY_INPUT_BEGIN.getKey(), "");
@@ -272,8 +272,8 @@ public class BatchProfilerIntegrationTest {
   @Test
   public void testBatchProfilerWithBeginTimeConstraint() throws Exception {
     // the input telemetry is text/json stored in the local filesystem
-    readerProperties.put(TELEMETRY_INPUT_PATH.getKey(), "src/test/resources/telemetry.json");
-    readerProperties.put(TELEMETRY_INPUT_FORMAT.getKey(), "text");
+    profilerProperties.put(TELEMETRY_INPUT_PATH.getKey(), "src/test/resources/telemetry.json");
+    profilerProperties.put(TELEMETRY_INPUT_FORMAT.getKey(), "text");
 
     // there are 60 messages after "2018-07-07T15:51:48Z" in the test data
     profilerProperties.put(TELEMETRY_INPUT_BEGIN.getKey(), "2018-07-07T15:51:48Z");

--- a/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/function/reader/ColumnEncodedTelemetryReaderTest.java
+++ b/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/function/reader/ColumnEncodedTelemetryReaderTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.metron.profiler.spark.function.reader;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ColumnEncodedTelemetryReaderTest {
+
+  @Test
+  public void test() {
+    Assert.fail("TODO");
+  }
+}

--- a/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/function/reader/ColumnEncodedTelemetryReaderTest.java
+++ b/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/function/reader/ColumnEncodedTelemetryReaderTest.java
@@ -18,13 +18,105 @@
  */
 package org.apache.metron.profiler.spark.function.reader;
 
+import org.apache.metron.profiler.spark.reader.TelemetryReaders;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.function.FilterFunction;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.SparkSession;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
+import java.util.Properties;
+
+import static org.apache.metron.profiler.spark.BatchProfilerConfig.TELEMETRY_INPUT_FORMAT;
+import static org.apache.metron.profiler.spark.BatchProfilerConfig.TELEMETRY_INPUT_PATH;
+
+/**
+ * Tests the {@link org.apache.metron.profiler.spark.reader.ColumnEncodedTelemetryReader} class.
+ */
 public class ColumnEncodedTelemetryReaderTest {
 
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+  private static SparkSession spark;
+  private Properties profilerProperties;
+  private Properties readerProperties;
+
+  @BeforeClass
+  public static void setupSpark() {
+    SparkConf conf = new SparkConf()
+            .setMaster("local")
+            .setAppName("BatchProfilerIntegrationTest")
+            .set("spark.sql.shuffle.partitions", "8");
+    spark = SparkSession
+            .builder()
+            .config(conf)
+            .getOrCreate();
+  }
+
+  @AfterClass
+  public static void tearDownSpark() {
+    if(spark != null) {
+      spark.close();
+    }
+  }
+
+  @Before
+  public void setup() {
+    readerProperties = new Properties();
+    profilerProperties = new Properties();
+  }
+
   @Test
-  public void test() {
-    Assert.fail("TODO");
+  public void testParquet() {
+    // re-write the test data as column-oriented ORC
+    String inputPath = tempFolder.getRoot().getAbsolutePath();
+    spark.read()
+            .format("json")
+            .load("src/test/resources/telemetry.json")
+            .write()
+            .mode("overwrite")
+            .format("parquet")
+            .save(inputPath);
+
+    // tell the profiler to use the CSV input data
+    profilerProperties.put(TELEMETRY_INPUT_PATH.getKey(), inputPath);
+    profilerProperties.put(TELEMETRY_INPUT_FORMAT.getKey(), "parquet");
+
+    // set a reader property; tell the reader to expect a header
+    readerProperties.put("header", "true");
+
+    // there should be 100 valid JSON records
+    Dataset<String> telemetry = TelemetryReaders.COLUMNAR.read(spark, profilerProperties, readerProperties);
+    Assert.assertEquals(100, telemetry.filter(new IsValidJSON()).count());
+  }
+
+  @Test
+  public void testORC() {
+    // re-write the test data as column-oriented ORC
+    String pathToORC = tempFolder.getRoot().getAbsolutePath();
+    spark.read()
+            .format("json")
+            .load("src/test/resources/telemetry.json")
+            .write()
+            .mode("overwrite")
+            .format("org.apache.spark.sql.execution.datasources.orc")
+            .save(pathToORC);
+
+    // tell the profiler to use the CSV input data
+    profilerProperties.put(TELEMETRY_INPUT_PATH.getKey(), pathToORC);
+    profilerProperties.put(TELEMETRY_INPUT_FORMAT.getKey(), "org.apache.spark.sql.execution.datasources.orc");
+
+    // there should be 100 valid JSON records
+    Dataset<String> telemetry = TelemetryReaders.COLUMNAR.read(spark, profilerProperties, readerProperties);
+    Assert.assertEquals(100, telemetry.filter(new IsValidJSON()).count());
   }
 }

--- a/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/function/reader/ColumnEncodedTelemetryReaderTest.java
+++ b/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/function/reader/ColumnEncodedTelemetryReaderTest.java
@@ -20,12 +20,8 @@ package org.apache.metron.profiler.spark.function.reader;
 
 import org.apache.metron.profiler.spark.reader.TelemetryReaders;
 import org.apache.spark.SparkConf;
-import org.apache.spark.api.java.function.FilterFunction;
 import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.SparkSession;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;

--- a/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/function/reader/IsValidJSON.java
+++ b/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/function/reader/IsValidJSON.java
@@ -16,27 +16,23 @@
  * limitations under the License.
  *
  */
+package org.apache.metron.profiler.spark.function.reader;
 
-package org.apache.metron.profiler.spark.reader;
-
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.SparkSession;
-
-import java.util.Properties;
+import org.apache.spark.api.java.function.FilterFunction;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
 
 /**
- * A {@link TelemetryReader} is responsible for creating a {@link Dataset} containing
- * telemetry that can be consumed by the {@link org.apache.metron.profiler.spark.BatchProfiler}.
+ * A filter function that filters out invalid JSON records.
  */
-public interface TelemetryReader {
+public class IsValidJSON implements FilterFunction<String> {
 
-  /**
-   * Read in the telemetry
-   *
-   * @param spark The spark session.
-   * @param profilerProps The profiler properties.
-   * @param readerProps The properties specific to reading input data.
-   * @return A {@link Dataset} containing archived telemetry.
-   */
-  Dataset<String> read(SparkSession spark, Properties profilerProps, Properties readerProps);
+  @Override
+  public boolean call(String text) throws Exception {
+    JSONParser parser = new JSONParser();
+    JSONObject json = (JSONObject) parser.parse(text);
+
+    // all of the test data has at least 32 fields in each JSON record
+    return json.keySet().size() >= 32;
+  }
 }

--- a/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/function/reader/TelemetryReadersTest.java
+++ b/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/function/reader/TelemetryReadersTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.metron.profiler.spark.function.reader;
+
+import org.apache.metron.profiler.spark.reader.ColumnEncodedTelemetryReader;
+import org.apache.metron.profiler.spark.reader.TelemetryReaders;
+import org.apache.metron.profiler.spark.reader.TextEncodedTelemetryReader;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.metron.profiler.spark.reader.TelemetryReaders.COLUMN_READER;
+import static org.apache.metron.profiler.spark.reader.TelemetryReaders.TEXT_READER;
+
+public class TelemetryReadersTest {
+
+  @Test
+  public void testTextReader() {
+    Assert.assertTrue(TelemetryReaders.create(TEXT_READER.toString()) instanceof TextEncodedTelemetryReader);
+  }
+
+  @Test
+  public void testColumnReader() {
+    Assert.assertTrue(TelemetryReaders.create(COLUMN_READER.toString()) instanceof ColumnEncodedTelemetryReader);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidReader() {
+    TelemetryReaders.create("invalid");
+    Assert.fail("exception expected");
+  }
+}

--- a/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/function/reader/TelemetryReadersTest.java
+++ b/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/function/reader/TelemetryReadersTest.java
@@ -24,19 +24,19 @@ import org.apache.metron.profiler.spark.reader.TextEncodedTelemetryReader;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.apache.metron.profiler.spark.reader.TelemetryReaders.COLUMN_READER;
-import static org.apache.metron.profiler.spark.reader.TelemetryReaders.TEXT_READER;
+import static org.apache.metron.profiler.spark.reader.TelemetryReaders.COLUMNAR;
+import static org.apache.metron.profiler.spark.reader.TelemetryReaders.TEXT;
 
 public class TelemetryReadersTest {
 
   @Test
   public void testTextReader() {
-    Assert.assertTrue(TelemetryReaders.create(TEXT_READER.toString()) instanceof TextEncodedTelemetryReader);
+    Assert.assertTrue(TelemetryReaders.create(TEXT.toString()) instanceof TextEncodedTelemetryReader);
   }
 
   @Test
   public void testColumnReader() {
-    Assert.assertTrue(TelemetryReaders.create(COLUMN_READER.toString()) instanceof ColumnEncodedTelemetryReader);
+    Assert.assertTrue(TelemetryReaders.create(COLUMNAR.toString()) instanceof ColumnEncodedTelemetryReader);
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/function/reader/TelemetryReadersTest.java
+++ b/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/function/reader/TelemetryReadersTest.java
@@ -25,18 +25,60 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import static org.apache.metron.profiler.spark.reader.TelemetryReaders.COLUMNAR;
+import static org.apache.metron.profiler.spark.reader.TelemetryReaders.JSON;
+import static org.apache.metron.profiler.spark.reader.TelemetryReaders.ORC;
+import static org.apache.metron.profiler.spark.reader.TelemetryReaders.PARQUET;
 import static org.apache.metron.profiler.spark.reader.TelemetryReaders.TEXT;
 
 public class TelemetryReadersTest {
 
   @Test
+  public void testJsonReader() {
+    String key = JSON.toString();
+    Assert.assertTrue(TelemetryReaders.create(key) instanceof TextEncodedTelemetryReader);
+  }
+
+  @Test
+  public void testJsonReaderLowerCase() {
+    String key = JSON.toString().toLowerCase();
+    Assert.assertTrue(TelemetryReaders.create(key) instanceof TextEncodedTelemetryReader);
+  }
+
+  @Test
+  public void testOrcReader() {
+    String key = ORC.toString();
+    Assert.assertTrue(TelemetryReaders.create(key) instanceof ColumnEncodedTelemetryReader);
+  }
+
+
+  @Test
+  public void testOrcReaderLowerCase() {
+    String key = ORC.toString().toLowerCase();
+    Assert.assertTrue(TelemetryReaders.create(key) instanceof ColumnEncodedTelemetryReader);
+  }
+
+  @Test
+  public void testParquetReader() {
+    String key = PARQUET.toString();
+    Assert.assertTrue(TelemetryReaders.create(key) instanceof ColumnEncodedTelemetryReader);
+  }
+
+  @Test
+  public void testParquetReaderLowerCase() {
+    String key = PARQUET.toString().toLowerCase();
+    Assert.assertTrue(TelemetryReaders.create(key) instanceof ColumnEncodedTelemetryReader);
+  }
+
+  @Test
   public void testTextReader() {
-    Assert.assertTrue(TelemetryReaders.create(TEXT.toString()) instanceof TextEncodedTelemetryReader);
+    String key = TEXT.toString();
+    Assert.assertTrue(TelemetryReaders.create(key) instanceof TextEncodedTelemetryReader);
   }
 
   @Test
   public void testColumnReader() {
-    Assert.assertTrue(TelemetryReaders.create(COLUMNAR.toString()) instanceof ColumnEncodedTelemetryReader);
+    String key = COLUMNAR.toString();
+    Assert.assertTrue(TelemetryReaders.create(key) instanceof ColumnEncodedTelemetryReader);
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/function/reader/TextEncodedTelemetryReaderTest.java
+++ b/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/function/reader/TextEncodedTelemetryReaderTest.java
@@ -18,13 +18,100 @@
  */
 package org.apache.metron.profiler.spark.function.reader;
 
+import org.apache.metron.profiler.spark.reader.TelemetryReaders;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.function.FilterFunction;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.SparkSession;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
+import java.util.Properties;
+
+import static org.apache.metron.profiler.spark.BatchProfilerConfig.TELEMETRY_INPUT_FORMAT;
+import static org.apache.metron.profiler.spark.BatchProfilerConfig.TELEMETRY_INPUT_PATH;
+
+/**
+ * Tests the {@link org.apache.metron.profiler.spark.reader.TextEncodedTelemetryReader} class.
+ */
 public class TextEncodedTelemetryReaderTest {
 
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+  private static SparkSession spark;
+  private Properties profilerProperties;
+  private Properties readerProperties;
+
+  @BeforeClass
+  public static void setupSpark() {
+    SparkConf conf = new SparkConf()
+            .setMaster("local")
+            .setAppName("BatchProfilerIntegrationTest")
+            .set("spark.sql.shuffle.partitions", "8");
+    spark = SparkSession
+            .builder()
+            .config(conf)
+            .getOrCreate();
+  }
+
+  @AfterClass
+  public static void tearDownSpark() {
+    if(spark != null) {
+      spark.close();
+    }
+  }
+
+  @Before
+  public void setup() {
+    readerProperties = new Properties();
+    profilerProperties = new Properties();
+  }
+
   @Test
-  public void test() {
-    Assert.fail("TODO");
+  public void testCSV() {
+    // re-write the test data as a CSV with a header record
+    String pathToCSV = tempFolder.getRoot().getAbsolutePath();
+    spark.read()
+            .format("text")
+            .load("src/test/resources/telemetry.json")
+            .as(Encoders.STRING())
+            .write()
+            .mode("overwrite")
+            .option("header", "true")
+            .format("csv")
+            .save(pathToCSV);
+
+    // tell the profiler to use the CSV input data
+    profilerProperties.put(TELEMETRY_INPUT_PATH.getKey(), pathToCSV);
+    profilerProperties.put(TELEMETRY_INPUT_FORMAT.getKey(), "csv");
+
+    // set a reader property; tell the reader to expect a header
+    readerProperties.put("header", "true");
+
+    // there should be 100 valid JSON records
+    Dataset<String> telemetry = TelemetryReaders.TEXT.read(spark, profilerProperties, readerProperties);
+    Assert.assertEquals(100, telemetry.filter(new IsValidJSON()).count());
+  }
+
+  @Test
+  public void testJSON() {
+    // use the test telemetry that is stored as raw json
+    profilerProperties.put(TELEMETRY_INPUT_PATH.getKey(), "src/test/resources/telemetry.json");
+    profilerProperties.put(TELEMETRY_INPUT_FORMAT.getKey(), "text");
+
+    // set a reader property; tell the reader to expect a header
+    readerProperties.put("header", "true");
+
+    // there should be 100 valid JSON records
+    Dataset<String> telemetry = TelemetryReaders.TEXT.read(spark, profilerProperties, readerProperties);
+    Assert.assertEquals(100, telemetry.filter(new IsValidJSON()).count());
   }
 }

--- a/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/function/reader/TextEncodedTelemetryReaderTest.java
+++ b/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/function/reader/TextEncodedTelemetryReaderTest.java
@@ -20,12 +20,9 @@ package org.apache.metron.profiler.spark.function.reader;
 
 import org.apache.metron.profiler.spark.reader.TelemetryReaders;
 import org.apache.spark.SparkConf;
-import org.apache.spark.api.java.function.FilterFunction;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.SparkSession;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;

--- a/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/function/reader/TextEncodedTelemetryReaderTest.java
+++ b/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/function/reader/TextEncodedTelemetryReaderTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.metron.profiler.spark.function.reader;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TextEncodedTelemetryReaderTest {
+
+  @Test
+  public void test() {
+    Assert.fail("TODO");
+  }
+}


### PR DESCRIPTION
The Batch Profiler currently only accepts input formats that can be directly serialized to JSON.  This PR enhances that support to accept a wider variety of input formats, most notably columnar formats  like ORC and Parquet.

My first attempt at doing this in #1191 didn't go far enough.  The tests I had written only tested reading a single text column from ORC, which is not how someone would store the data in ORC.  Each field of the message would be stored in a separate column.  The test I had written failed to test this difference.

## Changes

* This introduces the `TelemetryReader` interface that handles differences between input formats. 

* This provides two different `TelemetryReader` implementations.  One that handles textual input that can be directly serialized; like JSON or CSV.  Another that handles column oriented input like ORC and Parquet.

* A new property was introduced to make this configurable to allow the user to define the `TelemetryReader` implementation.

* The README was updated to define the new property and provide examples for common formats.

* Unit and integration tests were added or updated to test the new functionality.

## Test Plan

1. Stand-up a development environment.

    ```
    cd metron-deployment/development/centos6
    vagrant up
    vagrant ssh
    sudo su -
    ```

1. Validate the environment by ensuring alerts are visible within the Alerts UI and that the Metron Service Check in Ambari passes.

1. Allow some telemetry to be archived in HDFS.
    ```
    [root@node1 ~]# hdfs dfs -cat /apps/metron/indexing/indexed/*/* | wc -l
    6916
    ```

1. Shutdown Metron topologies, Storm, Elasticsearch, Kibana, MapReduce2 to free up some resources on the VM.

1. Use Ambari to install Spark (version 2.3+).  Actions > Add Service > Spark2

1. Make sure Spark can talk to HBase.

    ```
    SPARK_HOME=/usr/hdp/current/spark2-client
    cp  /usr/hdp/current/hbase-client/conf/hbase-site.xml $SPARK_HOME/conf/
    ```

1. Follow the Getting Started section of the README to seed a basic profile using the text/json telemetry that is archived in HDFS.

    1. Create the Profile.

        ```
        [root@node1 ~]# source /etc/default/metron
        [root@node1 ~]# cat $METRON_HOME/config/zookeeper/profiler.json
        {
          "profiles": [
            {
              "profile": "hello-world",
              "foreach": "'global'",
              "init":    { "count": "0" },
              "update":  { "count": "count + 1" },
              "result":  "count"
            }
          ],
          "timestampField": "timestamp"
        }
        ```

    1. Edit the Batch Profiler properties. to point it at the correct input path (changed localhost:9000 to localhost:8020).
        ```
        [root@node1 ~]# cat /usr/metron/0.5.1/config/batch-profiler.properties

        spark.app.name=Batch Profiler
        spark.master=local
        spark.sql.shuffle.partitions=8

        profiler.batch.input.path=hdfs://localhost:8020/apps/metron/indexing/indexed/*/*
        profiler.batch.input.format=text

        profiler.period.duration=15
        profiler.period.duration.units=MINUTES
        ```

    1. Edit logging as you see fit.  For example, set Spark logging to WARN and Profiler logging to DEBUG. This is described in the README.

    1. Run the Batch Profiler.
        ```
        $METRON_HOME/bin/start_batch_profiler.sh
        ```

1. Launch the Stellar REPL and retrieve the profile data.  Save this result as it will be used for validation in subsequent steps.
    ```
    [root@node1 ~]# $METRON_HOME/bin/stellar -z $ZOOKEEPER
    ...
    Stellar, Go!
    Functions are loading lazily in the background and will be unavailable until loaded fully.
    ...
    [Stellar]>>> window := PROFILE_FIXED(2, "HOURS")
    [ProfilePeriod{period=1707332, durationMillis=900000}, ProfilePeriod{period=1707333, durationMillis=900000}, ProfilePeriod{period=1707334, durationMillis=900000}, ProfilePeriod{period=1707335, durationMillis=900000}, ProfilePeriod{period=1707336, durationMillis=900000}, ProfilePeriod{period=1707337, durationMillis=900000}, ProfilePeriod{period=1707338, durationMillis=900000}, ProfilePeriod{period=1707339, durationMillis=900000}, ProfilePeriod{period=1707340, durationMillis=900000}]

    [Stellar]>>> PROFILE_GET("hello-world","global", window)
    [1020, 5066, 830]
    ```

1. Delete the profiler data.
    ```
    echo "truncate 'profiler'" |  hbase shell
    ```

1. Create a new directory in HDFS for the ORC data that we are about to generate.
    ```
    export HADOOP_USER_NAME=hdfs
    hdfs dfs -mkdir /apps/metron/indexing/orc
    hdfs dfs -chown metron:hadoop /apps/metron/indexing/orc
    ```

1. You may need to also create this directory for Spark.  
   ```
    export HADOOP_USER_NAME=hdfs
    hdfs dfs -mkdir /spark2-history
   ```

1. Launch the Spark shell
    ```
    export SPARK_MAJOR_VERSION=2
    export HADOOP_USER_NAME=hdfs
    spark-shell
    ```

1. Use the Spark Shell to transform the text/json telemetry to ORC.  Copy and paste the following into the spark-shell using "paste mode" with `:paste` then hit CTRL-D to end paste mode.
    ```
    val jsonPath = "hdfs://localhost:8020/apps/metron/indexing/indexed/*/*"
    val orcPath = "hdfs://localhost:8020/apps/metron/orc/"
    spark
      .read
      .format("json")
      .load(jsonPath)
      .write
      .mode("overwrite")
      .format("org.apache.spark.sql.execution.datasources.orc")
      .save(orcPath)
    spark
      .read
      .format("org.apache.spark.sql.execution.datasources.orc")
      .load(orcPath)
      .count
    ```
    ```
    [root@node1 0.6.1]# spark-shell
    SPARK_MAJOR_VERSION is set to 2, using Spark2
    18/10/08 16:31:47 WARN Utils: Your hostname, node1 resolves to a loopback address: 127.0.0.1; using 10.0.2.15 instead (on interface eth0)
    18/10/08 16:31:47 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address
    Setting default log level to "WARN".
    To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
    Spark context Web UI available at http://10.0.2.15:4040
    Spark context available as 'sc' (master = local[*], app id = local-1539016323556).
    Spark session available as 'spark'.
    Welcome to
          ____              __
         / __/__  ___ _____/ /__
        _\ \/ _ \/ _ `/ __/  '_/
       /___/ .__/\_,_/_/ /_/\_\   version 2.3.0.2.6.5.0-292
          /_/

    Using Scala version 2.11.8 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_112)
    Type in expressions to have them evaluated.
    Type :help for more information.

    scala>
    scala> :paste
    // Entering paste mode (ctrl-D to finish)

    val jsonPath = "hdfs://localhost:8020/apps/metron/indexing/indexed/*/*"
    val orcPath = "hdfs://localhost:8020/apps/metron/orc/"
    spark
      .read
      .format("json")
      .load(jsonPath)
      .write
      .mode("overwrite")
      .format("org.apache.spark.sql.execution.datasources.orc")
      .save(orcPath)
    spark
      .read
      .format("org.apache.spark.sql.execution.datasources.orc")
      .load(orcPath)
      .count

    // Exiting paste mode, now interpreting.

    jsonPath: String = hdfs://localhost:8020/apps/metron/indexing/indexed/*/*
    orcPath: String = hdfs://localhost:8020/apps/metron/orc/
    res6: Long = 3810
    ```

1. Edit `$METRON_HOME/config/batch-profiler.properties` so that the Batch Profiler consumes that telemetry stored as ORC.
    ```
    [root@node1 ~]# cat /usr/metron/0.5.1/config/batch-profiler.properties

    spark.app.name=Batch Profiler
    spark.master=local
    spark.sql.shuffle.partitions=8

    profiler.batch.input.path=hdfs://localhost:8020/apps/metron/orc/
    profiler.batch.input.reader=COLUMNAR
    profiler.batch.input.format=org.apache.spark.sql.execution.datasources.orc

    profiler.period.duration=15
    profiler.period.duration.units=MINUTES
    ```

1. Again, run the Batch Profiler again.  It will now consume the ORC data. 
    ```
    $METRON_HOME/bin/start_batch_profiler.sh
    ```

1. Again, launch the Stellar REPL and retrieve the profile data.  The data should match the previous profile data that was generated using the test/json telemetry.
    ```
    [root@node1 ~]# $METRON_HOME/bin/stellar -z $ZOOKEEPER
    ...
    Stellar, Go!
    Functions are loading lazily in the background and will be unavailable until loaded fully.
    ...
    [Stellar]>>> window := PROFILE_FIXED(2, "HOURS")
    [ProfilePeriod{period=1707332, durationMillis=900000}, ProfilePeriod{period=1707333, durationMillis=900000}, ProfilePeriod{period=1707334, durationMillis=900000}, ProfilePeriod{period=1707335, durationMillis=900000}, ProfilePeriod{period=1707336, durationMillis=900000}, ProfilePeriod{period=1707337, durationMillis=900000}, ProfilePeriod{period=1707338, durationMillis=900000}, ProfilePeriod{period=1707339, durationMillis=900000}, ProfilePeriod{period=1707340, durationMillis=900000}]

    [Stellar]>>> PROFILE_GET("hello-world","global", window)
    [1020, 5066, 830]
    ```

1. Notice that the output is exactly the same no matter which input format we have used.


## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
