### PR TITLE
METRON-1953 Stellar REPL Fails on Start

### DIFF
--- a/metron-platform/metron-common/src/main/scripts/stellar
+++ b/metron-platform/metron-common/src/main/scripts/stellar
@@ -38,7 +38,7 @@ set -u
 
 export METRON_PARSERS_PLATFORM="${METRON_PARSERS_PLATFORM:-storm}"
 export HBASE_CONFIGS=$(hbase classpath)
-export STELLAR_LIB=$(find $METRON_HOME/lib/ -name metron-parsers-*-uber.jar | grep -v "common")
+export STELLAR_LIB=$(find $METRON_HOME/lib/ -name metron-parsing-${METRON_PARSERS_PLATFORM}*.jar)
 export MANAGEMENT_LIB=$(find $METRON_HOME/lib/ -name metron-management*.jar)
 export PROFILER_LIB=$(find $METRON_HOME/lib/ -name metron-profiler-repl*.jar)
 java $METRON_JVMFLAGS -cp "${CONTRIB:-$METRON_HOME/contrib/*}:$STELLAR_LIB:$MANAGEMENT_LIB:$PROFILER_LIB:$HBASE_CONFIGS" org.apache.metron.stellar.common.shell.cli.StellarShell "$@"

--- a/metron-platform/metron-common/src/main/scripts/stellar
+++ b/metron-platform/metron-common/src/main/scripts/stellar
@@ -38,7 +38,7 @@ set -u
 
 export METRON_PARSERS_PLATFORM="${METRON_PARSERS_PLATFORM:-storm}"
 export HBASE_CONFIGS=$(hbase classpath)
-export STELLAR_LIB=$(find $METRON_HOME/lib/ -name metron-parsers-${METRON_PARSERS_PLATFORM}*.jar)
+export STELLAR_LIB=$(find $METRON_HOME/lib/ -name metron-parsers-*-uber.jar | grep -v "common")
 export MANAGEMENT_LIB=$(find $METRON_HOME/lib/ -name metron-management*.jar)
 export PROFILER_LIB=$(find $METRON_HOME/lib/ -name metron-profiler-repl*.jar)
 java $METRON_JVMFLAGS -cp "${CONTRIB:-$METRON_HOME/contrib/*}:$STELLAR_LIB:$MANAGEMENT_LIB:$PROFILER_LIB:$HBASE_CONFIGS" org.apache.metron.stellar.common.shell.cli.StellarShell "$@"


### PR DESCRIPTION
The Stellar REPL will fail to launch.  See full stack trace in [METRON-1953](https://issues.apache.org/jira/browse/METRON-1953)

There was a small typo in the Storm Parsers jar.  Instead of "parsers" it needs to be "parsing".

## Testing

1. Launch Full Dev.
    ```
    cd metron-deployment/development/centos6
    vagrant up
    vagrant ssh
    ```

1. Launch the REPL.  Ensure that it successfully is started.
    ```
    sudo su -
    source /etc/default/metron
    cd $METRON_HOME
    bin/stellar -z $ZOOKEEPER
    ```

1. Run some commands to validate the REPL.

## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
