### PR TITLE
METRON-1957 fix spec location of syslog configs

### DIFF
--- a/metron-deployment/packaging/docker/rpm-docker/SPECS/metron.spec
+++ b/metron-deployment/packaging/docker/rpm-docker/SPECS/metron.spec
@@ -157,6 +157,8 @@ This package installs the Metron Parser Common files
 %{metron_home}/config/zookeeper/parsers/jsonMap.json
 %{metron_home}/config/zookeeper/parsers/jsonMapQuery.json
 %{metron_home}/config/zookeeper/parsers/jsonMapWrappedQuery.json
+%{metron_home}/config/zookeeper/parsers/syslog3164.json
+%{metron_home}/config/zookeeper/parsers/syslog5424.json
 %{metron_home}/patterns/common
 %attr(0644,root,root) %{metron_home}/lib/metron-parsers-common-%{full_version}-uber.jar
 
@@ -182,8 +184,6 @@ This package installs the Metron Bundled Parser files
 %{metron_home}/config/zookeeper/parsers/bro.json
 %{metron_home}/config/zookeeper/parsers/snort.json
 %{metron_home}/config/zookeeper/parsers/squid.json
-%{metron_home}/config/zookeeper/parsers/syslog3164.json
-%{metron_home}/config/zookeeper/parsers/syslog5424.json
 %{metron_home}/config/zookeeper/parsers/websphere.json
 %{metron_home}/config/zookeeper/parsers/yaf.json
 %{metron_home}/config/zookeeper/parsers/asa.json
@@ -634,6 +634,8 @@ chkconfig --del metron-management-ui
 chkconfig --del metron-alerts-ui
 
 %changelog
+* Thu Dec 27 2018 Apache Metron <dev@metron.apache.og> - 0.7.1
+- Updat metron SPEC to move syslog configurations to right place
 * Wed Dec 26 2018 Apache Metron <dev@metron.apache.org> - 0.7.1
 - Update metron SPEC file to include syslog 3164 parser
 * Thu Nov 15 2018 Apache Metron <dev@metron.apache.org> - 0.7.0


### PR DESCRIPTION
Since the packaging change, the syslog parsers are in common, not in parsers.  Although the way we do things means it still worked, the spec should reflect that.


# test with full dev

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [-] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
