### PR TITLE
METRON-1954 Commit Script Fails to Extract Usernames with Numerals

### DIFF
--- a/dev-utilities/committer-utils/metron-committer-common
+++ b/dev-utilities/committer-utils/metron-committer-common
@@ -239,7 +239,7 @@ function setup_code {
 #
 function get_contributor_info {
     # use github api to retrieve the contributor's login
-    USER=`curl -s https://api.github.com/repos/apache/${CHOSEN_REPO}/pulls/${PR} | grep login | head -1 | awk -F":" '{print $2}' | sed 's/[^a-zA-Z.@_-]//g'`
+    USER=`curl -s https://api.github.com/repos/apache/${CHOSEN_REPO}/pulls/${PR} | grep login | head -1 | awk -F":" '{print $2}' | sed 's/[^a-zA-Z0-9.@_-]//g'`
     read -p "  github contributor's username [$USER]: " INPUT
     [ -n "$INPUT" ] && USER=${INPUT}
 


### PR DESCRIPTION
Run the script on PR #1306 and make sure that it correctly pulls out the username `ruffle1986`.

```
$ prepare-commit
/Users/nallen/.metron-prepare-commit
  ...using settings from /Users/nallen/.metron-prepare-commit
    [1] metron
    [2] metron-bro-plugin-kafka
  which repo? [1]: 1
  pull request: 1306
  local working directory [/Users/nallen/tmp/metron-pr1306]:
  origin repo [https://github.com/apache/metron]:
  base branch to merge into [master]:
Cloning into '/Users/nallen/tmp/metron-pr1306'...
remote: Enumerating objects: 16, done.
remote: Counting objects: 100% (16/16), done.
remote: Compressing objects: 100% (16/16), done.
remote: Total 48814 (delta 0), reused 1 (delta 0), pack-reused 48798
Receiving objects: 100% (48814/48814), 62.57 MiB | 15.31 MiB/s, done.
Resolving deltas: 100% (19818/19818), done.
Checking out files: 100% (3012/3012), done.
From https://gitbox.apache.org/repos/asf/metron
 * branch              master     -> FETCH_HEAD
 * [new branch]        master     -> upstream/master
Already on 'master'
Your branch is up to date with 'origin/master'.
Already up to date.
remote: Enumerating objects: 8, done.
remote: Counting objects: 100% (8/8), done.
remote: Total 9 (delta 8), reused 8 (delta 8), pack-reused 1
Unpacking objects: 100% (9/9), done.
From https://github.com/apache/metron
 * [new ref]           refs/pull/1306/head -> pr-1306

  github contributor's username [ruffle1986]:
```


## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
