### PR TITLE
METRON-1855: Make unified enrichment topology the default and deprecate split-join

### DIFF
--- a/Upgrading.md
+++ b/Upgrading.md
@@ -19,6 +19,23 @@ limitations under the License.
 This document constitutes a per-version listing of changes of
 configuration which are non-backwards compatible.
 
+## 0.6.0 to 0.6.1
+
+### [METRON-1855: Make unified enrichment topology the default and deprecate split-join](https://issues.apache.org/jira/browse/METRON-1855)
+The unified enrichment topology will be the new default in this release,
+and the split-join enrichment topology is now considered deprecated.
+If you wish to keep the deprecated split-join enrichment topology,
+you will need to make the following changes:
+
+* In Ambari > Metron > Config > Enrichment set the enrichment_topology setting to "Split-Join"
+* If running `start_enrichment_topology.sh` manually, pass in the parameters to start the Split-Join topology as follows
+
+    ```
+    $METRON_HOME/bin/start_enrichment_topology.sh --remote $METRON_HOME/flux/enrichment/remote-splitjoin.yaml --filter $METRON_HOME/config/enrichment-splitjoin.properties
+    ```
+
+* Restart the enrichment topology
+
 ## 0.4.2 to 0.5.0
 
 ### [METRON-941: native PaloAlto parser corrupts message when having a comma in the payload](https://issues.apache.org/jira/browse/METRON-941)

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/configuration/metron-enrichment-env.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/configuration/metron-enrichment-env.xml
@@ -165,17 +165,17 @@
   </property>
   <property>
     <name>enrichment_topology</name>
-    <description>Which Enrichment topology to execute</description>
-    <value>Split-Join</value>
+    <description>Which Enrichment topology to execute. Note: Split-Join is deprecated in favor of the Unified topology.</description>
+    <value>Unified</value>
     <display-name>Enrichment Topology</display-name>
     <value-attributes>
       <type>value-list</type>
       <entries>
         <entry>
-          <value>Split-Join</value>
+          <value>Unified</value>
         </entry>
         <entry>
-          <value>Unified</value>
+          <value>Split-Join</value>
         </entry>
       </entries>
       <selection-cardinality>1</selection-cardinality>

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/themes/metron_theme.json
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/themes/metron_theme.json
@@ -125,27 +125,8 @@
                   ]
                 },
                 {
-                  "name": "section-enrichment-splitjoin",
-                  "row-index": "3",
-                  "column-index": "0",
-                  "row-span": "1",
-                  "column-span": "1",
-                  "section-columns": "1",
-                  "section-rows": "1",
-                  "subsections": [
-                    {
-                      "name": "subsection-enrichment-splitjoin",
-                      "display-name": "Split Join Topology",
-                      "row-index": "0",
-                      "column-index": "0",
-                      "row-span": "1",
-                      "column-span": "1"
-                    }
-                  ]
-                },
-                {
                   "name": "section-enrichment-unified",
-                  "row-index": "4",
+                  "row-index": "3",
                   "column-index": "0",
                   "row-span": "1",
                   "column-span": "1",
@@ -155,6 +136,25 @@
                     {
                       "name": "subsection-enrichment-unified",
                       "display-name": "Unified Topology",
+                      "row-index": "0",
+                      "column-index": "0",
+                      "row-span": "1",
+                      "column-span": "1"
+                    }
+                  ]
+                },
+                {
+                  "name": "section-enrichment-splitjoin",
+                  "row-index": "4",
+                  "column-index": "0",
+                  "row-span": "1",
+                  "column-span": "1",
+                  "section-columns": "1",
+                  "section-rows": "1",
+                  "subsections": [
+                    {
+                      "name": "subsection-enrichment-splitjoin",
+                      "display-name": "Split Join Topology",
                       "row-index": "0",
                       "column-index": "0",
                       "row-span": "1",

--- a/metron-platform/Performance-tuning-guide.md
+++ b/metron-platform/Performance-tuning-guide.md
@@ -188,9 +188,11 @@ See more detail on starting parsers [here](https://github.com/apache/metron/blob
 
 **Enrichment**
 
+__Note__ These recommendations are based on the deprecated split-join enrichment topology. See [Enrichment Performance](metron-enrichment/Performance.md) for tuning recommendations for the new default unified enrichment topology.
+
 This is a mapping of the various performance tuning properties for enrichments and how they are materialized.
 
-Flux file found here - $METRON_HOME/flux/enrichment/remote.yaml
+Flux file found here - $METRON_HOME/flux/enrichment/remote-splitjoin.yaml
 
 _Note 1:_ Changes to Flux file properties that are managed by Ambari will render Ambari unable to further manage the property.
 
@@ -457,6 +459,8 @@ usage: start_parser_topology.sh
 ```
 
 ### Enrichment Tuning
+
+__Note__ These tuning suggestions are based on the deprecated split-join topology.
 
 We landed on the same number of partitions for enrichemnt and indexing as we did for bro - 48.
 

--- a/metron-platform/metron-enrichment/README.md
+++ b/metron-platform/metron-enrichment/README.md
@@ -31,35 +31,21 @@ data format (e.g. a JSON Map structure with `original_message` and
 
 ## Enrichment Architecture
 
-![Architecture](enrichment_arch.png)
+![Unified Architecture](unified_enrichment_arch.svg)
 
 ### Unified Enrichment Topology
 
-There is an experimental unified enrichment topology which is shipped.
-Currently the architecture, as described above, has a split/join in
-order to perform enrichments in parallel.  This poses some issues in
-terms of ease of tuning and reasoning about performance.  
-
-In order to deal with these issues, there is an alternative enrichment topology which
-uses data parallelism as opposed to the split/join task parallelism.
-This architecture uses a worker pool to fully enrich any message within 
-a worker.  This results in 
+The unified enrichment topology uses data parallelism as opposed to the deprecated
+split/join topology's task parallelism. This architecture uses a worker pool to fully
+enrich any message within a worker.  This results in
 * Fewer bolts in the topology 
 * Each bolt fully operates on a message.
 * Fewer network hops
 
-![Unified Architecture](unified_enrichment_arch.svg)
-
-This architecture is fully backwards compatible; the only difference is
-how the enrichment will operate on each message (in one bolt where the
-split/join is done in a threadpool as opposed
+This architecture is fully backwards compatible with the old split-join
+topology; the only difference is how the enrichment will operate on each
+message (in one bolt where the split/join is done in a threadpool as opposed
 to split across multiple bolts).
-
-#### Using It
-
-In order to use this, you will need to 
-* Edit `$METRON_HOME/bin/start_enrichment_topology.sh` and adjust it to use `remote-unified.yaml` instead of `remote.yaml`
-* Restart the enrichment topology.
 
 #### Configuring It
 
@@ -76,6 +62,19 @@ intel bolt, the configurations will be taken from the respective join bolt
 parallelism.  When proper ambari support for this is added, we will add
 its own property.
 
+### Split-Join Enrichment Topology
+
+The now-deprecated split/join topology is also available and performs enrichments in parallel.
+This poses some issues in terms of ease of tuning and reasoning about performance.
+
+![Architecture](enrichment_arch.png)
+
+#### Using It
+
+In order to use the older, deprecated topology, you will need to
+* Edit `$METRON_HOME/bin/start_enrichment_topology.sh` and adjust it to use `remote-splitjoin.yaml` instead of `remote-unified.yaml`
+* Restart the enrichment topology.
+
 ## Enrichment Configuration
 
 The configuration for the `enrichment` topology, the topology primarily
@@ -84,7 +83,6 @@ defined by JSON documents stored in zookeeper.
 
 There are two types of configurations at the moment, `global` and
 `sensor` specific.  
-
 
 ## Global Configuration 
 
@@ -133,7 +131,6 @@ The configuration is a complex JSON object with the following top level fields:
 * `threatIntel` : A complex JSON object representing the configuration of the threat intelligence enrichments
 
 ### The `enrichment` Configuration
-
 
 | Field            | Description                                                                                                                                                                                                                   | Example                                                          |
 |------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------|

--- a/metron-platform/metron-enrichment/src/main/scripts/start_enrichment_topology.sh
+++ b/metron-platform/metron-enrichment/src/main/scripts/start_enrichment_topology.sh
@@ -25,6 +25,6 @@ SPLIT_JOIN_ARGS="--remote $METRON_HOME/flux/enrichment/remote-splitjoin.yaml --f
 UNIFIED_ARGS="--remote $METRON_HOME/flux/enrichment/remote-unified.yaml --filter $METRON_HOME/config/enrichment-unified.properties"
 
 # by passing in different args, the user can execute an alternative enrichment topology
-ARGS=${@:-$SPLIT_JOIN_ARGS}
+ARGS=${@:-$UNIFIED_ARGS}
 
 storm jar $METRON_HOME/lib/$TOPOLOGY_JAR org.apache.storm.flux.Flux $ARGS

--- a/metron-platform/metron-enrichment/src/main/scripts/start_enrichment_topology.sh
+++ b/metron-platform/metron-enrichment/src/main/scripts/start_enrichment_topology.sh
@@ -20,7 +20,7 @@ METRON_VERSION=${project.version}
 METRON_HOME=/usr/metron/$METRON_VERSION
 TOPOLOGY_JAR=${project.artifactId}-$METRON_VERSION-uber.jar
 
-# there are two enrichment topologies.  by default, the split-join enrichment topology is executed
+# There are two enrichment topologies. By default, the unified enrichment topology is executed. Split-join is now deprecated.
 SPLIT_JOIN_ARGS="--remote $METRON_HOME/flux/enrichment/remote-splitjoin.yaml --filter $METRON_HOME/config/enrichment-splitjoin.properties"
 UNIFIED_ARGS="--remote $METRON_HOME/flux/enrichment/remote-unified.yaml --filter $METRON_HOME/config/enrichment-unified.properties"
 


### PR DESCRIPTION
## Contributor Comments

https://issues.apache.org/jira/browse/METRON-1855

Deprecates the split-join topology in favor of the simpler, more performant unified enrichment topology. Encompasses the following changes:

- The MPack is configured with the Unified topology as the new default
- Unified topology properties appear first in the Ambari Enrichment config section and in the enrichment type dropdown.
- Documentation changed to emphasize the unified topology
- Performance docs make note of the split-join topology deprecation in favor of the unified topology.

I'll make another note of it in the DISCUSS thread, but I think we should make a goal of marking split-join deprecated in this upcoming release and removing it altogether shortly thereafter.

DISCUSS thread - https://lists.apache.org/thread.html/6cfc883de28a5cb41f26d0523522d4b93272ac954e5713c80a35675e@%3Cdev.metron.apache.org%3E

**Testing**

- Spin up full dev
- Verify that the unified enrichment topology is now running by default. 
- View the Storm UI topology details for enrichment and verify that there is no longer a split/join bolt.
- Verify the unified enrichment properties show up first under the enrichments config section and that "unified" is active in the enrichment type dropdown.
- Change enrichment type to Split Join and verify that the deprecated topology is still able to be run.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- n/a If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
