### PR TITLE
METRON-1916 Stellar Classpath Function Resolver Should Handle ClassNotFoundException

### DIFF
--- a/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/dsl/functions/resolver/BaseFunctionResolver.java
+++ b/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/dsl/functions/resolver/BaseFunctionResolver.java
@@ -18,18 +18,9 @@
 
 package org.apache.metron.stellar.dsl.functions.resolver;
 
-import static java.lang.String.format;
-
 import com.google.common.base.Joiner;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
-import java.io.IOException;
-import java.io.Serializable;
-import java.lang.invoke.MethodHandles;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
 import org.apache.commons.lang.ObjectUtils;
 import org.apache.metron.stellar.dsl.Context;
 import org.apache.metron.stellar.dsl.Stellar;
@@ -37,6 +28,16 @@ import org.apache.metron.stellar.dsl.StellarFunction;
 import org.apache.metron.stellar.dsl.StellarFunctionInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static java.lang.String.format;
 
 /**
  * The base implementation of a function resolver that provides a means for lazy
@@ -237,8 +238,9 @@ public abstract class BaseFunctionResolver implements FunctionResolver, Serializ
     try {
       return clazz.getConstructor().newInstance();
 
-    } catch (Exception e) {
-      LOG.error("Unable to load {} because {}", clazz.getName(), e.getMessage(), e);
+    } catch (Exception | NoClassDefFoundError e) {
+      String className = clazz != null ? clazz.getName() : "null";
+      LOG.error("Unable to load {} because {}", className, e.getMessage(), e);
       return null;
     }
   }


### PR DESCRIPTION
Stellar can be executed in an environment where not all of the dependencies are available for each of the functions available on the classpath. When this happens, the classpath resolver blows-up even if you do not use the function that is missing dependencies.

For example this exception is thrown when not all of the dependencies are available for the new REST function.  I was only attempting to use STATS_INIT, not the REST function.
```
2018-11-30 15:47:00 DEBUG BaseFunctionResolver:165 - Resolving Stellar function in class RestFunctions.RestGet
2018-11-30 15:47:00 ERROR DefaultProfileBuilder:302 - Bad 'init' expression: error='Unable to parse: STATS_INIT() due to: org/apache/http/conn/HttpClientConnectionManager', expr='STATS_INIT()', profile='profile-with-stats', entity='global', variables-available='[adapter.threatinteladapter.end.ts, bro_timestamp, ip_dst_port, enrichmentsplitterbolt.splitter.end.ts, enrichmentsplitterbolt.splitter.begin.ts, adapter.hostfromjsonlistadapter.end.ts, adapter.geoadapter.begin.ts, uid, trans_depth, protocol, original_string, ip_dst_addr, threatinteljoinbolt.joiner.ts, host, enrichmentjoinbolt.joiner.ts, adapter.hostfromjsonlistadapter.begin.ts, threatintelsplitterbolt.splitter.begin.ts, ip_src_addr, user_agent, timestamp, method, request_body_len, uri, tags, source.type, adapter.geoadapter.end.ts, referrer, threatintelsplitterbolt.splitter.end.ts, adapter.threatinteladapter.begin.ts, ip_src_port, guid, response_body_len]'
org.apache.metron.stellar.dsl.ParseException: Unable to parse: STATS_INIT() due to: org/apache/http/conn/HttpClientConnectionManager
at org.apache.metron.stellar.common.BaseStellarProcessor.createException(BaseStellarProcessor.java:166)
at org.apache.metron.stellar.common.BaseStellarProcessor.parse(BaseStellarProcessor.java:154)
at org.apache.metron.stellar.common.DefaultStellarStatefulExecutor.execute(DefaultStellarStatefulExecutor.java:160)
at org.apache.metron.stellar.common.DefaultStellarStatefulExecutor.assign(DefaultStellarStatefulExecutor.java:95)
at org.apache.metron.profiler.DefaultProfileBuilder.assign(DefaultProfileBuilder.java:291)
at org.apache.metron.profiler.DefaultProfileBuilder.apply(DefaultProfileBuilder.java:136)
at org.apache.metron.profiler.DefaultMessageDistributor.distribute(DefaultMessageDistributor.java:177)
at org.apache.metron.profiler.storm.ProfileBuilderBolt.handleMessage(ProfileBuilderBolt.java:411)
at org.apache.metron.profiler.storm.ProfileBuilderBolt.execute(ProfileBuilderBolt.java:337)
at org.apache.storm.topology.WindowedBoltExecutor$1.onActivation(WindowedBoltExecutor.java:307)
at org.apache.storm.windowing.WindowManager.onTrigger(WindowManager.java:145)
at org.apache.storm.windowing.WatermarkTimeTriggerPolicy.handleWaterMarkEvent(WatermarkTimeTriggerPolicy.java:80)
at org.apache.storm.windowing.WatermarkTimeTriggerPolicy.track(WatermarkTimeTriggerPolicy.java:48)
at org.apache.storm.windowing.WindowManager.track(WindowManager.java:177)
at org.apache.storm.windowing.WindowManager.add(WindowManager.java:110)
at org.apache.storm.windowing.WaterMarkEventGenerator.run(WaterMarkEventGenerator.java:80)
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.NoClassDefFoundError: org/apache/http/conn/HttpClientConnectionManager
at java.lang.Class.getDeclaredConstructors0(Native Method)
at java.lang.Class.privateGetDeclaredConstructors(Class.java:2671)
at java.lang.Class.getConstructor0(Class.java:3075)
at java.lang.Class.getConstructor(Class.java:1825)
at org.apache.metron.stellar.dsl.functions.resolver.BaseFunctionResolver.createFunction(BaseFunctionResolver.java:240)
at org.apache.metron.stellar.dsl.functions.resolver.BaseFunctionResolver.resolveFunction(BaseFunctionResolver.java:194)
at org.apache.metron.stellar.dsl.functions.resolver.BaseFunctionResolver.resolveFunctions(BaseFunctionResolver.java:166)
at com.google.common.base.Suppliers$MemoizingSupplier.get(Suppliers.java:109)
at org.apache.metron.stellar.dsl.functions.resolver.BaseFunctionResolver.apply(BaseFunctionResolver.java:149)
at org.apache.metron.stellar.dsl.functions.resolver.BaseFunctionResolver.apply(BaseFunctionResolver.java:49)
at org.apache.metron.stellar.common.StellarCompiler.resolveFunction(StellarCompiler.java:688)
at org.apache.metron.stellar.common.StellarCompiler.lambda$exitTransformationFunc$13(StellarCompiler.java:656)
at org.apache.metron.stellar.common.StellarCompiler$Expression.apply(StellarCompiler.java:259)
at org.apache.metron.stellar.common.BaseStellarProcessor.parse(BaseStellarProcessor.java:151)
... 21 more
```

When this happens the Classpath Function Resolver should allow me to use whichever functions can be loaded correctly.  With this change the following error message is logged and execution is allowed to continue.
```
2018-12-01 08:22:42 ERROR BaseFunctionResolver:243 - Unable to load org.apache.metron.stellar.dsl.functions.RestFunctions$RestGet because org/apache/http/conn/HttpClientConnectionManager
java.lang.NoClassDefFoundError: org/apache/http/conn/HttpClientConnectionManager
	at java.lang.Class.getDeclaredConstructors0(Native Method)
	at java.lang.Class.privateGetDeclaredConstructors(Class.java:2671)
	at java.lang.Class.getConstructor0(Class.java:3075)
	at java.lang.Class.getConstructor(Class.java:1825)
	at org.apache.metron.stellar.dsl.functions.resolver.BaseFunctionResolver.createFunction(BaseFunctionResolver.java:239)
	at org.apache.metron.stellar.dsl.functions.resolver.BaseFunctionResolver.resolveFunction(BaseFunctionResolver.java:193)
	at org.apache.metron.stellar.dsl.functions.resolver.BaseFunctionResolver.resolveFunctions(BaseFunctionResolver.java:165)
	at com.google.common.base.Suppliers$MemoizingSupplier.get(Suppliers.java:109)
	at org.apache.metron.stellar.dsl.functions.resolver.BaseFunctionResolver.apply(BaseFunctionResolver.java:149)
	at org.apache.metron.stellar.dsl.functions.resolver.BaseFunctionResolver.apply(BaseFunctionResolver.java:49)
	at org.apache.metron.stellar.common.StellarCompiler.resolveFunction(StellarCompiler.java:688)
	at org.apache.metron.stellar.common.StellarCompiler.lambda$exitTransformationFunc$13(StellarCompiler.java:656)
	at org.apache.metron.stellar.common.StellarCompiler$Expression.apply(StellarCompiler.java:259)
	at org.apache.metron.stellar.common.BaseStellarProcessor.parse(BaseStellarProcessor.java:151)
	at org.apache.metron.stellar.common.DefaultStellarStatefulExecutor.execute(DefaultStellarStatefulExecutor.java:160)
	at org.apache.metron.stellar.common.DefaultStellarStatefulExecutor.assign(DefaultStellarStatefulExecutor.java:95)
	at org.apache.metron.profiler.DefaultProfileBuilder.assign(DefaultProfileBuilder.java:291)
	at org.apache.metron.profiler.DefaultProfileBuilder.apply(DefaultProfileBuilder.java:136)
	at org.apache.metron.profiler.DefaultMessageDistributor.distribute(DefaultMessageDistributor.java:177)
	at org.apache.metron.profiler.storm.ProfileBuilderBolt.handleMessage(ProfileBuilderBolt.java:411)
	at org.apache.metron.profiler.storm.ProfileBuilderBolt.execute(ProfileBuilderBolt.java:337)
	at org.apache.storm.topology.WindowedBoltExecutor$1.onActivation(WindowedBoltExecutor.java:307)
	at org.apache.storm.windowing.WindowManager.onTrigger(WindowManager.java:145)
	at org.apache.storm.windowing.WatermarkTimeTriggerPolicy.handleWaterMarkEvent(WatermarkTimeTriggerPolicy.java:80)
	at org.apache.storm.windowing.WatermarkTimeTriggerPolicy.track(WatermarkTimeTriggerPolicy.java:48)
	at org.apache.storm.windowing.WindowManager.track(WindowManager.java:177)
	at org.apache.storm.windowing.WindowManager.add(WindowManager.java:110)
	at org.apache.storm.windowing.WaterMarkEventGenerator.run(WaterMarkEventGenerator.java:80)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.ClassNotFoundException: org.apache.http.conn.HttpClientConnectionManager
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 35 more
```

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [ ] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [ ] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
