### PR TITLE
METRON-1889: Add any missing timestamp fields to unified enrichment topology

### DIFF
--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/utils/EnrichmentUtils.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/utils/EnrichmentUtils.java
@@ -21,21 +21,18 @@ import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
-import org.apache.commons.lang.StringUtils;
-import org.apache.hadoop.hbase.client.HTableInterface;
-import org.apache.metron.common.configuration.enrichment.EnrichmentConfig;
-import org.apache.metron.common.configuration.enrichment.SensorEnrichmentConfig;
-import org.apache.metron.enrichment.lookup.EnrichmentLookup;
-import org.apache.metron.enrichment.lookup.handler.KeyWithContext;
-import org.apache.metron.hbase.TableProvider;
-import org.apache.metron.enrichment.converter.EnrichmentKey;
-import org.json.simple.JSONObject;
-import sun.management.Sensor;
-
-import javax.annotation.Nullable;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.hbase.client.HTableInterface;
+import org.apache.metron.common.configuration.enrichment.EnrichmentConfig;
+import org.apache.metron.enrichment.converter.EnrichmentKey;
+import org.apache.metron.enrichment.lookup.EnrichmentLookup;
+import org.apache.metron.enrichment.lookup.handler.KeyWithContext;
+import org.apache.metron.hbase.TableProvider;
+import org.json.simple.JSONObject;
 
 public class EnrichmentUtils {
 


### PR DESCRIPTION
## Contributor Comments

https://issues.apache.org/jira/browse/METRON-1889

This is done in reference to this discussion on the mailing list wrt deprecating the split join topology. https://lists.apache.org/thread.html/e3a0f5634db74d44c4e2f2e0399cc3f0777f1e0dce2e1f764cc0a39f@%3Cdev.metron.apache.org%3E

The split-join enrichment topology has the following timestamp keys:

**Adapter timestamps**

```
  "adapter:hostfromjsonlistadapter:begin:ts": "1542840777691",
  "adapter:hostfromjsonlistadapter:end:ts": "1542840777691",
  "adapter:threatinteladapter:begin:ts": "1542840784545",
  "adapter:threatinteladapter:end:ts": "1542840784545",
  "adapter:geoadapter:begin:ts": "1542840783196",
  "adapter:geoadapter:end:ts": "1542840783196"
```

**Split and Join Bolt timestamps**

```
  "enrichmentsplitterbolt:splitter:begin:ts": "1542840777617",
  "enrichmentsplitterbolt:splitter:end:ts": "1542840777617",
  "enrichmentjoinbolt:joiner:ts": "1542840783234",
  "threatintelsplitterbolt:splitter:begin:ts": "1542840783247",
  "threatintelsplitterbolt:splitter:end:ts": "1542840783247",
  "threatinteljoinbolt:joiner:ts": "1542840784555"
```

The unified enrichment topology currently only has the following timestamp
keys:

```
  "parallelenricher:splitter:begin:ts": "1542807098066",
  "parallelenricher:splitter:end:ts": "1542807098066",
  "parallelenricher:enrich:begin:ts": "1542807098066"
```

The enrichment end timestamp is missing in the case when there are no enrichments. Also, the adapter timestamps did not carry over from the split-join topology.

In this PR, I've corrected for the missing `enrich:end:ts` case for when there are no enrichments and added back in the adapter timestamps.

This is the new timestamp output for the unified enrichment topology after my changes:

**Adapter timestamps**

```
  "adapter:geoadapter:begin:ts": "1542882553866",
  "adapter:geoadapter:end:ts": "1542882553866",
  "adapter:threatinteladapter:begin:ts": "1542882553869",
  "adapter:threatinteladapter:end:ts": "1542882553870",
  "adapter:hostfromjsonlistadapter:begin:ts": "1542882553866",
  "adapter:hostfromjsonlistadapter:end:ts": "1542882553866"
```

**Enrichment bolt timestamps**

```
  "parallelenricher:enrich:begin:ts": "1542882553869",
  "parallelenricher:enrich:end:ts": "1542882553870",
  "parallelenricher:splitter:begin:ts": "1542882553869",
  "parallelenricher:splitter:end:ts": "1542882553869"
```

**Testing**

Spin up full dev and you should see bro records in Elasticsearch (or Solr) that now contain the adapter timestamps. By default, the unified enrichment topology should be running, but make sure of this when you evaluate the records in the bro index.

## Pull Request Checklist

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- n/a If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- n/a Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
