### PR TITLE
METRON-1857 Fix Metaalert Nested Alert Field Name in Index Template

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/files/metaalert_index.template
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/files/metaalert_index.template
@@ -5,7 +5,7 @@
       "dynamic_templates": [
         {
           "alert_template": {
-          "path_match": "alert.*",
+          "path_match": "metron_alert.*",
           "match_mapping_type": "string",
           "mapping": {
             "type": "keyword"

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/files/metaalert_index.template
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/files/metaalert_index.template
@@ -6,7 +6,7 @@
         {
           "alert_template": {
           "path_match": "metron_alert.*",
-          "match_mapping_type": "string",
+          "match_mapping_type": "*",
           "mapping": {
             "type": "keyword"
           }


### PR DESCRIPTION
In #1049 the metaalert index template was updated to rename the alert field 'metron_alert'.  The nested alert field was missed in the original PR.

## Testing

1. Launch Full Dev.
1. Login to the Alerts UI.
1. Group alerts by IP
1. Find a grouping where there are multiple sensor types.
1. Create meta alert
1. Ensure that the meta alert is created successfully.

![screen shot 2018-11-06 at 10 02 06 am](https://user-images.githubusercontent.com/2475409/48072673-11421200-e1ab-11e8-9712-413ebad9888d.png)

## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
