### PR TITLE
METRON-1829: Large Error Message Causes Slow Search Performance

### DIFF
--- a/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/bolt/BulkMessageWriterBoltTest.java
+++ b/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/bolt/BulkMessageWriterBoltTest.java
@@ -207,7 +207,7 @@ public class BulkMessageWriterBoltTest extends BaseEnrichmentBoltTest {
     }
     UnitTestHelper.setLog4jLevel(BulkWriterComponent.class, Level.ERROR);
     verify(outputCollector, times(5)).ack(tuple);
-    verify(outputCollector, times(1)).emit(eq(Constants.ERROR_STREAM), any(Values.class));
+    verify(outputCollector, times(5)).emit(eq(Constants.ERROR_STREAM), any(Values.class));
     verify(outputCollector, times(1)).reportError(any(Throwable.class));
   }
 

--- a/metron-platform/metron-writer/pom.xml
+++ b/metron-platform/metron-writer/pom.xml
@@ -207,6 +207,12 @@
             <artifactId>metron-common</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.metron</groupId>
+            <artifactId>metron-test-utilities</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/BulkWriterComponent.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/BulkWriterComponent.java
@@ -140,24 +140,24 @@ public class BulkWriterComponent<MESSAGE_T> {
    * <p>Without a valid message, the JSON message cannot be added to the error.
    *
    * @param e The exception that occurred.
-   * @param tuples The tuples to error that may not contain valid messages.
+   * @param tuple The tuple to error that may not contain a valid message.
    */
-  public void error(Throwable e, Iterable<Tuple> tuples) {
-    LOG.error(format("Failing %d tuple(s)", Iterables.size(tuples)), e);
+  public void error(Throwable e, Tuple tuple) {
+    LOG.error("Failing tuple", e);
     MetronError error = new MetronError()
             .withErrorType(Constants.ErrorType.INDEXING_ERROR)
             .withThrowable(e);
-    handleError(tuples, error);
+    handleError(tuple, error);
   }
 
   /**
    * Errors a set of tuples.
    *
-   * @param tuples The tuples to error.
+   * @param tuple The tuple to error.
    * @param error
    */
-  private void handleError(Iterable<Tuple> tuples, MetronError error) {
-    tuples.forEach(t -> collector.ack(t));
+  private void handleError(Tuple tuple, MetronError error) {
+    collector.ack(tuple);
     ErrorUtils.handleError(collector, error);
   }
 

--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/BulkWriterComponent.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/BulkWriterComponent.java
@@ -124,7 +124,7 @@ public class BulkWriterComponent<MESSAGE_T> {
               .withErrorType(Constants.ErrorType.INDEXING_ERROR)
               .withThrowable(e);
       error.addRawMessage(messageGetStrategy.get(t));
-      handleError(tuples, error);
+      handleError(Collections.singleton(t), error);
             });
 
   }

--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/BulkWriterComponent.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/BulkWriterComponent.java
@@ -118,12 +118,15 @@ public class BulkWriterComponent<MESSAGE_T> {
 
   public void error(String sensorType, Throwable e, Iterable<Tuple> tuples, MessageGetStrategy messageGetStrategy) {
     LOG.error(format("Failing %d tuple(s); sensorType=%s", Iterables.size(tuples), sensorType), e);
-    MetronError error = new MetronError()
-            .withSensorType(Collections.singleton(sensorType))
-            .withErrorType(Constants.ErrorType.INDEXING_ERROR)
-            .withThrowable(e);
-    tuples.forEach(t -> error.addRawMessage(messageGetStrategy.get(t)));
-    handleError(tuples, error);
+    tuples.forEach(t -> {
+      MetronError error = new MetronError()
+              .withSensorType(Collections.singleton(sensorType))
+              .withErrorType(Constants.ErrorType.INDEXING_ERROR)
+              .withThrowable(e);
+      error.addRawMessage(messageGetStrategy.get(t));
+      handleError(tuples, error);
+            });
+
   }
 
   /**

--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/bolt/BulkMessageWriterBolt.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/bolt/BulkMessageWriterBolt.java
@@ -311,7 +311,7 @@ public class BulkMessageWriterBolt<CONFIG_T extends Configurations> extends Conf
     LOG.debug("Unable to extract message from tuple; expected valid JSON");
     getWriterComponent().error(
             new Exception("Unable to extract message from tuple; expected valid JSON"),
-            ImmutableList.of(tuple)
+            tuple
     );
   }
 

--- a/metron-platform/metron-writer/src/test/java/org/apache/metron/writer/BulkWriterComponentTest.java
+++ b/metron-platform/metron-writer/src/test/java/org/apache/metron/writer/BulkWriterComponentTest.java
@@ -18,10 +18,12 @@
 package org.apache.metron.writer;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
@@ -36,8 +38,10 @@ import org.apache.metron.common.message.MessageGetStrategy;
 import org.apache.metron.common.utils.ErrorUtils;
 import org.apache.metron.common.writer.BulkMessageWriter;
 import org.apache.metron.common.writer.BulkWriterResponse;
+import org.apache.metron.test.error.MetronErrorJSONMatcher;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.tuple.Tuple;
+import org.apache.storm.tuple.Values;
 import org.json.simple.JSONObject;
 import org.junit.Before;
 import org.junit.Rule;
@@ -142,9 +146,14 @@ public class BulkWriterComponentTest {
     bulkWriterComponent.write(sensorType, tuple1, message1, bulkMessageWriter, configurations, messageGetStrategy);
     bulkWriterComponent.write(sensorType, tuple2, message2, bulkMessageWriter, configurations, messageGetStrategy);
 
-    verifyStatic(times(1));
-    ErrorUtils.handleError(collector, expectedError1);
-    ErrorUtils.handleError(collector, expectedError2);
+    verify(collector, times(1)).emit(eq(Constants.ERROR_STREAM),
+            new Values(argThat(new MetronErrorJSONMatcher(expectedError1.getJSONObject()))));
+    verify(collector, times(1)).emit(eq(Constants.ERROR_STREAM),
+            new Values(argThat(new MetronErrorJSONMatcher(expectedError2.getJSONObject()))));
+    verify(collector, times(1)).ack(tuple1);
+    verify(collector, times(1)).ack(tuple2);
+    verify(collector, times(1)).reportError(e);
+    verifyNoMoreInteractions(collector);
   }
 
   @Test
@@ -184,9 +193,14 @@ public class BulkWriterComponentTest {
     bulkWriterComponent.write(sensorType, tuple1, message1, bulkMessageWriter, configurations, messageGetStrategy);
     bulkWriterComponent.write(sensorType, tuple2, message2, bulkMessageWriter, configurations, messageGetStrategy);
 
-    verifyStatic(times(1));
-    ErrorUtils.handleError(collector, expectedError1);
-    ErrorUtils.handleError(collector, expectedError2);
+    verify(collector, times(1)).emit(eq(Constants.ERROR_STREAM),
+            new Values(argThat(new MetronErrorJSONMatcher(expectedError1.getJSONObject()))));
+    verify(collector, times(1)).emit(eq(Constants.ERROR_STREAM),
+            new Values(argThat(new MetronErrorJSONMatcher(expectedError2.getJSONObject()))));
+    verify(collector, times(1)).ack(tuple1);
+    verify(collector, times(1)).ack(tuple2);
+    verify(collector, times(1)).reportError(e);
+    verifyNoMoreInteractions(collector);
   }
 
   @Test
@@ -208,9 +222,14 @@ public class BulkWriterComponentTest {
     bulkWriterComponent.write("sensor2", tuple2, message2, bulkMessageWriter, configurations, messageGetStrategy);
     bulkWriterComponent.errorAll(e, messageGetStrategy);
 
-    verifyStatic(times(1));
-    ErrorUtils.handleError(collector, error1);
-    ErrorUtils.handleError(collector, error2);
+    verify(collector, times(1)).emit(eq(Constants.ERROR_STREAM),
+            new Values(argThat(new MetronErrorJSONMatcher(error1.getJSONObject()))));
+    verify(collector, times(1)).emit(eq(Constants.ERROR_STREAM),
+            new Values(argThat(new MetronErrorJSONMatcher(error2.getJSONObject()))));
+    verify(collector, times(1)).ack(tuple1);
+    verify(collector, times(1)).ack(tuple2);
+    verify(collector, times(2)).reportError(e);
+    verifyNoMoreInteractions(collector);
 
     bulkWriterComponent.write("sensor1", tuple1, message1, bulkMessageWriter, configurations, messageGetStrategy);
     verify(bulkMessageWriter, times(0)).write(sensorType, configurations, Collections.singletonList(tuple1), Collections.singletonList(message1));

--- a/metron-platform/metron-writer/src/test/java/org/apache/metron/writer/BulkWriterComponentTest.java
+++ b/metron-platform/metron-writer/src/test/java/org/apache/metron/writer/BulkWriterComponentTest.java
@@ -167,10 +167,14 @@ public class BulkWriterComponentTest {
     Throwable e = new Exception("test exception");
     MetronError expectedError1 = new MetronError()
             .withSensorType(Collections.singleton(sensorType))
-            .withErrorType(Constants.ErrorType.INDEXING_ERROR).withThrowable(e).withRawMessages(Collections.singletonList(message1));
+            .withErrorType(Constants.ErrorType.INDEXING_ERROR)
+            .withThrowable(e)
+            .withRawMessages(Collections.singletonList(message1));
     MetronError expectedError2 = new MetronError()
             .withSensorType(Collections.singleton(sensorType))
-            .withErrorType(Constants.ErrorType.INDEXING_ERROR).withThrowable(e).withRawMessages(Collections.singletonList(message2));
+            .withErrorType(Constants.ErrorType.INDEXING_ERROR)
+            .withThrowable(e)
+            .withRawMessages(Collections.singletonList(message2));
     BulkWriterResponse response = new BulkWriterResponse();
     response.addAllErrors(e, tupleList);
 
@@ -190,10 +194,14 @@ public class BulkWriterComponentTest {
     Throwable e = new Exception("test exception");
     MetronError error1 = new MetronError()
             .withSensorType(Collections.singleton("sensor1"))
-            .withErrorType(Constants.ErrorType.INDEXING_ERROR).withThrowable(e).withRawMessages(Collections.singletonList(message1));
+            .withErrorType(Constants.ErrorType.INDEXING_ERROR)
+            .withThrowable(e)
+            .withRawMessages(Collections.singletonList(message1));
     MetronError error2 = new MetronError()
             .withSensorType(Collections.singleton("sensor2"))
-            .withErrorType(Constants.ErrorType.INDEXING_ERROR).withThrowable(e).withRawMessages(Collections.singletonList(message2));
+            .withErrorType(Constants.ErrorType.INDEXING_ERROR)
+            .withThrowable(e)
+            .withRawMessages(Collections.singletonList(message2));
 
     BulkWriterComponent<JSONObject> bulkWriterComponent = new BulkWriterComponent<>(collector);
     bulkWriterComponent.write("sensor1", tuple1, message1, bulkMessageWriter, configurations, messageGetStrategy);

--- a/metron-platform/metron-writer/src/test/java/org/apache/metron/writer/BulkWriterComponentTest.java
+++ b/metron-platform/metron-writer/src/test/java/org/apache/metron/writer/BulkWriterComponentTest.java
@@ -127,9 +127,12 @@ public class BulkWriterComponentTest {
   @Test
   public void writeShouldProperlyHandleWriterErrors() throws Exception {
     Throwable e = new Exception("test exception");
-    MetronError error = new MetronError()
+    MetronError expectedError1 = new MetronError()
             .withSensorType(Collections.singleton(sensorType))
-            .withErrorType(Constants.ErrorType.INDEXING_ERROR).withThrowable(e).withRawMessages(Arrays.asList(message1, message2));
+            .withErrorType(Constants.ErrorType.INDEXING_ERROR).withThrowable(e).withRawMessages(Collections.singletonList(message1));
+    MetronError expectedError2 = new MetronError()
+            .withSensorType(Collections.singleton(sensorType))
+            .withErrorType(Constants.ErrorType.INDEXING_ERROR).withThrowable(e).withRawMessages(Collections.singletonList(message2));
     BulkWriterResponse response = new BulkWriterResponse();
     response.addAllErrors(e, tupleList);
 
@@ -140,7 +143,8 @@ public class BulkWriterComponentTest {
     bulkWriterComponent.write(sensorType, tuple2, message2, bulkMessageWriter, configurations, messageGetStrategy);
 
     verifyStatic(times(1));
-    ErrorUtils.handleError(collector, error);
+    ErrorUtils.handleError(collector, expectedError1);
+    ErrorUtils.handleError(collector, expectedError2);
   }
 
   @Test
@@ -161,9 +165,12 @@ public class BulkWriterComponentTest {
   @Test
   public void writeShouldProperlyHandleWriterException() throws Exception {
     Throwable e = new Exception("test exception");
-    MetronError error = new MetronError()
+    MetronError expectedError1 = new MetronError()
             .withSensorType(Collections.singleton(sensorType))
-            .withErrorType(Constants.ErrorType.INDEXING_ERROR).withThrowable(e).withRawMessages(Arrays.asList(message1, message2));
+            .withErrorType(Constants.ErrorType.INDEXING_ERROR).withThrowable(e).withRawMessages(Collections.singletonList(message1));
+    MetronError expectedError2 = new MetronError()
+            .withSensorType(Collections.singleton(sensorType))
+            .withErrorType(Constants.ErrorType.INDEXING_ERROR).withThrowable(e).withRawMessages(Collections.singletonList(message2));
     BulkWriterResponse response = new BulkWriterResponse();
     response.addAllErrors(e, tupleList);
 
@@ -174,7 +181,8 @@ public class BulkWriterComponentTest {
     bulkWriterComponent.write(sensorType, tuple2, message2, bulkMessageWriter, configurations, messageGetStrategy);
 
     verifyStatic(times(1));
-    ErrorUtils.handleError(collector, error);
+    ErrorUtils.handleError(collector, expectedError1);
+    ErrorUtils.handleError(collector, expectedError2);
   }
 
   @Test


### PR DESCRIPTION
## Contributor Comments
When a failure happens in the BulkWriterComponent, all pending messages in a batch are combined into a single error message.  This results in a single large objects being written to ES and causes performance problems.  This PR attempts to solve this issue by instead creating separate error messages for each message in the batch. 

### Testing
This has been tested and verified in full dev:

1. Spin up full dev and verify data is being indexed into ES
2. Stop HDFS in Ambari.  This will cause a failure in the BulkWriterComponent.  By default the batch size for OOTB sensors is set to 5.
3. After HDFS has stopped, verify that documents are being written to an ES error index
4. Retrieve a single document from the ES error index.  There should only be a single `raw_message` field.  Subsequent documents in ES should also only contain a single `raw_message` field.  Before there would have been 5 `raw_message_*` fields in a single document.
5.  Verify error documents are displayed properly in Kibana.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
