### PR TITLE
METRON-1909: Remove http filter from release utils changelog generation

### DIFF
--- a/dev-utilities/release-utils/prepare-release-candidate
+++ b/dev-utilities/release-utils/prepare-release-candidate
@@ -293,7 +293,7 @@ mv "${ARTIFACT}.tar.gz.asc" "$ART_DIR"
 # Do this by getting all commits in current branch that aren't in current release. Filter out any merges by making sure lines start with blankspace followed by "METRON"
 # i.e. make sure the lines starts with a ticket number to avoid merge commits into feature branches
 printf "Creating CHANGES file\n"
-git log "${CAPITAL_REPO}_${VERSION}" "^tags/${TAG}" --no-merges | grep -E "^[[:blank:]]+METRON" | sed 's/\[//g' | sed 's/\]//g' | grep -v "http" > "${ART_DIR}/CHANGES"
+git log "${CAPITAL_REPO}_${VERSION}" "^tags/${TAG}" --no-merges | grep -E "^[[:blank:]]+METRON" | sed 's/\[//g' | sed 's/\]//g' > "${ART_DIR}/CHANGES"
 if [[ $? -ne 0 ]]; then
   "Error creating CHANGES file"
   exit 1


### PR DESCRIPTION
## Contributor Comments
Removing the http clause entirely.  Can be tested by running the script and making sure **NOT** to do a live run.  CHANGELOG file that's generated should be normal and still lack merge commits.

I also considered editing the command to collapse multiple commits against a single Jira, but decided against it because it would result in making the attribution less obvious in the changelog
i.e. if user1 and user2 both worked on METRON-0000, the commit history would look vaguely like
METRON-0000: Blah Blah Blah (user1)
METRON-0000: Blah Blah Blah (user2)

while the CHANGELOG would only contain
METRON-0000: Blah Blah Blah (user1).

If someone really cares, it might be nice to just do Jira number and description and then collapse it, but I'm inclined to call it too much work for something so small.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [ ] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
