### PR TITLE
METRON-1839 Install Elasticsearch MPack Step in Ansible Not Idempotent

### DIFF
--- a/metron-deployment/ansible/roles/ambari_master/defaults/main.yml
+++ b/metron-deployment/ansible/roles/ambari_master/defaults/main.yml
@@ -19,5 +19,6 @@ ambari_server_mem: 2048
 ambari_mpack_version: 0.6.1.0
 metron_mpack_name: metron_mpack-{{ ambari_mpack_version }}.tar.gz
 metron_mpack_path: "{{ playbook_dir }}/../../packaging/ambari/metron-mpack/target/{{ metron_mpack_name }}"
+elasticsearch_mpack_version: 5.6.2
 elasticsearch_mpack_name: elasticsearch_mpack-{{ ambari_mpack_version }}.tar.gz
 elasticsearch_mpack_path: "{{ playbook_dir }}/../../packaging/ambari/elasticsearch-mpack/target/{{ elasticsearch_mpack_name }}"

--- a/metron-deployment/ansible/roles/ambari_master/tasks/elasticsearch_mpack.yml
+++ b/metron-deployment/ansible/roles/ambari_master/tasks/elasticsearch_mpack.yml
@@ -21,6 +21,6 @@
     dest: /tmp
 
 - name: Install Elasticsearch MPack on Ambari Host
-  shell: ambari-server install-mpack --mpack=/tmp/elasticsearch_mpack-{{ ambari_mpack_version }}.tar.gz
+  shell: "ambari-server install-mpack --mpack={{ elasticsearch_mpack_name }}"
   args:
-    creates: /var/lib/ambari-server/resources/mpacks/elasticsearch-ambari.mpack-{{ ambari_mpack_version }}/addon-services
+    creates: /var/lib/ambari-server/resources/mpacks/elasticsearch-ambari.mpack-{{ elasticsearch_mpack_version }}/addon-services

--- a/metron-deployment/ansible/roles/ambari_master/tasks/elasticsearch_mpack.yml
+++ b/metron-deployment/ansible/roles/ambari_master/tasks/elasticsearch_mpack.yml
@@ -21,6 +21,6 @@
     dest: /tmp
 
 - name: Install Elasticsearch MPack on Ambari Host
-  shell: "ambari-server install-mpack --mpack={{ elasticsearch_mpack_name }}"
+  shell: "ambari-server install-mpack --mpack=/tmp/{{ elasticsearch_mpack_name }}"
   args:
     creates: /var/lib/ambari-server/resources/mpacks/elasticsearch-ambari.mpack-{{ elasticsearch_mpack_version }}/addon-services


### PR DESCRIPTION
When re-provisioning the development environment, the "Install Elasticsearch MPack on Ambari Host" step will fail.  This step needs to be idempotent so it succeeds when re-provisioned.

## Steps to Replicate

1. Start the development environment.
    ```
    cd metron-deployment/development/centos6
    vagrant up
    ```

2. Re-provision the environment.
    ```
    vagrant provision
    ```

3. This will fail with the following error message.
    ```
    TASK [ambari_master : Install Elasticsearch MPack on Ambari Host] **************
    fatal: [node1]: FAILED! => {"changed": true, "cmd": "ambari-server install-mpack --mpack=/tmp/elasticsearch_mpack-0.6.1.0.tar.gz", "delta": "0:00:00.360554", "end": "2018-10-20 17:13:54.836885", "msg": "non-zero return code", "rc": 255, "start": "2018-10-20 17:13:54.476331", "stderr": "", "stderr_lines": [], "stdout": "Using python /usr/bin/python\nInstalling management pack\nERROR: Management pack elasticsearch-ambari.mpack-5.6.2 already installed!\nERROR: Exiting with exit code -1. \nREASON: Management pack elasticsearch-ambari.mpack-5.6.2 already installed!", "stdout_lines": ["Using python /usr/bin/python", "Installing management pack", "ERROR: Management pack elasticsearch-ambari.mpack-5.6.2 already installed!", "ERROR: Exiting with exit code -1. ", "REASON: Management pack elasticsearch-ambari.mpack-5.6.2 already installed!"]}
    to retry, use: --limit @/Users/nallen/tmp/metron-pr1238/metron-deployment/development/centos6/ansible/playbook.retry

    PLAY RECAP *********************************************************************
    node1 : ok=36 changed=5 unreachable=0 failed=1

    Ansible failed to complete successfully. Any error output should be
    visible above. Please fix these errors and try again.
    ```
## Root Cause

While the Elasticsearch mpack tarball is named with the Metron version (`elasticsearch_mpack-0.6.1.0.tar.gz`), when installed the install path on disk uses the Elasticsearch version 5.6.2 (`/var/lib/ambari-server/resources/mpacks/elasticsearch-ambari.mpack-5.6.2`).  

Previously, the expected install path on disk was wrong.  This made the task always attempt to re-install the mpack.  The reinstall of an mpack failed since the --force option is not used.  

## Testing

1. Spin-up a development environment.

    ```
    cd metron-deployment/development/centos6
    vagrant up
    ```

1. Re-provision the same environment after the fist completes.

    ```
    vagrant --ansible-skip-tags="build,sensors" provision
    ```

1. If the re-provision makes it past the "Install Elasticsearch MPack on Ambari Host" step, the change is good.

## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
