### PR TITLE
METRON-1880 Use Caffeine for Profiler Caching

### DIFF
--- a/metron-analytics/metron-profiler-common/README.md
+++ b/metron-analytics/metron-profiler-common/README.md
@@ -28,7 +28,7 @@ The Profiler is a feature extraction mechanism that can generate a profile descr
 
 This is achieved by summarizing the telemetry data consumed by Metron over tumbling windows. A summary statistic is applied to the data received within a given window.  Collecting these values across many windows result in a time series that is useful for analysis.
 
-Any field contained within a message can be used to generate a profile.  A profile can even be produced by combining fields that originate in different data sources.  A user has considerable power to transform the data used in a profile by leveraging the Stellar language. 
+Any field contained within a message can be used to generate a profile.  A profile can even be produced by combining fields that originate in different data sources.  A user has considerable power to transform the data used in a profile by leveraging the Stellar language.
 
 There are three separate ports of the Profiler that share this common code base.
 * The [Storm Profiler](../metron-profiler-storm/README.md) builds low-latency profiles over streaming data sets.
@@ -58,12 +58,12 @@ Let's start with a simple example. The following profile maintains a count of th
       "profile": "hello-world",
       "foreach": "ip_src_addr",
       "init": {
-        "count": 0
+        "count": "0"
       },
       "update": {
         "count": "count + 1"
       },
-      "result": "count",
+      "result": "count"
     }
   ]
 }
@@ -321,7 +321,7 @@ It is important to note that the Profiler can persist any serializable Object, n
     ```
     $ source /etc/default/metron
     $ bin/stellar -z $ZOOKEEPER
-    
+
     [Stellar]>>> stats := PROFILE_GET( "example4", "10.0.0.1", PROFILE_FIXED(30, "MINUTES"))
     [org.apache.metron.common.math.stats.OnlineStatisticsProvider@79fe4ab9, ...]
     ```
@@ -330,10 +330,10 @@ It is important to note that the Profiler can persist any serializable Object, n
     ```
     [Stellar]>>> aStat := GET_FIRST(stats)
     org.apache.metron.common.math.stats.OnlineStatisticsProvider@79fe4ab9
-    
+
     [Stellar]>>> STATS_MEAN(aStat)
     15979.0625
-    
+
     [Stellar]>>> STATS_PERCENTILE(aStat, 90)
     30310.958
     ```
@@ -341,7 +341,7 @@ It is important to note that the Profiler can persist any serializable Object, n
 1. Merge all of the profile measurements over the past 30 minutes into a single sketch and calculate the 90th percentile.
     ```
     [Stellar]>>> merged := STATS_MERGE( stats)
-    
+
     [Stellar]>>> STATS_PERCENTILE(merged, 90)
     29810.992
     ```

--- a/metron-analytics/metron-profiler-common/pom.xml
+++ b/metron-analytics/metron-profiler-common/pom.xml
@@ -28,6 +28,11 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>${global_caffeine_version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-auth</artifactId>
             <version>${global_hadoop_version}</version>

--- a/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/DefaultMessageDistributor.java
+++ b/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/DefaultMessageDistributor.java
@@ -129,22 +129,28 @@ public class DefaultMessageDistributor implements MessageDistributor, Serializab
     this.periodDurationMillis = periodDurationMillis;
 
     // build the cache of active profiles
-    this.activeCache = Caffeine
+    Caffeine<Integer, ProfileBuilder> activeCacheBuilder = Caffeine
             .newBuilder()
             .maximumSize(maxNumberOfRoutes)
             .expireAfterAccess(profileTimeToLiveMillis, TimeUnit.MILLISECONDS)
             .removalListener(new ActiveCacheRemovalListener())
-            .ticker(ticker)
-            .build();
+            .ticker(ticker);
+    if(LOG.isDebugEnabled()) {
+      activeCacheBuilder.recordStats();
+    }
+    this.activeCache =  activeCacheBuilder.build();
 
     // build the cache of expired profiles
-    this.expiredCache = Caffeine
+    Caffeine<Integer, ProfileBuilder> expiredCacheBuilder = Caffeine
             .newBuilder()
             .maximumSize(maxNumberOfRoutes)
             .expireAfterWrite(profileTimeToLiveMillis, TimeUnit.MILLISECONDS)
             .removalListener(new ExpiredCacheRemovalListener())
-            .ticker(ticker)
-            .build();
+            .ticker(ticker);
+    if(LOG.isDebugEnabled()) {
+      expiredCacheBuilder.recordStats();
+    }
+    this.expiredCache = expiredCacheBuilder.build();
   }
 
   /**

--- a/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/DefaultMessageDistributorTest.java
+++ b/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/DefaultMessageDistributorTest.java
@@ -21,6 +21,7 @@
 package org.apache.metron.profiler;
 
 import com.github.benmanes.caffeine.cache.Ticker;
+import com.google.common.util.concurrent.MoreExecutors;
 import org.adrianwalker.multilinestring.Multiline;
 import org.apache.metron.common.configuration.profiler.ProfileConfig;
 import org.apache.metron.common.utils.JSONUtils;
@@ -32,6 +33,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.TimeUnit.HOURS;
@@ -102,7 +104,9 @@ public class DefaultMessageDistributorTest {
     distributor = new DefaultMessageDistributor(
             periodDurationMillis,
             profileTimeToLiveMillis,
-            maxNumberOfRoutes);
+            maxNumberOfRoutes,
+            Ticker.systemTicker(),
+            Optional.of(MoreExecutors.sameThreadExecutor()));
   }
 
   /**
@@ -190,12 +194,13 @@ public class DefaultMessageDistributorTest {
     // setup
     ProfileConfig definition = createDefinition(profileOne);
     String entity = (String) messageOne.get("ip_src_addr");
-    MessageRoute route = new MessageRoute(definition, entity, messageOne, System.currentTimeMillis());
+    MessageRoute route = new MessageRoute(definition, entity, messageOne, ticker.read());
     distributor = new DefaultMessageDistributor(
             periodDurationMillis,
             profileTimeToLiveMillis,
             maxNumberOfRoutes,
-            ticker);
+            ticker,
+            Optional.of(MoreExecutors.sameThreadExecutor()));
 
     // distribute one message
     distributor.distribute(route, context);
@@ -220,12 +225,13 @@ public class DefaultMessageDistributorTest {
     // setup
     ProfileConfig definition = createDefinition(profileOne);
     String entity = (String) messageOne.get("ip_src_addr");
-    MessageRoute route = new MessageRoute(definition, entity, messageOne, System.currentTimeMillis());
+    MessageRoute route = new MessageRoute(definition, entity, messageOne, ticker.read());
     distributor = new DefaultMessageDistributor(
             periodDurationMillis,
             profileTimeToLiveMillis,
             maxNumberOfRoutes,
-            ticker);
+            ticker,
+            Optional.of(MoreExecutors.sameThreadExecutor()));
 
     // distribute one message
     distributor.distribute(route, context);
@@ -251,12 +257,13 @@ public class DefaultMessageDistributorTest {
     // setup
     ProfileConfig definition = createDefinition(profileOne);
     String entity = (String) messageOne.get("ip_src_addr");
-    MessageRoute route = new MessageRoute(definition, entity, messageOne, System.currentTimeMillis());
+    MessageRoute route = new MessageRoute(definition, entity, messageOne, ticker.read());
     distributor = new DefaultMessageDistributor(
             periodDurationMillis,
             profileTimeToLiveMillis,
             maxNumberOfRoutes,
-            ticker);
+            ticker,
+            Optional.of(MoreExecutors.sameThreadExecutor()));
 
     // distribute one message
     distributor.distribute(route, context);

--- a/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/DefaultMessageDistributorTest.java
+++ b/metron-analytics/metron-profiler-common/src/test/java/org/apache/metron/profiler/DefaultMessageDistributorTest.java
@@ -20,7 +20,7 @@
 
 package org.apache.metron.profiler;
 
-import com.google.common.base.Ticker;
+import com.github.benmanes.caffeine.cache.Ticker;
 import org.adrianwalker.multilinestring.Multiline;
 import org.apache.metron.common.configuration.profiler.ProfileConfig;
 import org.apache.metron.common.utils.JSONUtils;
@@ -278,7 +278,7 @@ public class DefaultMessageDistributorTest {
    * An implementation of Ticker that can be used to drive time
    * when testing the Guava caches.
    */
-  private class FixedTicker extends Ticker {
+  private class FixedTicker implements Ticker {
 
     /**
      * The time that will be reported.
@@ -298,7 +298,7 @@ public class DefaultMessageDistributorTest {
       this.timestampNanos += units.toNanos(time);
       return this;
     }
-
+    
     @Override
     public long read() {
       return this.timestampNanos;


### PR DESCRIPTION
Caffeine is a more performant cache when cache sizes are larger.  We've already seen a significant improvement elsewhere in Metron based on the work done in #947. 

The Profiler should use Caffeine for caching to ensure that the caches are not a performance bottleneck.

## Testing

1. Spin-up Full Dev.
1. Create a profile using the Stellar REPL.
1. Deploy the profile for the Storm-based Profiler.
1. Ensure valid profile data is persisted in HBase.

## Pull Request Checklist
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
