### PR TITLE
METRON-1874 Create a Parser Debugger

### DIFF
--- a/metron-platform/metron-management/src/main/java/org/apache/metron/management/Functions.java
+++ b/metron-platform/metron-management/src/main/java/org/apache/metron/management/Functions.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.metron.management;
+
+import org.apache.metron.stellar.common.utils.ConversionUtils;
+
+import java.util.List;
+
+import static java.lang.String.format;
+
+/**
+ *
+ */
+public class Functions {
+
+  /**
+   * Get an argument from the Stellar function arguments
+   *
+   * @param argName The name of the argument.
+   * @param index The index within the list of arguments.
+   * @param clazz The type expected.
+   * @param args All of the arguments.
+   * @param <T> The type of the argument expected.
+   */
+  public static <T> T getArg(String argName, int index, Class<T> clazz, List<Object> args) {
+    if(index >= args.size()) {
+      String msg = format("missing '%s'; expected at least %d argument(s), found %d", argName, index+1, args.size());
+      throw new IllegalArgumentException(msg);
+    }
+
+    return ConversionUtils.convert(args.get(index), clazz);
+  }
+
+  /**
+   * Returns true if an argument of a specific type at a given index exists.  Otherwise returns
+   * false if an argument does not exist at the index or is not the expected type.
+   *
+   * @param argName The name of the argument.
+   * @param index The index within the list of arguments.
+   * @param clazz The type expected.
+   * @param args All of the arguments.
+   * @param <T> The type of argument expected.
+   */
+  public static <T> boolean hasArg(String argName, int index, Class<T> clazz, List<Object> args) {
+    boolean result = false;
+
+    if(args.size() > index) {
+      if(clazz.isAssignableFrom(args.get(index).getClass())) {
+        return true;
+      }
+    }
+
+    return result;
+  }
+}

--- a/metron-platform/metron-management/src/main/java/org/apache/metron/management/Functions.java
+++ b/metron-platform/metron-management/src/main/java/org/apache/metron/management/Functions.java
@@ -26,7 +26,7 @@ import java.util.List;
 import static java.lang.String.format;
 
 /**
- *
+ * Contains utility functionality that is useful across all of the Stellar management functions.
  */
 public class Functions {
 

--- a/metron-platform/metron-management/src/main/java/org/apache/metron/management/KafkaFunctions.java
+++ b/metron-platform/metron-management/src/main/java/org/apache/metron/management/KafkaFunctions.java
@@ -60,6 +60,7 @@ import java.util.concurrent.TimeoutException;
 
 import static java.lang.String.format;
 import static org.apache.metron.stellar.dsl.Context.Capabilities.GLOBAL_CONFIG;
+import static org.apache.metron.management.Functions.getArg;
 
 /**
  * Defines the following Kafka-related functions available in Stellar.
@@ -1053,23 +1054,5 @@ public class KafkaFunctions {
     properties.put(MESSAGE_VIEW_PROPERTY, MESSAGE_VIEW_SIMPLE);
 
     return properties;
-  }
-
-  /**
-   * Get an argument from a list of arguments.
-   *
-   * @param argName The name of the argument.
-   * @param index The index within the list of arguments.
-   * @param clazz The type expected.
-   * @param args All of the arguments.
-   * @param <T> The type of the argument expected.
-   */
-  public static <T> T getArg(String argName, int index, Class<T> clazz, List<Object> args) {
-    if(index >= args.size()) {
-      throw new IllegalArgumentException(format("missing '%s'; expected at least %d argument(s), found %d",
-              argName, index+1, args.size()));
-    }
-
-    return ConversionUtils.convert(args.get(index), clazz);
   }
 }

--- a/metron-platform/metron-management/src/main/java/org/apache/metron/management/ParserFunctions.java
+++ b/metron-platform/metron-management/src/main/java/org/apache/metron/management/ParserFunctions.java
@@ -19,112 +19,56 @@
 
 package org.apache.metron.management;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import org.apache.metron.common.configuration.ParserConfigurations;
-import org.apache.metron.common.configuration.SensorParserConfig;
-import org.apache.metron.common.message.metadata.RawMessage;
-import org.apache.metron.parsers.ParserRunnerImpl;
-import org.apache.metron.parsers.ParserRunnerResults;
+import org.apache.metron.stellar.dsl.BaseStellarFunction;
 import org.apache.metron.stellar.dsl.Context;
 import org.apache.metron.stellar.dsl.ParseException;
 import org.apache.metron.stellar.dsl.Stellar;
 import org.apache.metron.stellar.dsl.StellarFunction;
-import org.json.simple.JSONObject;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
+import static java.lang.String.format;
 import static org.apache.metron.management.Functions.getArg;
-import static org.apache.metron.common.message.metadata.RawMessageStrategies.*;
 import static org.apache.metron.management.Functions.hasArg;
-import static java.util.Collections.emptyMap;
 
 /**
- * Stellar functions related to Parsers.
+ * Stellar functions that allow the user to parse messages in the Stellar REPL.
  */
 public class ParserFunctions {
-
-  /**
-   * TODO
-   */
-  private static final String FIXED_SENSOR_TYPE = "sensor";
-
-  /**
-   *
-   */
-  public static class Parser {
-
-    private ParserConfigurations parserConfigurations;
-
-    public Parser(String sensorConfig) {
-      parserConfigurations = create(sensorConfig.getBytes());
-    }
-
-    public Parser(Map<String, Object> sensorConfig) {
-      parserConfigurations = create(new JSONObject(sensorConfig).toJSONString().getBytes());
-    }
-
-    private static ParserConfigurations create(byte[] sensorConfig) {
-      try {
-        ParserConfigurations result = new ParserConfigurations();
-        result.updateSensorParserConfig(FIXED_SENSOR_TYPE, SensorParserConfig.fromBytes(sensorConfig));
-        return result;
-
-      } catch(IOException e) {
-        throw new IllegalArgumentException(e);
-      }
-    }
-
-    public Parser withGlobals(Map<String, Object> globals) {
-      parserConfigurations.updateGlobalConfig(globals);
-      return this;
-    }
-
-    public ParserConfigurations getParserConfigurations() {
-      return parserConfigurations;
-    }
-
-    @Override
-    public String toString() {
-      try {
-        return parserConfigurations.getSensorParserConfig(FIXED_SENSOR_TYPE).toJSON();
-
-      } catch(JsonProcessingException e) {
-        throw new RuntimeException(e);
-      }
-    }
-  }
 
   @Stellar(
           namespace = "PARSER",
           name = "INIT",
-          description = "TODO",
+          description = "Initialize a parser to parse messages.",
           params = {
                   "config - A map containing the sensor type as key and the sensor configuration as value.",
                   "globals - An optional map of global configuration values."
           },
-          returns = "TODO"
+          returns = "A parser that can be used to parse messages."
   )
-  public static class ParserInit implements StellarFunction {
+  public static class InitializeFunction extends BaseStellarFunction {
 
     @Override
-    public Object apply(List<Object> args, Context context) throws ParseException {
-      Parser parser;
-      if(hasArg("config", 0, String.class, args)) {
-        String arg = getArg("config", 0, String.class, args);
-        parser = new Parser(arg);
+    public Object apply(List<Object> args) throws ParseException {
+
+      String sensorType = getArg("sensorType", 0, String.class, args);
+      StellarParserRunner parser = new StellarParserRunner(sensorType);
+
+      // handle the parser configuration argument
+      if(hasArg("config", 1, String.class, args)) {
+        // parser config passed in as a string
+        String arg = getArg("config", 1, String.class, args);
+        parser.withParserConfiguration(arg);
 
       } else {
-        Map<String, Object> arg = getArg("config", 0, Map.class, args);
-        parser = new Parser(arg);
+        // parser configuration passed in as a map
+        Map<String, Object> arg = getArg("config", 1, Map.class, args);
+        parser.withParserConfiguration(arg);
       }
 
-      // handle the optional globals
+      // handle the 'globals' argument which is optional
       if(hasArg("globals", 1, Map.class, args)) {
         Map<String, Object> globals = getArg("globals", 1, Map.class, args);
         parser.withGlobals(globals);
@@ -132,59 +76,53 @@ public class ParserFunctions {
 
       return parser;
     }
-
-    @Override
-    public void initialize(Context context) {
-      // nothing to do
-    }
-
-    @Override
-    public boolean isInitialized() {
-      return true;
-    }
   }
 
   @Stellar(
           namespace = "PARSER",
           name = "PARSE",
-          description = "TODO",
+          description = "Parse a message.",
           params = {
-                  "TODO"
+                  "input - A message or list of messages to parse."
           },
-          returns = "A parser runner."
+          returns = "A list of messages that result from parsing the input."
   )
-  public static class ParserRun implements StellarFunction {
+  public static class ParseFunction implements StellarFunction {
 
     @Override
     public Object apply(List<Object> args, Context context) throws ParseException {
-      Parser parser = getArg("config", 0, Parser.class, args);
+      StellarParserRunner parser = getArg("config", 0, StellarParserRunner.class, args);
+      parser.withContext(context);
 
-      byte[] inputArg;
+      List<String> messages = getMessages(args);
+      return parser.parse(messages);
+    }
+
+    /**
+     * Retrieves the messages that need parsed from the function arguments.
+     * @param args The function arguments.
+     * @return The list of messages to parse.
+     */
+    private List<String> getMessages(List<Object> args) {
+      List<String> messages = new ArrayList<>();
       if(hasArg("input", 1, String.class, args)) {
-        // convert a String to raw bytes
-        inputArg = getArg("input", 1, String.class, args).getBytes();
+        // the input is a single message as a strign
+        String msg = getArg("input", 1, String.class, args);
+        messages.add(msg);
+
+      } else if(hasArg("input", 1, List.class, args)) {
+        // the input is a list of messages
+        List<Object> arg1 = getArg("input", 1, List.class, args);
+        for(Object object: arg1) {
+          String msg = String.class.cast(object);
+          messages.add(msg);
+        }
 
       } else {
-        // otherwise assume its the raw bytes
-        inputArg = getArg("input", 1, byte[].class, args);
+        throw new IllegalArgumentException(format("Expected a string or list of strings to parse."));
       }
 
-      // run the parser against the raw input
-      RawMessage rawMessage = DEFAULT.get(emptyMap(), inputArg, false, emptyMap());
-      ParserRunnerImpl parserRunner = new ParserRunnerImpl(Collections.singleton(FIXED_SENSOR_TYPE));
-      parserRunner.init(() -> parser.getParserConfigurations(), context);
-      ParserRunnerResults<JSONObject> results = parserRunner.execute(FIXED_SENSOR_TYPE, rawMessage, parser.getParserConfigurations());
-
-      // join both messages and errors into a list that can be returned
-      Stream<JSONObject> messages = results
-              .getMessages()
-              .stream();
-      Stream<JSONObject> errors = results
-              .getErrors()
-              .stream()
-              .map(error -> error.getJSONObject());
-      return Stream.concat(messages, errors)
-              .collect(Collectors.toList());
+      return messages;
     }
 
     @Override

--- a/metron-platform/metron-management/src/main/java/org/apache/metron/management/ParserFunctions.java
+++ b/metron-platform/metron-management/src/main/java/org/apache/metron/management/ParserFunctions.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.metron.management;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.metron.common.configuration.ParserConfigurations;
+import org.apache.metron.common.configuration.SensorParserConfig;
+import org.apache.metron.common.message.metadata.RawMessage;
+import org.apache.metron.parsers.ParserRunnerImpl;
+import org.apache.metron.parsers.ParserRunnerResults;
+import org.apache.metron.stellar.dsl.Context;
+import org.apache.metron.stellar.dsl.ParseException;
+import org.apache.metron.stellar.dsl.Stellar;
+import org.apache.metron.stellar.dsl.StellarFunction;
+import org.json.simple.JSONObject;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.metron.management.Functions.getArg;
+import static org.apache.metron.common.message.metadata.RawMessageStrategies.*;
+import static org.apache.metron.management.Functions.hasArg;
+import static java.util.Collections.emptyMap;
+
+/**
+ * Stellar functions related to Parsers.
+ */
+public class ParserFunctions {
+
+  /**
+   * TODO
+   */
+  private static final String FIXED_SENSOR_TYPE = "sensor";
+
+  /**
+   *
+   */
+  public static class Parser {
+
+    private ParserConfigurations parserConfigurations;
+
+    public Parser(String sensorConfig) {
+      parserConfigurations = create(sensorConfig.getBytes());
+    }
+
+    public Parser(Map<String, Object> sensorConfig) {
+      parserConfigurations = create(new JSONObject(sensorConfig).toJSONString().getBytes());
+    }
+
+    private static ParserConfigurations create(byte[] sensorConfig) {
+      try {
+        ParserConfigurations result = new ParserConfigurations();
+        result.updateSensorParserConfig(FIXED_SENSOR_TYPE, SensorParserConfig.fromBytes(sensorConfig));
+        return result;
+
+      } catch(IOException e) {
+        throw new IllegalArgumentException(e);
+      }
+    }
+
+    public Parser withGlobals(Map<String, Object> globals) {
+      parserConfigurations.updateGlobalConfig(globals);
+      return this;
+    }
+
+    public ParserConfigurations getParserConfigurations() {
+      return parserConfigurations;
+    }
+
+    @Override
+    public String toString() {
+      try {
+        return parserConfigurations.getSensorParserConfig(FIXED_SENSOR_TYPE).toJSON();
+
+      } catch(JsonProcessingException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  @Stellar(
+          namespace = "PARSER",
+          name = "INIT",
+          description = "TODO",
+          params = {
+                  "config - A map containing the sensor type as key and the sensor configuration as value.",
+                  "globals - An optional map of global configuration values."
+          },
+          returns = "TODO"
+  )
+  public static class ParserInit implements StellarFunction {
+
+    @Override
+    public Object apply(List<Object> args, Context context) throws ParseException {
+      Parser parser;
+      if(hasArg("config", 0, String.class, args)) {
+        String arg = getArg("config", 0, String.class, args);
+        parser = new Parser(arg);
+
+      } else {
+        Map<String, Object> arg = getArg("config", 0, Map.class, args);
+        parser = new Parser(arg);
+      }
+
+      // handle the optional globals
+      if(hasArg("globals", 1, Map.class, args)) {
+        Map<String, Object> globals = getArg("globals", 1, Map.class, args);
+        parser.withGlobals(globals);
+      }
+
+      return parser;
+    }
+
+    @Override
+    public void initialize(Context context) {
+      // nothing to do
+    }
+
+    @Override
+    public boolean isInitialized() {
+      return true;
+    }
+  }
+
+  @Stellar(
+          namespace = "PARSER",
+          name = "PARSE",
+          description = "TODO",
+          params = {
+                  "TODO"
+          },
+          returns = "A parser runner."
+  )
+  public static class ParserRun implements StellarFunction {
+
+    @Override
+    public Object apply(List<Object> args, Context context) throws ParseException {
+      Parser parser = getArg("config", 0, Parser.class, args);
+
+      byte[] inputArg;
+      if(hasArg("input", 1, String.class, args)) {
+        // convert a String to raw bytes
+        inputArg = getArg("input", 1, String.class, args).getBytes();
+
+      } else {
+        // otherwise assume its the raw bytes
+        inputArg = getArg("input", 1, byte[].class, args);
+      }
+
+      // run the parser against the raw input
+      RawMessage rawMessage = DEFAULT.get(emptyMap(), inputArg, false, emptyMap());
+      ParserRunnerImpl parserRunner = new ParserRunnerImpl(Collections.singleton(FIXED_SENSOR_TYPE));
+      parserRunner.init(() -> parser.getParserConfigurations(), context);
+      ParserRunnerResults<JSONObject> results = parserRunner.execute(FIXED_SENSOR_TYPE, rawMessage, parser.getParserConfigurations());
+
+      // join both messages and errors into a list that can be returned
+      Stream<JSONObject> messages = results
+              .getMessages()
+              .stream();
+      Stream<JSONObject> errors = results
+              .getErrors()
+              .stream()
+              .map(error -> error.getJSONObject());
+      return Stream.concat(messages, errors)
+              .collect(Collectors.toList());
+    }
+
+    @Override
+    public void initialize(Context context) {
+      // nothing to do
+    }
+
+    @Override
+    public boolean isInitialized() {
+      return true;
+    }
+  }
+}

--- a/metron-platform/metron-management/src/main/java/org/apache/metron/management/ParserFunctions.java
+++ b/metron-platform/metron-management/src/main/java/org/apache/metron/management/ParserFunctions.java
@@ -111,7 +111,7 @@ public class ParserFunctions {
 
       List<String> messages = new ArrayList<>();
       if(hasArg(inputArgName, 1, String.class, args)) {
-        // the input is a single message as a strign
+        // the input is a single message as a string
         String msg = getArg(inputArgName, 1, String.class, args);
         messages.add(msg);
 

--- a/metron-platform/metron-management/src/main/java/org/apache/metron/management/StellarParserRunner.java
+++ b/metron-platform/metron-management/src/main/java/org/apache/metron/management/StellarParserRunner.java
@@ -27,6 +27,7 @@ import org.json.simple.JSONObject;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -68,7 +69,9 @@ public class StellarParserRunner {
 
     private List<JSONObject> doParse(List<String> messages) {
         // initialize
-        ParserRunnerImpl runner = new ParserRunnerImpl(Collections.singleton(sensorType));
+        HashSet<String> sensorTypes = new HashSet<>();
+        sensorTypes.add(sensorType);
+        ParserRunnerImpl runner = new ParserRunnerImpl(sensorTypes);
         runner.init(() -> parserConfigurations, context);
 
         // parse each message

--- a/metron-platform/metron-management/src/main/java/org/apache/metron/management/StellarParserRunner.java
+++ b/metron-platform/metron-management/src/main/java/org/apache/metron/management/StellarParserRunner.java
@@ -1,0 +1,134 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.management;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.metron.common.configuration.ParserConfigurations;
+import org.apache.metron.common.configuration.SensorParserConfig;
+import org.apache.metron.parsers.ParserRunnerImpl;
+import org.apache.metron.parsers.ParserRunnerResults;
+import org.apache.metron.stellar.dsl.Context;
+import org.json.simple.JSONObject;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyMap;
+import static org.apache.metron.common.message.metadata.RawMessageStrategies.DEFAULT;
+
+/**
+ * Enables parsing of messages in the Stellar REPL.
+ *
+ * <p>Maintains all of the state between subsequent executions of the parser functions.
+ */
+public class StellarParserRunner {
+
+    private String sensorType;
+    private ParserConfigurations parserConfigurations;
+    private Context context;
+
+    /**
+     * @param sensorType The sensor type of the messages to parse.
+     */
+    public StellarParserRunner(String sensorType) {
+        this.sensorType = sensorType;
+    }
+
+    public List<JSONObject> parse(List<String> messages) {
+        if(parserConfigurations == null) {
+            throw new IllegalArgumentException("Missing required parser configuration");
+        }
+        if(context == null) {
+            throw new IllegalArgumentException("Missing required context");
+        }
+        return doParse(messages);
+    }
+
+    private List<JSONObject> doParse(List<String> messages) {
+        // initialize
+        ParserRunnerImpl runner = new ParserRunnerImpl(Collections.singleton(sensorType));
+        runner.init(() -> parserConfigurations, context);
+
+        // parse each message
+        List<ParserRunnerResults<JSONObject>> results = messages
+                .stream()
+                .map(str -> str.getBytes())
+                .map(msg -> DEFAULT.get(emptyMap(), msg, false, emptyMap()))
+                .map(msg -> runner.execute(sensorType, msg, parserConfigurations))
+                .collect(Collectors.toList());
+
+        // aggregate both successes and errors into a list that can be returned
+        Stream<JSONObject> successes = results
+                .stream()
+                .flatMap(result -> result.getMessages().stream());
+        Stream<JSONObject> errors = results
+                .stream()
+                .flatMap(result -> result.getErrors().stream())
+                .map(err -> err.getJSONObject());
+        return Stream.concat(successes, errors)
+                .collect(Collectors.toList());
+    }
+
+    public StellarParserRunner withParserConfiguration(String sensorConfig) {
+        parserConfigurations = create(sensorConfig.getBytes());
+        return this;
+    }
+
+    public StellarParserRunner withParserConfiguration(Map<String, Object> config) {
+        parserConfigurations = create(new JSONObject(config).toJSONString().getBytes());
+        return this;
+    }
+
+    public StellarParserRunner withContext(Context context) {
+        this.context = context;
+        return this;
+    }
+
+    public StellarParserRunner withGlobals(Map<String, Object> globals) {
+        parserConfigurations.updateGlobalConfig(globals);
+        return this;
+    }
+
+    public ParserConfigurations getParserConfigurations() {
+        return parserConfigurations;
+    }
+
+    private ParserConfigurations create(byte[] sensorConfig) {
+        try {
+            ParserConfigurations result = new ParserConfigurations();
+            result.updateSensorParserConfig(sensorType, SensorParserConfig.fromBytes(sensorConfig));
+            return result;
+
+        } catch(IOException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        try {
+            return parserConfigurations.getSensorParserConfig(sensorType).toJSON();
+        } catch(JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/metron-platform/metron-management/src/main/java/org/apache/metron/management/StellarParserRunner.java
+++ b/metron-platform/metron-management/src/main/java/org/apache/metron/management/StellarParserRunner.java
@@ -18,7 +18,6 @@
 package org.apache.metron.management;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.collect.Iterables;
 import org.apache.metron.common.configuration.ParserConfigurations;
 import org.apache.metron.common.configuration.SensorParserConfig;
 import org.apache.metron.parsers.ParserRunnerImpl;
@@ -27,12 +26,10 @@ import org.apache.metron.stellar.dsl.Context;
 import org.json.simple.JSONObject;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
 import static org.apache.metron.common.message.metadata.RawMessageStrategies.DEFAULT;
@@ -78,7 +75,7 @@ public class StellarParserRunner {
         List<ParserRunnerResults<JSONObject>> results = messages
                 .stream()
                 .map(str -> str.getBytes())
-                .map(msg -> DEFAULT.get(emptyMap(), msg, false, emptyMap()))
+                .map(bytes -> DEFAULT.get(emptyMap(), bytes, false, emptyMap()))
                 .map(msg -> runner.execute(sensorType, msg, parserConfigurations))
                 .collect(Collectors.toList());
 

--- a/metron-platform/metron-management/src/test/java/org/apache/metron/management/ParserFunctionsTest.java
+++ b/metron-platform/metron-management/src/test/java/org/apache/metron/management/ParserFunctionsTest.java
@@ -22,11 +22,8 @@ package org.apache.metron.management;
 import org.adrianwalker.multilinestring.Multiline;
 import org.apache.metron.common.Constants;
 import org.apache.metron.stellar.common.DefaultStellarStatefulExecutor;
-import org.apache.metron.stellar.common.StellarProcessor;
 import org.apache.metron.stellar.common.StellarStatefulExecutor;
 import org.apache.metron.stellar.dsl.Context;
-import org.apache.metron.stellar.dsl.MapVariableResolver;
-import org.apache.metron.stellar.dsl.VariableResolver;
 import org.apache.metron.stellar.dsl.functions.resolver.FunctionResolver;
 import org.apache.metron.stellar.dsl.functions.resolver.SimpleFunctionResolver;
 import org.json.simple.JSONObject;
@@ -42,14 +39,37 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.metron.common.Constants.Fields.*;
+import static org.apache.metron.common.Constants.ErrorFields.ERROR_HASH;
+import static org.apache.metron.common.Constants.ErrorFields.ERROR_TYPE;
+import static org.apache.metron.common.Constants.ErrorFields.EXCEPTION;
+import static org.apache.metron.common.Constants.ErrorFields.MESSAGE;
+import static org.apache.metron.common.Constants.ErrorFields.STACK;
+import static org.apache.metron.common.Constants.Fields.DST_ADDR;
+import static org.apache.metron.common.Constants.Fields.DST_PORT;
+import static org.apache.metron.common.Constants.Fields.SRC_ADDR;
+import static org.apache.metron.common.Constants.Fields.SRC_PORT;
 
 /**
- * TODO
+ * Tests the {@link ParserFunctions} class.
  */
 public class ParserFunctionsTest {
 
   static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  FunctionResolver functionResolver;
+  Map<String, Object> variables;
+  Context context = null;
+  StellarStatefulExecutor executor;
+
+  @Before
+  public void setup() {
+    variables = new HashMap<>();
+    functionResolver = new SimpleFunctionResolver()
+            .withClass(ParserFunctions.ParseFunction.class)
+            .withClass(ParserFunctions.InitializeFunction.class);
+    context = new Context.Builder().build();
+    executor = new DefaultStellarStatefulExecutor(functionResolver, context);
+  }
 
   /**
    * {
@@ -85,47 +105,19 @@ public class ParserFunctionsTest {
 
   /**
    * {
-   *  "fieldValidations" : [
-   *     {
-   *      "input" : [ "ip_src_addr", "ip_dst_addr"],
-   *      "validation" : "IP"
-   *     }
-   *   ]
-   * }
-   */
-  @Multiline
-  private String globals;
-
-  /**
-   * {
    *  "parserClassName":"org.apache.metron.parsers.bro.BasicBroParser",
    *  "filterClassName":"org.apache.metron.parsers.filters.StellarFilter",
    *  "sensorTopic":"bro"
    * }
    */
   @Multiline
-  private String broConfig;
-
-  FunctionResolver functionResolver;
-  Map<String, Object> variables;
-  Context context = null;
-  StellarStatefulExecutor executor;
-
-  @Before
-  public void setup() {
-    variables = new HashMap<>();
-    functionResolver = new SimpleFunctionResolver()
-            .withClass(ParserFunctions.ParserInit.class)
-            .withClass(ParserFunctions.ParserRun.class);
-    context = new Context.Builder().build();
-    executor = new DefaultStellarStatefulExecutor(functionResolver, context);
-  }
+  private String broParserConfig;
 
   @Test
-  public void test() {
+  public void testParseBroMessage() {
     // initialize the parser with the sensor config
-    set("config", broConfig);
-    assign("parser", "PARSER_INIT(config)");
+    set("config", broParserConfig);
+    assign("parser", "PARSER_INIT('bro', config)");
 
     // parse the message
     set("message", broMessage);
@@ -134,11 +126,91 @@ public class ParserFunctionsTest {
     // validate the parsed message
     Assert.assertEquals(1, messages.size());
     JSONObject message = messages.get(0);
+    Assert.assertEquals("bro", message.get(Constants.SENSOR_TYPE));
     Assert.assertEquals("10.122.196.204", message.get(SRC_ADDR.getName()));
     Assert.assertEquals(33976L, message.get(SRC_PORT.getName()));
     Assert.assertEquals("144.254.71.184", message.get(DST_ADDR.getName()));
     Assert.assertEquals(53L, message.get(DST_PORT.getName()));
     Assert.assertEquals("dns", message.get("protocol"));
+  }
+
+  @Test
+  public void testParseMultipleMessages() {
+    // initialize the parser with the sensor config
+    set("config", broParserConfig);
+    assign("parser", "PARSER_INIT('bro', config)");
+
+    // parse the message
+    set("msg1", broMessage);
+    set("msg2", broMessage);
+    set("msg3", broMessage);
+    List<JSONObject> messages = execute("PARSER_PARSE(parser, [msg1, msg2, msg3])", List.class);
+
+    // expect a parsed message
+    Assert.assertEquals(3, messages.size());
+    for(JSONObject message: messages) {
+      Assert.assertEquals("bro", message.get(Constants.SENSOR_TYPE));
+      Assert.assertTrue(message.containsKey(Constants.GUID));
+      Assert.assertEquals("10.122.196.204", message.get(SRC_ADDR.getName()));
+      Assert.assertEquals(33976L, message.get(SRC_PORT.getName()));
+      Assert.assertEquals("144.254.71.184", message.get(DST_ADDR.getName()));
+      Assert.assertEquals(53L, message.get(DST_PORT.getName()));
+      Assert.assertEquals("dns", message.get("protocol"));
+    }
+  }
+
+  @Test
+  public void testParseInvalidMessage() {
+    // initialize the parser with the sensor config
+    set("config", broParserConfig);
+    assign("parser", "PARSER_INIT('bro', config)");
+
+    // parse the message
+    String invalidMessage = "{ this is an invalid message }}";
+    set("message", invalidMessage);
+    List<JSONObject> messages = execute("PARSER_PARSE(parser, message)", List.class);
+
+    // validate the parsed message
+    Assert.assertEquals(1, messages.size());
+
+    // expect an error message to be returned
+    JSONObject error = messages.get(0);
+    Assert.assertEquals(invalidMessage, error.get("raw_message"));
+    Assert.assertEquals(Constants.ERROR_TYPE, error.get(Constants.SENSOR_TYPE));
+    Assert.assertEquals("parser_error", error.get(ERROR_TYPE.getName()));
+    Assert.assertTrue(error.containsKey(MESSAGE.getName()));
+    Assert.assertTrue(error.containsKey(EXCEPTION.getName()));
+    Assert.assertTrue(error.containsKey(STACK.getName()));
+    Assert.assertTrue(error.containsKey(ERROR_HASH.getName()));
+    Assert.assertTrue(error.containsKey(Constants.GUID));
+  }
+
+  @Test
+  public void testParseSomeGoodSomeBadMessages() {
+    // initialize the parser with the sensor config
+    set("config", broParserConfig);
+    assign("parser", "PARSER_INIT('bro', config)");
+
+    // parse the message
+    String invalidMessage = "{ this is an invalid message }}";
+    set("msg1", broMessage);
+    set("msg2", invalidMessage);
+    List<JSONObject> messages = execute("PARSER_PARSE(parser, [msg1, msg2])", List.class);
+
+    // expect 2 messages to be returned - 1 success and 1 error
+    Assert.assertEquals(2, messages.size());
+    Assert.assertEquals(1, messages.stream().filter(msg -> isBro(msg)).count());
+    Assert.assertEquals(1, messages.stream().filter(msg -> isError(msg)).count());
+  }
+
+  private boolean isError(JSONObject message) {
+    String sensorType = String.class.cast(message.get(Constants.SENSOR_TYPE));
+    return Constants.ERROR_TYPE.equals(sensorType);
+  }
+
+  private boolean isBro(JSONObject message) {
+    String sensorType = String.class.cast(message.get(Constants.SENSOR_TYPE));
+    return "bro".equals(sensorType);
   }
 
   /**

--- a/metron-platform/metron-management/src/test/java/org/apache/metron/management/ParserFunctionsTest.java
+++ b/metron-platform/metron-management/src/test/java/org/apache/metron/management/ParserFunctionsTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.metron.management;
+
+import org.adrianwalker.multilinestring.Multiline;
+import org.apache.metron.common.Constants;
+import org.apache.metron.stellar.common.DefaultStellarStatefulExecutor;
+import org.apache.metron.stellar.common.StellarProcessor;
+import org.apache.metron.stellar.common.StellarStatefulExecutor;
+import org.apache.metron.stellar.dsl.Context;
+import org.apache.metron.stellar.dsl.MapVariableResolver;
+import org.apache.metron.stellar.dsl.VariableResolver;
+import org.apache.metron.stellar.dsl.functions.resolver.FunctionResolver;
+import org.apache.metron.stellar.dsl.functions.resolver.SimpleFunctionResolver;
+import org.json.simple.JSONObject;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.metron.common.Constants.Fields.*;
+
+/**
+ * TODO
+ */
+public class ParserFunctionsTest {
+
+  static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  /**
+   * {
+   *  "dns": {
+   *  "ts":1402308259.609,
+   *  "uid":"CuJT272SKaJSuqO0Ia",
+   *  "id.orig_h":"10.122.196.204",
+   *  "id.orig_p":33976,
+   *  "id.resp_h":"144.254.71.184",
+   *  "id.resp_p":53,
+   *  "proto":"udp",
+   *  "trans_id":62418,
+   *  "query":"www.cisco.com",
+   *  "qclass":1,
+   *  "qclass_name":"C_INTERNET",
+   *  "qtype":28,
+   *  "qtype_name":"AAAA",
+   *  "rcode":0,
+   *  "rcode_name":"NOERROR",
+   *  "AA":true,
+   *  "TC":false,
+   *  "RD":true,
+   *  "RA":true,
+   *  "Z":0,
+   *  "answers":["www.cisco.com.akadns.net","origin-www.cisco.com","2001:420:1201:2::a"],
+   *  "TTLs":[3600.0,289.0,14.0],
+   *  "rejected":false
+   *  }
+   * }
+   */
+  @Multiline
+  public String broMessage;
+
+  /**
+   * {
+   *  "fieldValidations" : [
+   *     {
+   *      "input" : [ "ip_src_addr", "ip_dst_addr"],
+   *      "validation" : "IP"
+   *     }
+   *   ]
+   * }
+   */
+  @Multiline
+  private String globals;
+
+  /**
+   * {
+   *  "parserClassName":"org.apache.metron.parsers.bro.BasicBroParser",
+   *  "filterClassName":"org.apache.metron.parsers.filters.StellarFilter",
+   *  "sensorTopic":"bro"
+   * }
+   */
+  @Multiline
+  private String broConfig;
+
+  FunctionResolver functionResolver;
+  Map<String, Object> variables;
+  Context context = null;
+  StellarStatefulExecutor executor;
+
+  @Before
+  public void setup() {
+    variables = new HashMap<>();
+    functionResolver = new SimpleFunctionResolver()
+            .withClass(ParserFunctions.ParserInit.class)
+            .withClass(ParserFunctions.ParserRun.class);
+    context = new Context.Builder().build();
+    executor = new DefaultStellarStatefulExecutor(functionResolver, context);
+  }
+
+  @Test
+  public void test() {
+    // initialize the parser with the sensor config
+    set("config", broConfig);
+    assign("parser", "PARSER_INIT(config)");
+
+    // parse the message
+    set("message", broMessage);
+    List<JSONObject> messages = execute("PARSER_PARSE(parser, message)", List.class);
+
+    // validate the parsed message
+    Assert.assertEquals(1, messages.size());
+    JSONObject message = messages.get(0);
+    Assert.assertEquals("10.122.196.204", message.get(SRC_ADDR.getName()));
+    Assert.assertEquals(33976L, message.get(SRC_PORT.getName()));
+    Assert.assertEquals("144.254.71.184", message.get(DST_ADDR.getName()));
+    Assert.assertEquals(53L, message.get(DST_PORT.getName()));
+    Assert.assertEquals("dns", message.get("protocol"));
+  }
+
+  /**
+   * Set the value of a variable.
+   *
+   * @param var The variable to assign.
+   * @param value The value to assign.
+   */
+  private void set(String var, Object value) {
+    executor.assign(var, value);
+  }
+
+  /**
+   * Assign a value to the result of an expression.
+   *
+   * @param var The variable to assign.
+   * @param expression The expression to execute.
+   */
+  private Object assign(String var, String expression) {
+    executor.assign(var, expression, Collections.emptyMap());
+    return executor.getState().get(var);
+  }
+
+  /**
+   * Execute a Stellar expression.
+   *
+   * @param expression The Stellar expression to execute.
+   * @param clazz
+   * @param <T>
+   * @return The result of executing the Stellar expression.
+   */
+  private <T> T execute(String expression, Class<T> clazz) {
+    T results = executor.execute(expression, Collections.emptyMap(), clazz);
+    LOG.debug("{} = {}", expression, results);
+    return results;
+  }
+}

--- a/metron-platform/metron-management/src/test/java/org/apache/metron/management/StellarParserRunnerTest.java
+++ b/metron-platform/metron-management/src/test/java/org/apache/metron/management/StellarParserRunnerTest.java
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.management;
+
+import org.adrianwalker.multilinestring.Multiline;
+import org.apache.metron.common.Constants;
+import org.apache.metron.stellar.dsl.Context;
+import org.json.simple.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.metron.common.Constants.ErrorFields.ERROR_HASH;
+import static org.apache.metron.common.Constants.ErrorFields.ERROR_TYPE;
+import static org.apache.metron.common.Constants.ErrorFields.EXCEPTION;
+import static org.apache.metron.common.Constants.ErrorFields.MESSAGE;
+import static org.apache.metron.common.Constants.ErrorFields.STACK;
+import static org.apache.metron.common.Constants.Fields.DST_ADDR;
+import static org.apache.metron.common.Constants.Fields.DST_PORT;
+import static org.apache.metron.common.Constants.Fields.SRC_ADDR;
+import static org.apache.metron.common.Constants.Fields.SRC_PORT;
+
+public class StellarParserRunnerTest {
+
+    /**
+     * {
+     *  "dns": {
+     *  "ts":1402308259.609,
+     *  "uid":"CuJT272SKaJSuqO0Ia",
+     *  "id.orig_h":"10.122.196.204",
+     *  "id.orig_p":33976,
+     *  "id.resp_h":"144.254.71.184",
+     *  "id.resp_p":53,
+     *  "proto":"udp",
+     *  "trans_id":62418,
+     *  "query":"www.cisco.com",
+     *  "qclass":1,
+     *  "qclass_name":"C_INTERNET",
+     *  "qtype":28,
+     *  "qtype_name":"AAAA",
+     *  "rcode":0,
+     *  "rcode_name":"NOERROR",
+     *  "AA":true,
+     *  "TC":false,
+     *  "RD":true,
+     *  "RA":true,
+     *  "Z":0,
+     *  "answers":["www.cisco.com.akadns.net","origin-www.cisco.com","2001:420:1201:2::a"],
+     *  "TTLs":[3600.0,289.0,14.0],
+     *  "rejected":false
+     *  }
+     * }
+     */
+    @Multiline
+    public String broMessage;
+
+    /**
+     * {
+     *  "parserClassName":"org.apache.metron.parsers.bro.BasicBroParser",
+     *  "filterClassName":"org.apache.metron.parsers.filters.StellarFilter",
+     *  "sensorTopic":"bro"
+     * }
+     */
+    @Multiline
+    private String broParserConfig;
+
+    @Test
+    public void testParseMessage() {
+        List<String> toParse = new ArrayList<>();
+        toParse.add(broMessage);
+        toParse.add(broMessage);
+        toParse.add(broMessage);
+
+        // parse the messages
+        StellarParserRunner runner = new StellarParserRunner("bro")
+                .withParserConfiguration(broParserConfig)
+                .withContext(Context.EMPTY_CONTEXT());
+        List<JSONObject> messages = runner.parse(toParse);
+
+        // expect 3 successfully parsed message
+        Assert.assertEquals(3, messages.size());
+        for(JSONObject message: messages) {
+            Assert.assertEquals("bro", message.get(Constants.SENSOR_TYPE));
+            Assert.assertTrue(message.containsKey(Constants.GUID));
+            Assert.assertEquals("10.122.196.204", message.get(SRC_ADDR.getName()));
+            Assert.assertEquals(33976L, message.get(SRC_PORT.getName()));
+            Assert.assertEquals("144.254.71.184", message.get(DST_ADDR.getName()));
+            Assert.assertEquals(53L, message.get(DST_PORT.getName()));
+            Assert.assertEquals("dns", message.get("protocol"));
+        }
+    }
+
+    @Test
+    public void testParseInvalidMessage() {
+        List<String> toParse = new ArrayList<>();
+        toParse.add("{DAS}");
+
+        // parse the messages
+        StellarParserRunner runner = new StellarParserRunner("bro")
+                .withParserConfiguration(broParserConfig)
+                .withContext(Context.EMPTY_CONTEXT());
+        List<JSONObject> messages = runner.parse(toParse);
+
+        // expect an error message to be returned
+        JSONObject error = messages.get(0);
+        Assert.assertEquals(toParse.get(0), error.get("raw_message"));
+        Assert.assertEquals(Constants.ERROR_TYPE, error.get(Constants.SENSOR_TYPE));
+        Assert.assertEquals("parser_error", error.get(ERROR_TYPE.getName()));
+        Assert.assertTrue(error.containsKey(MESSAGE.getName()));
+        Assert.assertTrue(error.containsKey(EXCEPTION.getName()));
+        Assert.assertTrue(error.containsKey(STACK.getName()));
+        Assert.assertTrue(error.containsKey(ERROR_HASH.getName()));
+        Assert.assertTrue(error.containsKey(Constants.GUID));
+    }
+}

--- a/metron-platform/metron-management/src/test/java/org/apache/metron/management/StellarParserRunnerTest.java
+++ b/metron-platform/metron-management/src/test/java/org/apache/metron/management/StellarParserRunnerTest.java
@@ -129,4 +129,20 @@ public class StellarParserRunnerTest {
         Assert.assertTrue(error.containsKey(ERROR_HASH.getName()));
         Assert.assertTrue(error.containsKey(Constants.GUID));
     }
+
+    @Test
+    public void testToString() {
+        List<String> toParse = new ArrayList<>();
+        toParse.add(broMessage);
+        toParse.add("{DAS}");
+
+        // parse the messages
+        StellarParserRunner runner = new StellarParserRunner("bro")
+                .withParserConfiguration(broParserConfig)
+                .withContext(Context.EMPTY_CONTEXT());
+        List<JSONObject> messages = runner.parse(toParse);
+
+        // toString() should tally the number of successes and failures
+        Assert.assertEquals("Parser{1 successful, 1 error(s)}", runner.toString());
+    }
 }

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/ParserRunnerImpl.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/ParserRunnerImpl.java
@@ -87,13 +87,13 @@ public class ParserRunnerImpl implements ParserRunner<JSONObject>, Serializable 
   protected transient Consumer<ParserRunnerResults> onSuccess;
   protected transient Consumer<MetronError> onError;
 
-  private Set<String> sensorTypes;
+  private HashSet<String> sensorTypes;
   private Map<String, ParserComponent> sensorToParserComponentMap;
 
   // Stellar variables
   private transient Context stellarContext;
 
-  public ParserRunnerImpl(Set<String> sensorTypes) {
+  public ParserRunnerImpl(HashSet<String> sensorTypes) {
     this.sensorTypes = sensorTypes;
   }
 

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/ParserRunnerImpl.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/ParserRunnerImpl.java
@@ -87,13 +87,13 @@ public class ParserRunnerImpl implements ParserRunner<JSONObject>, Serializable 
   protected transient Consumer<ParserRunnerResults> onSuccess;
   protected transient Consumer<MetronError> onError;
 
-  private HashSet<String> sensorTypes;
+  private Set<String> sensorTypes;
   private Map<String, ParserComponent> sensorToParserComponentMap;
 
   // Stellar variables
   private transient Context stellarContext;
 
-  public ParserRunnerImpl(HashSet<String> sensorTypes) {
+  public ParserRunnerImpl(Set<String> sensorTypes) {
     this.sensorTypes = sensorTypes;
   }
 


### PR DESCRIPTION
Users should be able to parse messages in a controlled environment like the Stellar REPL.  This can help troubleshoot issues that are occurring at high velocity in a live Parser topology.  

* This could help a user understand why a deployed parser is not working as they would expect.  
* This can help a user to test their parser configuration before deploying to their live Metron cluster.
* This can help a user understand why a particular message is failing to parse successfully.

## Try It Out

Try out the following examples in the Stellar REPL.

### Parse a Message

1. Define the parser configuration.
    ```
    [Stellar]>>> config := SHELL_EDIT()
    {
         "parserClassName":"org.apache.metron.parsers.bro.BasicBroParser",
         "filterClassName":"org.apache.metron.parsers.filters.StellarFilter",
         "sensorTopic":"bro"
    }
    ```

1. Grab a message from the input topic to parse. You could also just mock-up a message that you would like to test.
    ```
    [Stellar]>>> bro := KAFKA_GET('bro')
    [{"http": {"ts":1542313125.807068,"uid":"CUrRne3iLIxXavQtci","id.orig_h"...
    ```

1. Initialize the parser. The parser keeps track of the number of successes and failures which can be useful when parsing a batch of messages.
    ```
    [Stellar]>>> parser := PARSER_INIT("bro", config)
    Parser{0 successful, 0 error(s)}
    ```

1. Parse the message.
    ```
    [Stellar]>>> msgs := PARSER_PARSE(parser, bro)
    [{"bro_timestamp":"1542313125.807068","method":"GET","ip_dst_port":8080,...
    ```

1. Review the successfully parsed message.
    ```
    [Stellar]>>> LENGTH(msgs)
    1
    ```
    ```
    [Stellar]>>> msg := GET(msgs, 0)

    [Stellar]>>> MAP_GET("guid", msg)
    7f2e0c77-c58c-488e-b1ad-fbec10fb8182
    ```
    ```
    [Stellar]>>> MAP_GET("timestamp", msg)
    1542313125807
    ```
    ```
    [Stellar]>>> MAP_GET("source.type", msg)
    bro
    ```

1. The parser will tally the success.
    ```
    [Stellar]>>> parser
    Parser{1 successful, 0 error(s)}
    ```

### Parse Multiple Messages

1. Grab 5 raw input messages from Kafka.
    ```
    [Stellar]>>> input := KAFKA_GET("bro", 5)
    [{"dns": {"ts":1542313125.342913,"uid":"CmJWpN3Ynwsggof57e", ...
    ```

1. Parse the messages.
    ```
    [Stellar]>>> msgs := PARSER_PARSE(parser, input)
    [{"TTLs":[13888.0],"qclass_name":"C_INTERNET", ...
    ```

1. Review the parsed messages.  There were 5 messages returned and each have a valid GUID as you would expect.
    ```
    [Stellar]>>> LENGTH(msgs)
    5
    ```
    ```
    [Stellar]>>> MAP(msgs, m -> MAP_GET("guid", m))
    [3b40ab62-ab6a-4dff-86c5-f35cdb2b01ea, 3b5826a7-f2d4-4df2-a28a-ab1f66037b4b, 9fc5f794-26f6-464f-bb99-05fb649ea465, c7162bee-01f9-4cc2-8e26-13101bc22ac1, b86dbb50-cb1d-4889-87ee-3919bcce6fdb]
    ````

### Parse an Invalid Message

1. Mock-up a message that will fail to parse.
    ```
    [Stellar]>>> invalid := "{invalid>"
    {invalid>
    ```

1. Parse the invalid message.  This will return the error message that is pushed onto the error topic.  The error message contains all of the details indicating why parsing was unsuccessful.
    ```
    [Stellar]>>> errors := PARSER_PARSE(parser, invalid)
    2018-11-15 20:29:01 ERROR BasicBroParser:144 - Unable to parse Message: {invalid>
    Unexpected character (i) at position 1.
    	at org.json.simple.parser.Yylex.yylex(Yylex.java:610)
    	at org.json.simple.parser.JSONParser.nextToken(JSONParser.java:269)
    	at org.json.simple.parser.JSONParser.parse(JSONParser.java:118)
    	at org.json.simple.parser.JSONParser.parse(JSONParser.java:81)
    	at org.json.simple.parser.JSONParser.parse(JSONParser.java:75)
    	at org.apache.metron.parsers.bro.JSONCleaner.clean(JSONCleaner.java:49)
    	at org.apache.metron.parsers.bro.BasicBroParser.parse(BasicBroParser.java:68)
    	at org.apache.metron.parsers.interfaces.MessageParser.parseOptional(MessageParser.java:54)
    	at org.apache.metron.parsers.interfaces.MessageParser.parseOptionalResult(MessageParser.java:67)
    	at org.apache.metron.parsers.ParserRunnerImpl.execute(ParserRunnerImpl.java:146)
    	at org.apache.metron.management.StellarParserRunner.lambda$doParse$3(StellarParserRunner.java:76)
    	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
    	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
    	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
    	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1382)
    	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
    	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
    	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
    	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
    	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
    	at org.apache.metron.management.StellarParserRunner.doParse(StellarParserRunner.java:77)
    	at org.apache.metron.management.StellarParserRunner.parse(StellarParserRunner.java:62)
    	at org.apache.metron.management.ParserFunctions$ParseFunction.apply(ParserFunctions.java:98)
    	at org.apache.metron.stellar.common.StellarCompiler.lambda$exitTransformationFunc$13(StellarCompiler.java:652)
    	at org.apache.metron.stellar.common.StellarCompiler$Expression.apply(StellarCompiler.java:250)
    	at org.apache.metron.stellar.common.BaseStellarProcessor.parse(BaseStellarProcessor.java:151)
    	at org.apache.metron.stellar.common.shell.DefaultStellarShellExecutor.executeStellar(DefaultStellarShellExecutor.java:405)
    	at org.apache.metron.stellar.common.shell.DefaultStellarShellExecutor.execute(DefaultStellarShellExecutor.java:257)
    	at org.apache.metron.stellar.common.shell.specials.AssignmentCommand.execute(AssignmentCommand.java:66)
    	at org.apache.metron.stellar.common.shell.DefaultStellarShellExecutor.execute(DefaultStellarShellExecutor.java:252)
    	at org.apache.metron.stellar.common.shell.cli.StellarShell.execute(StellarShell.java:359)
    	at org.jboss.aesh.console.AeshProcess.run(AeshProcess.java:53)
    	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    	at java.lang.Thread.run(Thread.java:748)
    [{"exception":"java.lang.IllegalStateException: Unable to parse Message: {invalid>","failed_sensor_type":"bro","stack":"java.lang.IllegalStateException: Unable to parse Message: {invalid>\n\tat org.apache.metron.parsers.bro.BasicBroParser.parse(BasicBroParser.java:145)\n\tat org.apache.metron.parsers.interfaces.MessageParser.parseOptional(MessageParser.java:54)\n\tat org.apache.metron.parsers.interfaces.MessageParser.parseOptionalResult(MessageParser.java:67)\n\tat org.apache.metron.parsers.ParserRunnerImpl.execute(ParserRunnerImpl.java:146)\n\tat org.apache.metron.management.StellarParserRunner.lambda$doParse$3(StellarParserRunner.java:76)\n\tat java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)\n\tat java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)\n\tat java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)\n\tat java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1382)\n\tat java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)\n\tat java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)\n\tat java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)\n\tat java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)\n\tat java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)\n\tat org.apache.metron.management.StellarParserRunner.doParse(StellarParserRunner.java:77)\n\tat org.apache.metron.management.StellarParserRunner.parse(StellarParserRunner.java:62)\n\tat org.apache.metron.management.ParserFunctions$ParseFunction.apply(ParserFunctions.java:98)\n\tat org.apache.metron.stellar.common.StellarCompiler.lambda$exitTransformationFunc$13(StellarCompiler.java:652)\n\tat org.apache.metron.stellar.common.StellarCompiler$Expression.apply(StellarCompiler.java:250)\n\tat org.apache.metron.stellar.common.BaseStellarProcessor.parse(BaseStellarProcessor.java:151)\n\tat org.apache.metron.stellar.common.shell.DefaultStellarShellExecutor.executeStellar(DefaultStellarShellExecutor.java:405)\n\tat org.apache.metron.stellar.common.shell.DefaultStellarShellExecutor.execute(DefaultStellarShellExecutor.java:257)\n\tat org.apache.metron.stellar.common.shell.specials.AssignmentCommand.execute(AssignmentCommand.java:66)\n\tat org.apache.metron.stellar.common.shell.DefaultStellarShellExecutor.execute(DefaultStellarShellExecutor.java:252)\n\tat org.apache.metron.stellar.common.shell.cli.StellarShell.execute(StellarShell.java:359)\n\tat org.jboss.aesh.console.AeshProcess.run(AeshProcess.java:53)\n\tat java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)\n\tat java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)\n\tat java.lang.Thread.run(Thread.java:748)\nCaused by: Unexpected character (i) at position 1.\n\tat org.json.simple.parser.Yylex.yylex(Yylex.java:610)\n\tat org.json.simple.parser.JSONParser.nextToken(JSONParser.java:269)\n\tat org.json.simple.parser.JSONParser.parse(JSONParser.java:118)\n\tat org.json.simple.parser.JSONParser.parse(JSONParser.java:81)\n\tat org.json.simple.parser.JSONParser.parse(JSONParser.java:75)\n\tat org.apache.metron.parsers.bro.JSONCleaner.clean(JSONCleaner.java:49)\n\tat org.apache.metron.parsers.bro.BasicBroParser.parse(BasicBroParser.java:68)\n\t... 28 more\n","hostname":"node1","raw_message":"{invalid>","error_hash":"e547a79488545c912977781a8d556341b3263943fad484f4d4b87e3b6052eac2","error_type":"parser_error","guid":"a2e06d23-6cef-4f26-b0ba-52263764d4ef","message":"Unable to parse Message: {invalid>","source.type":"error","timestamp":1542313741271}]
    ```

1. Review the details of the error.
    ```
    [Stellar]>>> error := GET(errors, 0)

    [Stellar]>>> MAP_GET("raw_message", error)
    {invalid>

    [Stellar]>>> MAP_GET("message", error)
    Unable to parse Message: {invalid>

    [Stellar]>>> MAP_GET("stack", error)
    java.lang.IllegalStateException: Unable to parse Message: {invalid>
    	at org.apache.metron.parsers.bro.BasicBroParser.parse(BasicBroParser.java:145)
    	at org.apache.metron.parsers.interfaces.MessageParser.parseOptional(MessageParser.java:54)
    	at org.apache.metron.parsers.interfaces.MessageParser.parseOptionalResult(MessageParser.java:67)
    	at org.apache.metron.parsers.ParserRunnerImpl.execute(ParserRunnerImpl.java:146)
    	at org.apache.metron.management.StellarParserRunner.lambda$doParse$3(StellarParserRunner.java:76)
    	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
    	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
    	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
    	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1382)
    	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
    	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
    	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
    	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
    	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
    	at org.apache.metron.management.StellarParserRunner.doParse(StellarParserRunner.java:77)
    	at org.apache.metron.management.StellarParserRunner.parse(StellarParserRunner.java:62)
    	at org.apache.metron.management.ParserFunctions$ParseFunction.apply(ParserFunctions.java:98)
    	at org.apache.metron.stellar.common.StellarCompiler.lambda$exitTransformationFunc$13(StellarCompiler.java:652)
    	at org.apache.metron.stellar.common.StellarCompiler$Expression.apply(StellarCompiler.java:250)
    	at org.apache.metron.stellar.common.BaseStellarProcessor.parse(BaseStellarProcessor.java:151)
    	at org.apache.metron.stellar.common.shell.DefaultStellarShellExecutor.executeStellar(DefaultStellarShellExecutor.java:405)
    	at org.apache.metron.stellar.common.shell.DefaultStellarShellExecutor.execute(DefaultStellarShellExecutor.java:257)
    	at org.apache.metron.stellar.common.shell.specials.AssignmentCommand.execute(AssignmentCommand.java:66)
    	at org.apache.metron.stellar.common.shell.DefaultStellarShellExecutor.execute(DefaultStellarShellExecutor.java:252)
    	at org.apache.metron.stellar.common.shell.cli.StellarShell.execute(StellarShell.java:359)
    	at org.jboss.aesh.console.AeshProcess.run(AeshProcess.java:53)
    	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    	at java.lang.Thread.run(Thread.java:748)
    Caused by: Unexpected character (i) at position 1.
    	at org.json.simple.parser.Yylex.yylex(Yylex.java:610)
    	at org.json.simple.parser.JSONParser.nextToken(JSONParser.java:269)
    	at org.json.simple.parser.JSONParser.parse(JSONParser.java:118)
    	at org.json.simple.parser.JSONParser.parse(JSONParser.java:81)
    	at org.json.simple.parser.JSONParser.parse(JSONParser.java:75)
    	at org.apache.metron.parsers.bro.JSONCleaner.clean(JSONCleaner.java:49)
    	at org.apache.metron.parsers.bro.BasicBroParser.parse(BasicBroParser.java:68)
    	... 28 more

    ```


## Pull Request Checklist
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
