### PR TITLE
METRON-1895:  Add Knox SSO as an option in Metron

### DIFF
--- a/dependencies_with_url.csv
+++ b/dependencies_with_url.csv
@@ -489,3 +489,5 @@ org.hibernate.validator:hibernate-validator:jar:6.0.9.Final:compile,ASLv2,https:
 com.github.palindromicity:simple-syslog-5424:jar:0.0.9:compile,ASLv2,https://github.com/palindromicity/simple-syslog-5424
 org.elasticsearch.client:elasticsearch-rest-high-level-client:jar:5.6.2:compile,ASLv2,https://github.com/elastic/elasticsearch/blob/master/LICENSE.txt
 org.elasticsearch.plugin:aggs-matrix-stats-client:jar:5.6.2:compile,ASLv2,https://github.com/elastic/elasticsearch/blob/master/LICENSE.txt
+com.github.stephenc.jcip:jcip-annotations:jar:1.0-1:compile,ASLv2,http://stephenc.github.io/jcip-annotations/
+com.nimbusds:nimbus-jose-jwt:jar:4.41.2:compile,ASLv2,https://bitbucket.org/connect2id/nimbus-jose-jwt/wiki/Home

--- a/metron-deployment/packaging/docker/rpm-docker/SPECS/metron.spec
+++ b/metron-deployment/packaging/docker/rpm-docker/SPECS/metron.spec
@@ -424,8 +424,14 @@ This package installs the Metron Rest %{metron_home}
 %dir %{metron_home}/bin
 %dir %{metron_home}/lib
 %{metron_home}/config/rest_application.yml
+%{metron_home}/config/knox/conf/topologies/metron.xml
+%{metron_home}/config/knox/data/services/alerts/rewrite.xml
+%{metron_home}/config/knox/data/services/alerts/service.xml
+%{metron_home}/config/knox/data/services/rest/rewrite.xml
+%{metron_home}/config/knox/data/services/rest/service.xml
 %{metron_home}/bin/metron-rest.sh
 %{metron_home}/bin/pcap_to_pdml.sh
+%{metron_home}/bin/install_metron_knox.sh
 %attr(0644,root,root) %{metron_home}/lib/metron-rest-%{full_version}.jar
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/metron-interface/metron-alerts/cypress/integration/pcap/pcap.spec.js
+++ b/metron-interface/metron-alerts/cypress/integration/pcap/pcap.spec.js
@@ -25,6 +25,11 @@ context('PCAP Tab', () => {
       url: '/api/v1/user',
       response: 'user'
     });
+    cy.route({
+        method: 'POST',
+        url: '/api/v1/logout',
+        response: []
+    });
 
     cy.route('GET', 'config', 'fixture:config.json');
     cy.route('POST', 'search', 'fixture:search.json');
@@ -50,7 +55,7 @@ context('PCAP Tab', () => {
     cy.wait('@runningJobs').its('url').should('include', '?state=RUNNING');
   });
 
-  it('submitting PCAP job request', () => {
+  it.only('submitting PCAP job request', () => {
     cy.contains('PCAP').click();
     cy.route('POST', '/api/v1/pcap/fixed', 'fixture:pcap.status-00.json')
       .as('postingPcapJob');

--- a/metron-interface/metron-alerts/cypress/integration/pcap/pcap.spec.js
+++ b/metron-interface/metron-alerts/cypress/integration/pcap/pcap.spec.js
@@ -55,7 +55,7 @@ context('PCAP Tab', () => {
     cy.wait('@runningJobs').its('url').should('include', '?state=RUNNING');
   });
 
-  it.only('submitting PCAP job request', () => {
+  it('submitting PCAP job request', () => {
     cy.contains('PCAP').click();
     cy.route('POST', '/api/v1/pcap/fixed', 'fixture:pcap.status-00.json')
       .as('postingPcapJob');

--- a/metron-interface/metron-alerts/proxy.conf.json
+++ b/metron-interface/metron-alerts/proxy.conf.json
@@ -2,9 +2,5 @@
   "/api/v1": {
     "target": "http://node1:8082",
     "secure": false
-  },
-  "/logout": {
-    "target": "http://node1:8082",
-    "secure": false
   }
 }

--- a/metron-interface/metron-alerts/src/app/app.component.html
+++ b/metron-interface/metron-alerts/src/app/app.component.html
@@ -14,7 +14,7 @@
 <div class="container-fluid px-0" [class.notransition]="noTransition">
     <nav class="navbar" *ngIf="loggedIn">
         <a class="" href="#">
-            <img alt="" src="../assets/images/logo.png" width="135" height="45">
+            <img alt="" src="assets/images/logo.png" width="135" height="45">
         </a>
         <ul class="nav ml-4">
             <li class="nav-item" routerLinkActive="active">

--- a/metron-interface/metron-alerts/src/app/service/authentication.service.ts
+++ b/metron-interface/metron-alerts/src/app/service/authentication.service.ts
@@ -30,7 +30,7 @@ export class AuthenticationService {
   private static USER_NOT_VERIFIED = 'USER-NOT-VERIFIED';
   private currentUser: string = AuthenticationService.USER_NOT_VERIFIED;
   loginUrl = this.appConfigService.getApiRoot() + '/user';
-  logoutUrl = '/logout';
+  logoutUrl = this.appConfigService.getApiRoot() + '/logout';
   onLoginEvent: ReplaySubject<boolean> = new ReplaySubject<boolean>();
   $onLoginEvent = this.onLoginEvent.asObservable();
 

--- a/metron-interface/metron-alerts/src/app/shared/directives/alert-search.directive.ts
+++ b/metron-interface/metron-alerts/src/app/shared/directives/alert-search.directive.ts
@@ -38,7 +38,7 @@ export class AlertSearchDirective implements AfterViewInit, OnChanges {
     const el = elementRef.nativeElement;
     el.classList.add('editor');
 
-    ace.config.set('basePath', '/assets/ace');
+    ace.config.set('basePath', 'assets/ace');
 
     this.editor = ace.edit(el);
     this.editor.$blockScrolling = Infinity;

--- a/metron-interface/metron-alerts/src/index.html
+++ b/metron-interface/metron-alerts/src/index.html
@@ -16,7 +16,7 @@
 <head>
   <meta charset="utf-8">
   <title>Metron Alerts</title>
-  <base href="/">
+  <base href="./">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">

--- a/metron-interface/metron-rest/pom.xml
+++ b/metron-interface/metron-rest/pom.xml
@@ -39,6 +39,7 @@
         <spring.version>5.0.5.RELEASE</spring.version>
         <eclipse.link.version>2.6.4</eclipse.link.version>
         <jsonpath.version>2.4.0</jsonpath.version>
+        <jwt.version>4.41.2</jwt.version>
     </properties>
     <dependencies>
       <dependency>
@@ -425,6 +426,11 @@
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>${jwt.version}</version>
         </dependency>
     </dependencies>
 

--- a/metron-interface/metron-rest/src/main/config/knox/conf/topologies/metron.xml
+++ b/metron-interface/metron-rest/src/main/config/knox/conf/topologies/metron.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software
+	Foundation (ASF) under one or more contributor license agreements. See the
+	NOTICE file distributed with this work for additional information regarding
+	copyright ownership. The ASF licenses this file to You under the Apache License,
+	Version 2.0 (the "License"); you may not use this file except in compliance
+	with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software distributed
+	under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+	OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+  the specific language governing permissions and limitations under the License.
+  -->
+<topology>
+
+  <gateway>
+    <provider>
+        <role>authentication</role>
+        <name>ShiroProvider</name>
+        <enabled>true</enabled>
+        <param>
+            <name>sessionTimeout</name>
+            <value>30</value>
+        </param>
+        <param>
+            <name>main.ldapRealm</name>
+            <value>org.apache.hadoop.gateway.shirorealm.KnoxLdapRealm</value>
+        </param>
+        <param>
+            <name>main.ldapRealm.userDnTemplate</name>
+            <value>uid={0},ou=people,dc=hadoop,dc=apache,dc=org</value>
+        </param>
+        <param>
+            <name>main.ldapRealm.contextFactory.url</name>
+            <value>ldap://localhost:33389</value>
+        </param>
+        <param>
+            <name>main.ldapRealm.contextFactory.authenticationMechanism</name>
+            <value>simple</value>
+        </param>
+        <param>
+            <name>urls./**</name>
+            <value>authcBasic</value>
+        </param>
+    </provider>
+
+    <provider>
+      <role>identity-assertion</role>
+      <name>Default</name>
+      <enabled>true</enabled>
+    </provider>
+
+    <provider>
+      <role>authorization</role>
+      <name>AclsAuthz</name>
+      <enabled>true</enabled>
+    </provider>
+
+  </gateway>
+
+  <service>
+    <role>METRON-REST</role>
+    <url>http://localhost:8082</url>
+  </service>
+
+  <service>
+    <role>METRON-ALERTS</role>
+    <url>http://localhost:4201</url>
+  </service>
+
+</topology>

--- a/metron-interface/metron-rest/src/main/config/knox/data/services/alerts/rewrite.xml
+++ b/metron-interface/metron-rest/src/main/config/knox/data/services/alerts/rewrite.xml
@@ -1,0 +1,14 @@
+<rules>
+  <rule dir="IN" name="METRON-ALERTS/metron-alerts/inbound/root" pattern="*://*:*/**/metron-alerts/">
+    <rewrite template="{$serviceUrl[METRON-ALERTS-UI]}/"/>
+  </rule>
+  <rule dir="IN" name="METRON-ALERTS/metron-alerts/inbound/path" pattern="*://*:*/**/metron-alerts/{**}">
+    <rewrite template="{$serviceUrl[METRON-ALERTS-UI]}/{**}"/>
+  </rule>
+  <rule dir="IN" name="METRON-ALERTS/metron-alerts/inbound/query" pattern="*://*:*/**/metron-alerts/{**}?{**}">
+    <rewrite template="{$serviceUrl[METRON-ALERTS]}/{**}?{**}"/>
+  </rule>
+  <!--rule dir="OUT" name="METRON-ALERTS/alerts/outbound/path" pattern="*://*:*/{path=**}">
+    <rewrite template="{$frontend[path]}/alerts/{path=**}"/>
+  </rule-->
+</rules>

--- a/metron-interface/metron-rest/src/main/config/knox/data/services/alerts/rewrite.xml
+++ b/metron-interface/metron-rest/src/main/config/knox/data/services/alerts/rewrite.xml
@@ -1,3 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software
+	Foundation (ASF) under one or more contributor license agreements. See the
+	NOTICE file distributed with this work for additional information regarding
+	copyright ownership. The ASF licenses this file to You under the Apache License,
+	Version 2.0 (the "License"); you may not use this file except in compliance
+	with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software distributed
+	under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+	OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+  the specific language governing permissions and limitations under the License.
+  -->
 <rules>
   <rule dir="IN" name="METRON-ALERTS/metron-alerts/inbound/root" pattern="*://*:*/**/metron-alerts/">
     <rewrite template="{$serviceUrl[METRON-ALERTS-UI]}/"/>
@@ -8,7 +21,4 @@
   <rule dir="IN" name="METRON-ALERTS/metron-alerts/inbound/query" pattern="*://*:*/**/metron-alerts/{**}?{**}">
     <rewrite template="{$serviceUrl[METRON-ALERTS]}/{**}?{**}"/>
   </rule>
-  <!--rule dir="OUT" name="METRON-ALERTS/alerts/outbound/path" pattern="*://*:*/{path=**}">
-    <rewrite template="{$frontend[path]}/alerts/{path=**}"/>
-  </rule-->
 </rules>

--- a/metron-interface/metron-rest/src/main/config/knox/data/services/alerts/service.xml
+++ b/metron-interface/metron-rest/src/main/config/knox/data/services/alerts/service.xml
@@ -1,3 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software
+	Foundation (ASF) under one or more contributor license agreements. See the
+	NOTICE file distributed with this work for additional information regarding
+	copyright ownership. The ASF licenses this file to You under the Apache License,
+	Version 2.0 (the "License"); you may not use this file except in compliance
+	with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software distributed
+	under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+	OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+  the specific language governing permissions and limitations under the License.
+  -->
 <service role="METRON-ALERTS" name="metron-alerts" version="0.6.1">
   <routes>
     <route path="/metron-alerts/"/>

--- a/metron-interface/metron-rest/src/main/config/knox/data/services/alerts/service.xml
+++ b/metron-interface/metron-rest/src/main/config/knox/data/services/alerts/service.xml
@@ -1,0 +1,8 @@
+<service role="METRON-ALERTS" name="metron-alerts" version="0.6.1">
+  <routes>
+    <route path="/metron-alerts/"/>
+    <route path="/metron-alerts/**"/>
+    <route path="/metron-alerts/**?**"/>
+  </routes>
+  <dispatch classname="org.apache.hadoop.gateway.dispatch.PassAllHeadersDispatch"/>
+</service>

--- a/metron-interface/metron-rest/src/main/config/knox/data/services/rest/rewrite.xml
+++ b/metron-interface/metron-rest/src/main/config/knox/data/services/rest/rewrite.xml
@@ -1,0 +1,5 @@
+<rules>
+  <rule dir="IN" name="METRON-REST/metron-rest/inbound" pattern="*://*:*/**/metron-rest/{path=**}?{**}">
+    <rewrite template="{$serviceUrl[METRON-REST]}/{path=**}?{**}"/>
+  </rule>
+</rules>

--- a/metron-interface/metron-rest/src/main/config/knox/data/services/rest/rewrite.xml
+++ b/metron-interface/metron-rest/src/main/config/knox/data/services/rest/rewrite.xml
@@ -1,3 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software
+	Foundation (ASF) under one or more contributor license agreements. See the
+	NOTICE file distributed with this work for additional information regarding
+	copyright ownership. The ASF licenses this file to You under the Apache License,
+	Version 2.0 (the "License"); you may not use this file except in compliance
+	with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software distributed
+	under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+	OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+  the specific language governing permissions and limitations under the License.
+  -->
 <rules>
   <rule dir="IN" name="METRON-REST/metron-rest/inbound" pattern="*://*:*/**/metron-rest/{path=**}?{**}">
     <rewrite template="{$serviceUrl[METRON-REST]}/{path=**}?{**}"/>

--- a/metron-interface/metron-rest/src/main/config/knox/data/services/rest/service.xml
+++ b/metron-interface/metron-rest/src/main/config/knox/data/services/rest/service.xml
@@ -1,3 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software
+	Foundation (ASF) under one or more contributor license agreements. See the
+	NOTICE file distributed with this work for additional information regarding
+	copyright ownership. The ASF licenses this file to You under the Apache License,
+	Version 2.0 (the "License"); you may not use this file except in compliance
+	with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software distributed
+	under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+	OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+  the specific language governing permissions and limitations under the License.
+  -->
 <service role="METRON-REST" name="metron-rest" version="0.6.1">
   <routes>
     <route path="/metron-rest/**"/>

--- a/metron-interface/metron-rest/src/main/config/knox/data/services/rest/service.xml
+++ b/metron-interface/metron-rest/src/main/config/knox/data/services/rest/service.xml
@@ -1,0 +1,6 @@
+<service role="METRON-REST" name="metron-rest" version="0.6.1">
+  <routes>
+    <route path="/metron-rest/**"/>
+  </routes>
+  <dispatch classname="org.apache.hadoop.gateway.dispatch.PassAllHeadersDispatch"/>
+</service>

--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/MetronRestConstants.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/MetronRestConstants.java
@@ -72,6 +72,7 @@ public class MetronRestConstants {
   public static final String META_DAO_IMPL = "meta.dao.impl";
   public static final String META_DAO_SORT = "meta.dao.sort";
 
+  public static final String SECURITY_ROLE_PREFIX = "ROLE_";
   public static final String SECURITY_ROLE_USER = "USER";
   public static final String SECURITY_ROLE_ADMIN = "ADMIN";
 
@@ -88,4 +89,10 @@ public class MetronRestConstants {
   public static final String PCAP_PDML_SCRIPT_PATH_SPRING_PROPERTY = "pcap.pdml.script.path";
   public static final String PCAP_YARN_QUEUE_SPRING_PROPERTY = "pcap.yarn.queue";
   public static final String PCAP_FINALIZER_THREADPOOL_SIZE_SPRING_PROPERTY = "pcap.finalizer.threadpool.size";
+
+  public static final String LDAP_PROVIDER_URL_SPRING_PROPERTY = "ldap.provider.url";
+  public static final String LDAP_PROVIDER_USERDN_SPRING_PROPERTY = "ldap.provider.userdn";
+  public static final String LDAP_PROVIDER_PASSWORD_SPRING_PROPERTY = "ldap.provider.password";
+
+  public static final String KNOX_ROOT_SPRING_PROPERTY = "knox.root";
 }

--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/MetronRestConstants.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/MetronRestConstants.java
@@ -25,6 +25,7 @@ public class MetronRestConstants {
   public static final String TEST_PROFILE = "test";
   public static final String LDAP_PROFILE = "ldap";
   public static final String DOCKER_PROFILE = "docker";
+  public static final String KNOX_PROFILE = "knox";
   public static final String CSRF_ENABLE_PROFILE = "csrf-enable";
 
   public static final String GROK_TEMP_PATH_SPRING_PROPERTY = "grok.path.temp";

--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/config/KnoxSSOAuthenticationFilter.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/config/KnoxSSOAuthenticationFilter.java
@@ -1,0 +1,314 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.rest.config;
+
+import com.nimbusds.jose.JWSObject;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jwt.SignedJWT;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ldap.core.AttributesMapper;
+import org.springframework.ldap.core.LdapTemplate;
+import org.springframework.ldap.support.LdapNameBuilder;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.PublicKey;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.RSAPublicKey;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.springframework.ldap.query.LdapQueryBuilder.query;
+
+/**
+ * This class is a Servlet Filter that authenticates a Knox SSO token.  The token is stored in a cookie and is
+ * verified against a public Knox key.  The token expiration and begin time are also validated.  Upon successful validation,
+ * a Spring Authentication object is built from the user name and user groups queried from LDAP.  Currently, user groups are
+ * mapped directly to Spring roles and prepended with "ROLE_".
+ */
+public class KnoxSSOAuthenticationFilter implements Filter {
+  private static final Logger LOG = LoggerFactory.getLogger(KnoxSSOAuthenticationFilter.class);
+
+  private String userSearchBase;
+  private Path knoxKeyFile;
+  private String knoxKeyString;
+  private String knoxCookie;
+  private LdapTemplate ldapTemplate;
+
+  public KnoxSSOAuthenticationFilter(String userSearchBase,
+                                     Path knoxKeyFile,
+                                     String knoxKeyString,
+                                     String knoxCookie,
+                                     LdapTemplate ldapTemplate) throws IOException, CertificateException {
+    this.userSearchBase = userSearchBase;
+    this.knoxKeyFile = knoxKeyFile;
+    this.knoxKeyString = knoxKeyString;
+    this.knoxCookie = knoxCookie;
+    if (ldapTemplate == null) {
+      throw new IllegalStateException("KnoxSSO requires LDAP. You must add 'ldap' to the active profiles.");
+    }
+    this.ldapTemplate = ldapTemplate;
+  }
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {
+  }
+
+  @Override
+  public void destroy() {
+  }
+
+  /**
+   * Extracts the Knox token from the configured cookie.  If basic authentication headers are present, SSO authentication
+   * is skipped.
+   * @param request
+   * @param response
+   * @param chain
+   * @throws IOException
+   * @throws ServletException
+   */
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+          throws IOException, ServletException {
+    HttpServletRequest httpRequest = (HttpServletRequest) request;
+
+    // If a basic authentication header is present, use that to authenticate and skip SSO
+    String authHeader = httpRequest.getHeader("Authorization");
+    if (authHeader == null || !authHeader.startsWith("Basic")) {
+      String serializedJWT = getJWTFromCookie(httpRequest);
+      if (serializedJWT != null) {
+        SignedJWT jwtToken = null;
+        try {
+          jwtToken = SignedJWT.parse(serializedJWT);
+          String userName = jwtToken.getJWTClaimsSet().getSubject();
+          LOG.info("SSO login user : {} ", userName);
+          if (isValid(jwtToken, userName)) {
+            Authentication authentication = getAuthentication(userName, httpRequest);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+          }
+        } catch (ParseException e) {
+          LOG.warn("Unable to parse the JWT token", e);
+        }
+      }
+    }
+    chain.doFilter(request, response);
+  }
+
+  /**
+   * Validates a Knox token with expiration and begin times and verifies the token with a public Knox key.
+   * @param jwtToken Knox token
+   * @param userName User name associated with the token
+   * @return Whether a token is valid or not
+   * @throws ParseException
+   */
+  protected boolean isValid(SignedJWT jwtToken, String userName) throws ParseException {
+    // Verify the user name is present
+    if (userName == null || userName.isEmpty()) {
+      LOG.info("Could not find user name in SSO token");
+      return false;
+    }
+
+    Date now = new Date();
+
+    // Verify the token has not expired
+    Date expirationTime = jwtToken.getJWTClaimsSet().getExpirationTime();
+    if (expirationTime != null && now.after(expirationTime)) {
+      LOG.info("SSO token expired: {} ", userName);
+      return false;
+    }
+
+    // Verify the token is not before time
+    Date notBeforeTime = jwtToken.getJWTClaimsSet().getNotBeforeTime();
+    if (notBeforeTime != null && now.before(notBeforeTime)) {
+      LOG.info("SSO token not yet valid: {} ", userName);
+      return false;
+    }
+
+    return validateSignature(jwtToken);
+  }
+
+  /**
+   * Verify the signature of the JWT token in this method. This method depends on
+   * the public key that was established during init based upon the provisioned
+   * public key. Override this method in subclasses in order to customize the
+   * signature verification behavior.
+   *
+   * @param jwtToken
+   *            the token that contains the signature to be validated
+   * @return valid true if signature verifies successfully; false otherwise
+   */
+  protected boolean validateSignature(SignedJWT jwtToken) {
+    // Verify the token signature algorithm was as expected
+    String receivedSigAlg = jwtToken.getHeader().getAlgorithm().getName();
+    if (!receivedSigAlg.equals("RS256")) {
+      return false;
+    }
+
+    // Verify the token has been properly signed
+    if (JWSObject.State.SIGNED == jwtToken.getState()) {
+      LOG.debug("SSO token is in a SIGNED state");
+      if (jwtToken.getSignature() != null) {
+        LOG.debug("SSO token signature is not null");
+        try {
+          JWSVerifier verifier = new RSASSAVerifier(parseRSAPublicKey(getKnoxKey()));
+          if (jwtToken.verify(verifier)) {
+            LOG.debug("SSO token has been successfully verified");
+            return true;
+          } else {
+            LOG.warn("SSO signature verification failed. Please check the public key.");
+          }
+        } catch (Exception e) {
+          LOG.warn("Error while validating signature", e);
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Encapsulate the acquisition of the JWT token from HTTP cookies within the
+   * request.
+   *
+   * Taken from
+   *
+   * @param req
+   *            servlet request to get the JWT token from
+   * @return serialized JWT token
+   */
+  protected String getJWTFromCookie(HttpServletRequest req) {
+    String serializedJWT = null;
+    Cookie[] cookies = req.getCookies();
+    if (cookies != null) {
+      for (Cookie cookie : cookies) {
+        LOG.debug(String.format("Found cookie: %s [%s]", cookie.getName(), cookie.getValue()));
+        if (knoxCookie.equals(cookie.getName())) {
+          if (LOG.isDebugEnabled()) {
+            LOG.debug(knoxCookie + " cookie has been found and is being processed");
+          }
+          serializedJWT = cookie.getValue();
+          break;
+        }
+      }
+    } else {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(knoxCookie + " not found");
+      }
+    }
+    return serializedJWT;
+  }
+
+  /**
+   * A public Knox key can either be passed in directly or read from a file.
+   * @return Public Knox key
+   * @throws IOException
+   */
+  private String getKnoxKey() throws IOException {
+    String knoxKey;
+    if ((this.knoxKeyString == null || this.knoxKeyString.isEmpty()) && this.knoxKeyFile != null) {
+      List<String> keyLines = Files.readAllLines(knoxKeyFile, StandardCharsets.UTF_8);
+      if (keyLines != null) {
+        knoxKey = String.join("", keyLines);
+      } else {
+        knoxKey = "";
+      }
+    } else {
+      knoxKey = this.knoxKeyString;
+    }
+    return knoxKey;
+  }
+
+  public static RSAPublicKey parseRSAPublicKey(String pem)
+          throws CertificateException, UnsupportedEncodingException {
+    String PEM_HEADER = "-----BEGIN CERTIFICATE-----\n";
+    String PEM_FOOTER = "\n-----END CERTIFICATE-----";
+    String fullPem = (pem.startsWith(PEM_HEADER) && pem.endsWith(PEM_FOOTER)) ? pem : PEM_HEADER + pem + PEM_FOOTER;
+    PublicKey key = null;
+    try {
+      CertificateFactory fact = CertificateFactory.getInstance("X.509");
+      ByteArrayInputStream is = new ByteArrayInputStream(fullPem.getBytes("UTF8"));
+      X509Certificate cer = (X509Certificate) fact.generateCertificate(is);
+      key = cer.getPublicKey();
+    } catch (CertificateException ce) {
+      String message = null;
+      if (pem.startsWith(PEM_HEADER)) {
+        message = "CertificateException - be sure not to include PEM header "
+                + "and footer in the PEM configuration element.";
+      } else {
+        message = "CertificateException - PEM may be corrupt";
+      }
+      throw new CertificateException(message, ce);
+    }
+    return (RSAPublicKey) key;
+  }
+
+  /**
+   * Builds the Spring Authentication object using the supplied user name and groups looked up from LDAP.  Groups are currently
+   * mapped directly to Spring roles by converting to upper case and prepending the name with "ROLE_".
+   * @param userName
+   * @param httpRequest
+   * @return
+   */
+  private Authentication getAuthentication(String userName, HttpServletRequest httpRequest) {
+    String ldapName = LdapNameBuilder.newInstance().add(userSearchBase).add("uid", userName).build().toString();
+
+    // Search ldap for a user's groups and convert to a Spring role
+    List<GrantedAuthority> grantedAuths = ldapTemplate.search(query()
+            .where("objectclass")
+            .is("groupOfNames")
+            .and("member")
+            .is(ldapName), (AttributesMapper<String>) attrs -> (String) attrs.get("cn").get())
+            .stream()
+            .map(group -> String.format("ROLE_%s", group.toUpperCase()))
+            .map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+
+    final UserDetails principal = new User(userName, "", grantedAuths);
+    final Authentication authentication = new UsernamePasswordAuthenticationToken(
+            principal, "", grantedAuths);
+    WebAuthenticationDetails webDetails = new WebAuthenticationDetails(httpRequest);
+    ((AbstractAuthenticationToken) authentication).setDetails(webDetails);
+    return authentication;
+  }
+
+}

--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/config/LdapConfig.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/config/LdapConfig.java
@@ -17,33 +17,33 @@
  */
 package org.apache.metron.rest.config;
 
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.env.Environment;
 import org.springframework.ldap.core.LdapTemplate;
 import org.springframework.ldap.core.support.LdapContextSource;
 
 import static org.apache.metron.rest.MetronRestConstants.LDAP_PROFILE;
+import static org.apache.metron.rest.MetronRestConstants.LDAP_PROVIDER_PASSWORD_SPRING_PROPERTY;
+import static org.apache.metron.rest.MetronRestConstants.LDAP_PROVIDER_URL_SPRING_PROPERTY;
+import static org.apache.metron.rest.MetronRestConstants.LDAP_PROVIDER_USERDN_SPRING_PROPERTY;
 
 @Configuration
 @Profile(LDAP_PROFILE)
 public class LdapConfig {
 
-  @Value("${ldap.provider.url}")
-  private String providerUrl;
-  @Value("${ldap.provider.userdn}")
-  private String providerUserDn;
-  @Value("${ldap.provider.password}")
-  private String providerPassword;
+  @Autowired
+  private Environment environment;
 
   @Bean
   public LdapTemplate ldapTemplate() {
     LdapContextSource contextSource = new LdapContextSource();
 
-    contextSource.setUrl(providerUrl);
-    contextSource.setUserDn(providerUserDn);
-    contextSource.setPassword(providerPassword);
+    contextSource.setUrl(environment.getProperty(LDAP_PROVIDER_URL_SPRING_PROPERTY));
+    contextSource.setUserDn(environment.getProperty(LDAP_PROVIDER_USERDN_SPRING_PROPERTY));
+    contextSource.setPassword(environment.getProperty(LDAP_PROVIDER_PASSWORD_SPRING_PROPERTY));
     contextSource.afterPropertiesSet();
 
     return new LdapTemplate(contextSource);

--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/config/LdapConfig.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/config/LdapConfig.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.rest.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.ldap.core.LdapTemplate;
+import org.springframework.ldap.core.support.LdapContextSource;
+
+import static org.apache.metron.rest.MetronRestConstants.LDAP_PROFILE;
+
+@Configuration
+@Profile(LDAP_PROFILE)
+public class LdapConfig {
+
+  @Value("${ldap.provider.url}")
+  private String providerUrl;
+  @Value("${ldap.provider.userdn}")
+  private String providerUserDn;
+  @Value("${ldap.provider.password}")
+  private String providerPassword;
+
+  @Bean
+  public LdapTemplate ldapTemplate() {
+    LdapContextSource contextSource = new LdapContextSource();
+
+    contextSource.setUrl(providerUrl);
+    contextSource.setUserDn(providerUserDn);
+    contextSource.setPassword(providerPassword);
+    contextSource.afterPropertiesSet();
+
+    return new LdapTemplate(contextSource);
+  }
+
+}

--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/config/SwaggerConfig.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/config/SwaggerConfig.java
@@ -17,8 +17,8 @@
  */
 package org.apache.metron.rest.config;
 
+import org.apache.metron.rest.MetronRestConstants;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -40,9 +40,6 @@ import static org.apache.metron.rest.MetronRestConstants.KNOX_PROFILE;
 @EnableSwagger2
 public class SwaggerConfig {
 
-  @Value("${knox.root}")
-  private String knoxRoot;
-
   @Autowired
   private Environment environment;
 
@@ -54,6 +51,7 @@ public class SwaggerConfig {
     List<String> activeProfiles = Arrays.asList(environment.getActiveProfiles());
     Docket docket = new Docket(DocumentationType.SWAGGER_2);
     if (activeProfiles.contains(KNOX_PROFILE)) {
+      String knoxRoot = environment.getProperty(MetronRestConstants.KNOX_ROOT_SPRING_PROPERTY, String.class, "");
       docket = docket.pathProvider(new RelativePathProvider (servletContext) {
         @Override
         protected String applicationPath() {

--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/config/SwaggerConfig.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/config/SwaggerConfig.java
@@ -17,22 +17,66 @@
  */
 package org.apache.metron.rest.config;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.paths.RelativePathProvider;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import javax.servlet.ServletContext;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.metron.rest.MetronRestConstants.KNOX_PROFILE;
 
 @Configuration
 @EnableSwagger2
 public class SwaggerConfig {
+
+  @Value("${knox.root}")
+  private String knoxRoot;
+
+  @Autowired
+  private Environment environment;
+
+  @Autowired
+  ServletContext servletContext;
+
   @Bean
   public Docket api() {
-    return new Docket(DocumentationType.SWAGGER_2)
-            .select()
+    List<String> activeProfiles = Arrays.asList(environment.getActiveProfiles());
+    Docket docket = new Docket(DocumentationType.SWAGGER_2);
+    if (activeProfiles.contains(KNOX_PROFILE)) {
+      docket = docket.pathProvider(new RelativePathProvider (servletContext) {
+        @Override
+        protected String applicationPath() {
+          return knoxRoot;
+        }
+
+        @Override
+        protected String getDocumentationPath() {
+          return knoxRoot;
+        }
+
+        @Override
+        public String getApplicationBasePath() {
+          return knoxRoot;
+        }
+
+        @Override
+        public String getOperationPath(String operationPath) {
+          return knoxRoot + super.getOperationPath(operationPath);
+        }
+      });
+    }
+    return docket.select()
             .apis(RequestHandlerSelectors.withClassAnnotation(RestController.class))
             .paths(PathSelectors.any())
             .build();

--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/config/WebSecurityConfig.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/config/WebSecurityConfig.java
@@ -20,8 +20,16 @@ package org.apache.metron.rest.config;
 import static org.apache.metron.rest.MetronRestConstants.SECURITY_ROLE_ADMIN;
 import static org.apache.metron.rest.MetronRestConstants.SECURITY_ROLE_USER;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.interfaces.RSAPublicKey;
 import java.util.Arrays;
 import java.util.List;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
 import org.apache.metron.rest.MetronRestConstants;
 import org.slf4j.Logger;
@@ -31,16 +39,32 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
+import org.springframework.http.HttpMethod;
+import org.springframework.ldap.core.AttributesMapper;
+import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.ldap.core.LdapTemplate;
+import org.springframework.ldap.core.support.LdapContextSource;
+import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.LdapShaPasswordEncoder;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.ldap.DefaultSpringSecurityContextSource;
+import org.springframework.security.ldap.authentication.LdapAuthenticationProvider;
+import org.springframework.security.ldap.search.FilterBasedLdapUserSearch;
+import org.springframework.security.ldap.userdetails.LdapAuthoritiesPopulator;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.logout.HttpStatusReturningLogoutSuccessHandler;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -58,26 +82,48 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     @Autowired
     private DataSource dataSource;
 
+    @Autowired(required = false)
+    private LdapTemplate ldapTemplate;
+
     @Value("${ldap.provider.url}")
     private String providerUrl;
+
     @Value("${ldap.provider.userdn}")
     private String providerUserDn;
+
     @Value("${ldap.provider.password}")
     private String providerPassword;
+
     @Value("${ldap.user.dn.patterns}")
     private String userDnPatterns;
+
     @Value("${ldap.user.passwordAttribute}")
     private String passwordAttribute;
+
     @Value("${ldap.user.searchBase}")
     private String userSearchBase;
+
     @Value("${ldap.user.searchFilter}")
     private String userSearchFilter;
+
     @Value("${ldap.group.searchBase}")
     private String groupSearchBase;
+
     @Value("${ldap.group.roleAttribute}")
     private String groupRoleAttribute;
+
     @Value("${ldap.group.searchFilter}")
     private String groupSearchFilter;
+
+    @Value("${knox.sso.pubkeyFile:}")
+    private Path knoxKeyFile;
+
+    @Value("${knox.sso.pubkey:}")
+    private String knoxKeyString;
+
+    @Value("${knox.sso.cookie:hadoop-jwt}")
+    private String knoxCookie;
+
 
     @RequestMapping(value = {"/login", "/logout", "/sensors", "/sensors*/**"}, method = RequestMethod.GET)
     public String handleNGRequests() {
@@ -103,11 +149,17 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .logoutUrl("/api/v1/logout")
                 .logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler())
                 .invalidateHttpSession(true)
-                .deleteCookies("JSESSIONID");
-        if (Arrays.asList(environment.getActiveProfiles()).contains(MetronRestConstants.CSRF_ENABLE_PROFILE)) {
+                .deleteCookies("JSESSIONID", knoxCookie);
+
+        List<String> activeProfiles = Arrays.asList(environment.getActiveProfiles());
+        if (activeProfiles.contains(MetronRestConstants.CSRF_ENABLE_PROFILE)) {
             http.csrf().csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse());
         } else {
             http.csrf().disable();
+        }
+        if (activeProfiles.contains(MetronRestConstants.KNOX_PROFILE)) {
+          http.addFilterAt(new KnoxSSOAuthenticationFilter(userSearchBase, knoxKeyFile, knoxKeyString,
+                  knoxCookie, ldapTemplate), UsernamePasswordAuthenticationFilter.class);
         }
     }
 

--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/config/WebSecurityConfig.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/config/WebSecurityConfig.java
@@ -100,6 +100,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .and().httpBasic()
                 .and()
                 .logout()
+                .logoutUrl("/api/v1/logout")
                 .logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler())
                 .invalidateHttpSession(true)
                 .deleteCookies("JSESSIONID");

--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/controller/AlertsUIController.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/controller/AlertsUIController.java
@@ -18,6 +18,7 @@
 package org.apache.metron.rest.controller;
 
 import static org.apache.metron.rest.MetronRestConstants.SECURITY_ROLE_ADMIN;
+import static org.apache.metron.rest.MetronRestConstants.SECURITY_ROLE_PREFIX;
 
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -74,7 +75,7 @@ public class AlertsUIController {
     }
   }
 
-  @Secured({"ROLE_" + SECURITY_ROLE_ADMIN})
+  @Secured({SECURITY_ROLE_PREFIX + SECURITY_ROLE_ADMIN})
   @ApiOperation(value = "Retrieves all users' settings.  Only users that are part of "
           + "the \"ROLE_ADMIN\" role are allowed to get all user settings.")
   @ApiResponses(value = {@ApiResponse(message = "List of all user settings", code = 200),
@@ -103,7 +104,7 @@ public class AlertsUIController {
     return responseEntity;
   }
 
-  @Secured({"ROLE_" + SECURITY_ROLE_ADMIN})
+  @Secured({SECURITY_ROLE_PREFIX + SECURITY_ROLE_ADMIN})
   @ApiOperation(value = "Deletes a user's settings.  Only users that are part of "
           + "the \"ROLE_ADMIN\" role are allowed to delete user settings.")
   @ApiResponses(value = {@ApiResponse(message = "User settings were deleted", code = 200),

--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/security/SecurityUtils.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/security/SecurityUtils.java
@@ -21,6 +21,15 @@ package org.apache.metron.rest.security;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.io.ByteArrayInputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.security.PublicKey;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.RSAPublicKey;
+
 public class SecurityUtils {
 
   /** Returns the username of the currently logged in user.
@@ -36,5 +45,29 @@ public class SecurityUtils {
       user = principal.toString();
     }
     return user;
+  }
+
+  public static RSAPublicKey parseRSAPublicKey(String pem)
+          throws CertificateException, UnsupportedEncodingException {
+    String PEM_HEADER = "-----BEGIN CERTIFICATE-----\n";
+    String PEM_FOOTER = "\n-----END CERTIFICATE-----";
+    String fullPem = (pem.startsWith(PEM_HEADER) && pem.endsWith(PEM_FOOTER)) ? pem : PEM_HEADER + pem + PEM_FOOTER;
+    PublicKey key = null;
+    try {
+      CertificateFactory fact = CertificateFactory.getInstance("X.509");
+      ByteArrayInputStream is = new ByteArrayInputStream(fullPem.getBytes(StandardCharsets.UTF_8));
+      X509Certificate cer = (X509Certificate) fact.generateCertificate(is);
+      key = cer.getPublicKey();
+    } catch (CertificateException ce) {
+      String message = null;
+      if (pem.startsWith(PEM_HEADER)) {
+        message = "CertificateException - be sure not to include PEM header "
+                + "and footer in the PEM configuration element.";
+      } else {
+        message = "CertificateException - PEM may be corrupt";
+      }
+      throw new CertificateException(message, ce);
+    }
+    return (RSAPublicKey) key;
   }
 }

--- a/metron-interface/metron-rest/src/main/scripts/install_metron_knox.sh
+++ b/metron-interface/metron-rest/src/main/scripts/install_metron_knox.sh
@@ -22,9 +22,9 @@ KNOX_HOME=${KNOX_HOME:-/usr/hdp/current/knox-server}
 KNOX_METRON_REST_DIR=$KNOX_HOME/data/services/metron-rest/$METRON_VERSION
 KNOX_METRON_ALERTS_DIR=$KNOX_HOME/data/services/metron-alerts/$METRON_VERSION
 
-mkdir -p KNOX_METRON_REST_DIR
-mkdir -p KNOX_METRON_ALERTS_DIR
+mkdir -p $KNOX_METRON_REST_DIR
+mkdir -p $KNOX_METRON_ALERTS_DIR
 
 cp $METRON_HOME/config/knox/data/services/rest/* $KNOX_METRON_REST_DIR
 cp $METRON_HOME/config/knox/data/services/alerts/* $KNOX_METRON_ALERTS_DIR
-cp $METRON_HOME/config/knox/conf/topologies/metron.xml $KNOX_HOME/topologies
+cp $METRON_HOME/config/knox/conf/topologies/metron.xml $KNOX_HOME/conf/topologies

--- a/metron-interface/metron-rest/src/main/scripts/install_metron_knox.sh
+++ b/metron-interface/metron-rest/src/main/scripts/install_metron_knox.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+METRON_VERSION=${project.version}
+METRON_HOME=${METRON_HOME:-/usr/metron/${METRON_VERSION}}
+KNOX_HOME=${KNOX_HOME:-/usr/hdp/current/knox-server}
+KNOX_METRON_REST_DIR=$KNOX_HOME/data/services/metron-rest/$METRON_VERSION
+KNOX_METRON_ALERTS_DIR=$KNOX_HOME/data/services/metron-alerts/$METRON_VERSION
+
+mkdir -p KNOX_METRON_REST_DIR
+mkdir -p KNOX_METRON_ALERTS_DIR
+
+cp $METRON_HOME/config/knox/data/services/rest/* $KNOX_METRON_REST_DIR
+cp $METRON_HOME/config/knox/data/services/alerts/* $KNOX_METRON_ALERTS_DIR
+cp $METRON_HOME/config/knox/conf/topologies/metron.xml $KNOX_HOME/topologies


### PR DESCRIPTION
## Contributor Comments
This PR enables Metron to use Knox SSO for authentication.  This PR depends on https://github.com/apache/metron/pull/1275 and, in it's current state, is meant only as a way to demonstrate this capability.

### Testing

1. Follow the instructions in the "Testing" section of https://github.com/apache/metron/pull/1275 to add Metron as a Knox service.  Once you can access REST and the UIs through Knox you are ready for the next steps.

2. Add the Metron REST host to the Knox SSO white list.  Navigate to the `Advanced knoxsso-topology` setting in Ambari at `Services > Knox > Configs > Advanced knoxsso-topology`.  This property contains the complete Knox SSO topology xml.  Update the `knoxsso.redirect.whitelist.regex` param value to include `node1`.  The complete xml should look like this:
```
<topology>
          <gateway>
              <provider>
                  <role>webappsec</role>
                  <name>WebAppSec</name>
                  <enabled>true</enabled>
                  <param><name>xframe.options.enabled</name><value>true</value></param>
              </provider>

              <provider>
                  <role>authentication</role>
                  <name>ShiroProvider</name>
                  <enabled>true</enabled>
                  <param>
                      <name>sessionTimeout</name>
                      <value>30</value>
                  </param>
                  <param>
                      <name>redirectToUrl</name>
                      <value>/gateway/knoxsso/knoxauth/login.html</value>
                  </param>
                  <param>
                      <name>restrictedCookies</name>
                      <value>rememberme,WWW-Authenticate</value>
                  </param>
                  <param>
                      <name>main.ldapRealm</name>
                      <value>org.apache.hadoop.gateway.shirorealm.KnoxLdapRealm</value>
                  </param>
                  <param>
                      <name>main.ldapContextFactory</name>
                      <value>org.apache.hadoop.gateway.shirorealm.KnoxLdapContextFactory</value>
                  </param>
                  <param>
                      <name>main.ldapRealm.contextFactory</name>
                      <value>$ldapContextFactory</value>
                  </param>
                  <param>
                      <name>main.ldapRealm.userDnTemplate</name>
                      <value>uid={0},ou=people,dc=hadoop,dc=apache,dc=org</value>
                  </param>
                  <param>
                      <name>main.ldapRealm.contextFactory.url</name>
                      <value>ldap://localhost:33389</value>
                  </param>    
                  <param>
                      <name>main.ldapRealm.authenticationCachingEnabled</name>
                      <value>false</value>
                  </param>
                  <param>
                      <name>main.ldapRealm.contextFactory.authenticationMechanism</name>
                      <value>simple</value>
                  </param>
                  <param>
                      <name>urls./**</name>
                      <value>authcBasic</value>
                  </param>
              </provider>

              <provider>
                  <role>identity-assertion</role>
                  <name>Default</name>
                  <enabled>true</enabled>
              </provider>
          </gateway>

          <application>
            <name>knoxauth</name>
          </application>

          <service>
              <role>KNOXSSO</role>
              <param>
                  <name>knoxsso.cookie.secure.only</name>
                  <value>false</value>
              </param>
              <param>
                  <name>knoxsso.token.ttl</name>
                  <value>30000</value>
              </param>
              <param>
                 <name>knoxsso.redirect.whitelist.regex</name>
                 <value>^https?:\/\/(localhost|127\.0\.0\.1|0:0:0:0:0:0:0:1|::1|node1):[0-9].*$</value>
              </param>
          </service>

      </topology>
``` 
Save and restart Knox.

3. Update the `metron.xml` topology file at `/usr/hdp/current/knox-server/conf/topologies/metron.xml` to use Knox SSO authentication.  Replace this:
```
<provider>
        <role>authentication</role>
        <name>ShiroProvider</name>
        <enabled>true</enabled>
        <param>
            <name>sessionTimeout</name>
            <value>30</value>
        </param>
        <param>
            <name>main.ldapRealm</name>
            <value>org.apache.hadoop.gateway.shirorealm.KnoxLdapRealm</value>
        </param>
        <param>
            <name>main.ldapRealm.userDnTemplate</name>
            <value>uid={0},ou=people,dc=hadoop,dc=apache,dc=org</value>
        </param>
        <param>
            <name>main.ldapRealm.contextFactory.url</name>
            <value>ldap://localhost:33389</value>
        </param>
        <param>
            <name>main.ldapRealm.contextFactory.authenticationMechanism</name>
            <value>simple</value>
        </param>
        <param>
            <name>urls./**</name>
            <value>authcBasic</value>
        </param>
    </provider>
```
With this:
```
<provider>
        <role>federation</role>
        <name>SSOCookieProvider</name>
        <enabled>true</enabled>
        <param>
            <name>sso.authentication.provider.url</name>
            <value>https://node1:8443/gateway/knoxsso/api/v1/websso</value>
        </param>
    </provider>
```

4. Extract the Knox public key with this command:
```
openssl s_client -connect node1:8443 < /dev/null | openssl x509 | grep -v 'CERTIFICATE' | paste -sd "" -
```
Copy the key value (on the next line after `Done`).  Navigate to the `Metron Spring options` property in Ambari at `Services > Metron > Configs > REST > Metron Spring options`.  Append the Knox public key property and value to the existing `Metron Spring options` value.  It should look like:
```
--knox.root=/gateway/metron/metron-rest --knox.sso.pubkey=<key generated from openssl command>
```
Restart REST.  You should now be able to access Metron using Knox SSO.  

5. Request the global config with this url in a browser:
```
https://node1:8443/gateway/metron/metron-rest/api/v1/global/config
```
You should be redirected to the Knox SSO url with the `originalUrl` param properly set:
```
https://node1:8443/gateway/knoxsso/knoxauth/login.html?originalUrl=https://node1:8443/gateway/metron/metron-rest/api/v1/global/config
```

6. After authenticating with LDAP credentials, you should be successfully redirected and see the global config in the browser.  

7. Navigate to the Alerts UI:
```
https://node1:8443/gateway/metron/metron-alerts/alerts-list
```
You should go directly to the Alerts UI without being prompted for credentials.

8. To verify roles are working correctly, authenticate as the `admin` user with `admin/admin-password`.  The `https://node1:8443/gateway/metron/metron-rest/api/v1/user/whoami/roles` endpoint should return `ROLE_USER` and `ROLE_ADMIN` just as it currently does.

### Outstanding Issues
This is meant only as a demonstration currently and will likely change depending on the outcome of https://github.com/apache/metron/pull/1275.  Set up is a cumbersome, manual process right now so we will need to make that easier or automate it.  

We also need to consider how we manage the `metron.xml` topology file and potentially add our own Knox SSO topology file.  We can apply the decisions we make in https://github.com/apache/metron/pull/1275 for this case as well.

I am also planning on adding a comprehensive unit test for the KnoxSSOAuthenticationFilter class and maybe refactoring it down to a couple different classes.  Feedback welcome there.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [ ] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
