### PR TITLE
METRON-1813 Stellar REPL Not Initialized with Client JAAS

### DIFF
--- a/metron-platform/metron-common/src/main/scripts/stellar
+++ b/metron-platform/metron-common/src/main/scripts/stellar
@@ -28,10 +28,15 @@ elif [ -e /usr/lib/bigtop-utils/bigtop-detect-javahome ]; then
   . /usr/lib/bigtop-utils/bigtop-detect-javahome
 fi
 
+export METRON_SYSCONFIG="/etc/default/metron"
+if [ -f "$METRON_SYSCONFIG" ]; then
+	source $METRON_SYSCONFIG
+fi
+
+export METRON_VERSION="${METRON_VERSION:-${project.version}}"
+export METRON_HOME="${METRON_HOME:-/usr/metron/$METRON_VERSION}"
 export HBASE_CONFIGS=$(hbase classpath)
-export METRON_VERSION=${project.version}
-export METRON_HOME=/usr/metron/$METRON_VERSION
 export STELLAR_LIB=$(find $METRON_HOME/lib/ -name metron-parsers*.jar)
 export MANAGEMENT_LIB=$(find $METRON_HOME/lib/ -name metron-management*.jar)
 export PROFILER_LIB=$(find $METRON_HOME/lib/ -name metron-profiler-repl*.jar)
-java $JVMFLAGS -cp "${CONTRIB:-$METRON_HOME/contrib/*}:$STELLAR_LIB:$MANAGEMENT_LIB:$PROFILER_LIB:$HBASE_CONFIGS" org.apache.metron.stellar.common.shell.cli.StellarShell "$@"
+java $METRON_JVMFLAGS -cp "${CONTRIB:-$METRON_HOME/contrib/*}:$STELLAR_LIB:$MANAGEMENT_LIB:$PROFILER_LIB:$HBASE_CONFIGS" org.apache.metron.stellar.common.shell.cli.StellarShell "$@"


### PR DESCRIPTION
Running a function like `KAFKA_GET` in the Stellar REPL does not work in a kerberized environment.  

* When the Stellar REPL is launched in a Kerberized environment, it needs to have the Client JAAS passed to it so that Stellar functions can access resources like Kafka. 
* The JVM running the REPL never gets passed the `-Djava.security.auth.login.config=$METRON_HOME/client_jaas.conf` JVM arg. 

## Testing

1. Launch the development environment.

1. Kerberize the development environment.

1. Launch the REPL.
    ```
    source /etc/default/metron
    $METRON_HOME/bin/stellar -z $ZOOKEEPER
    ```

1. Retrieve messages using Kafka.
    ```
    conf := { "group.id":"bro_parser","security.protocol":"SASL_PLAINTEXT" }
    KAFKA_GET("bro", 10, conf)
    ```

1. If you can retrieve messages, the fix worked.

## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
