### PR TITLE
METRON-1958: Optimize Cypress to use best practices

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/templates/alerts_ui.yml.j2
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/templates/alerts_ui.yml.j2
@@ -21,3 +21,5 @@ port: {{metron_alerts_ui_port}}
 rest:
   host: {{metron_rest_host}}
   port: {{metron_rest_port}}
+
+dirPath: alerts-ui

--- a/metron-interface/metron-alerts/alerts_ui_cypress.yml
+++ b/metron-interface/metron-alerts/alerts_ui_cypress.yml
@@ -18,6 +18,6 @@ port: 4201
 
 rest:
   host: localhost
-  port: 8080
+  port: 4201
 
-dirPath: alerts-ui
+dirPath: dist

--- a/metron-interface/metron-alerts/alerts_ui_cypress.yml
+++ b/metron-interface/metron-alerts/alerts_ui_cypress.yml
@@ -14,10 +14,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-port: 4201
+port: 4200
 
 rest:
   host: localhost
-  port: 4201
+  port: 4200
 
 dirPath: dist

--- a/metron-interface/metron-alerts/cypress.json
+++ b/metron-interface/metron-alerts/cypress.json
@@ -4,6 +4,5 @@
   "video": false,
   "supportFile": false,
   "pluginsFile": false,
-  "requestTimeout": 300000,
-  "responseTimeout": 300000
+  "baseUrl": "http://localhost:4200"
 }

--- a/metron-interface/metron-alerts/cypress.json
+++ b/metron-interface/metron-alerts/cypress.json
@@ -3,5 +3,7 @@
   "viewportHeight": 850,
   "video": false,
   "supportFile": false,
-  "pluginsFile": false
+  "pluginsFile": false,
+  "requestTimeout": 300000,
+  "responseTimeout": 300000
 }

--- a/metron-interface/metron-alerts/cypress/integration/pcap/pcap.spec.js
+++ b/metron-interface/metron-alerts/cypress/integration/pcap/pcap.spec.js
@@ -25,6 +25,11 @@ context('PCAP Tab', () => {
       url: '/api/v1/user',
       response: 'user'
     });
+    cy.route({
+      method: 'POST',
+      url: 'logout',
+      response: []
+    });
 
     cy.route('GET', '/api/v1/global/config', 'fixture:config.json');
     cy.route('POST', 'search', 'fixture:search.json');

--- a/metron-interface/metron-alerts/cypress/integration/pcap/pcap.spec.js
+++ b/metron-interface/metron-alerts/cypress/integration/pcap/pcap.spec.js
@@ -42,7 +42,6 @@ context('PCAP Tab', () => {
   });
 
   afterEach(() => {
-    cy.get('.logout-link').click();
   });
 
   it('checking running jobs on navigating to PCAP tab', () => {

--- a/metron-interface/metron-alerts/cypress/integration/pcap/pcap.spec.js
+++ b/metron-interface/metron-alerts/cypress/integration/pcap/pcap.spec.js
@@ -26,7 +26,7 @@ context('PCAP Tab', () => {
       response: 'user'
     });
 
-    cy.route('GET', 'config', 'fixture:config.json');
+    cy.route('GET', 'global/config', 'fixture:config.json');
     cy.route('POST', 'search', 'fixture:search.json');
 
     cy.route({
@@ -34,7 +34,7 @@ context('PCAP Tab', () => {
       url: '/api/v1/pcap?state=*',
       response: []
     }).as('runningJobs');
-    
+
     cy.visit('http://localhost:4200/login');
     cy.get('[name="user"]').type('user');
     cy.get('[name="password"]').type('password');
@@ -62,7 +62,7 @@ context('PCAP Tab', () => {
     cy.get('[data-qe-id="protocol"]').type('24');
     cy.get('[data-qe-id="include-reverse"]').check();
     cy.get('[data-qe-id="packet-filter"]').type('filter');
-    
+
     cy.get('[data-qe-id="submit-button"]').click();
 
     cy.wait('@postingPcapJob').then((xhr) => {
@@ -82,7 +82,7 @@ context('PCAP Tab', () => {
 
     cy.contains('PCAP').click();
     cy.get('[data-qe-id="submit-button"]').click();
-    
+
     cy.wait('@jobStatusCheck').its('url').should('include', '/api/v1/pcap/job_1537878471649_0001');
   });
 
@@ -92,7 +92,7 @@ context('PCAP Tab', () => {
 
     cy.contains('PCAP').click();
     cy.get('[data-qe-id="submit-button"]').click();
-    
+
     cy.wait('@jobStatusCheck');
 
     cy.contains('75%').should('be.visible');
@@ -105,7 +105,7 @@ context('PCAP Tab', () => {
 
     cy.contains('PCAP').click();
     cy.get('[data-qe-id="submit-button"]').click();
-    
+
     cy.wait('@statusCheck');
 
     cy.wait('@gettingPdml').its('url').should('include', '/api/v1/pcap/job_1537878471649_0001/pdml?page=1');
@@ -119,7 +119,7 @@ context('PCAP Tab', () => {
 
     cy.contains('PCAP').click();
     cy.get('[data-qe-id="submit-button"]').click();
-    
+
     cy.wait('@statusCheck');
 
     cy.wait('@gettingPdml');
@@ -135,7 +135,7 @@ context('PCAP Tab', () => {
 
     cy.contains('PCAP').click();
     cy.get('[data-qe-id="submit-button"]').click();
-    
+
     cy.wait('@statusCheck');
     cy.wait('@gettingPdml');
 
@@ -143,7 +143,7 @@ context('PCAP Tab', () => {
     cy.contains('General information').should('not.be.visible');
 
     cy.get(':nth-child(3) > .timestamp').click();
-    
+
     cy.contains('General information').should('be.visible');
     cy.get('[data-qe-id="proto"]').should('have.length', 6);
   });
@@ -155,12 +155,12 @@ context('PCAP Tab', () => {
 
     cy.contains('PCAP').click();
     cy.get('[data-qe-id="submit-button"]').click();
-    
+
     cy.wait('@statusCheck');
     cy.wait('@gettingPdml');
 
     cy.contains('Page 1 of 2').should('be.visible');
-    
+
     cy.get('.fa-chevron-right').click();
 
     cy.wait('@gettingPdml').its('url').should('include', '?page=2');
@@ -174,7 +174,7 @@ context('PCAP Tab', () => {
 
     cy.contains('PCAP').click();
     cy.get('[data-qe-id="submit-button"]').click();
-    
+
     cy.wait('@statusCheck');
     cy.wait('@gettingPdml');
 
@@ -194,7 +194,7 @@ context('PCAP Tab', () => {
 
     cy.contains('PCAP').click();
     cy.get('[data-qe-id="submit-button"]').click();
-    
+
     cy.wait('@jobStatusCheck');
 
     cy.get('[data-qe-id="pcap-cancel-query-button"]').click();
@@ -210,7 +210,7 @@ context('PCAP Tab', () => {
     cy.get('[data-qe-id="ip-dst-addr"]').type('ccc.ddd.222.000');
     cy.get('[data-qe-id="ip-src-port"]').type('99999');
     cy.get('[data-qe-id="ip-dst-port"]').type('aaaa');
-    
+
     cy.get('.pcap-search-validation-errors').should('be.visible');
     cy.get('.pcap-search-validation-errors li').should('have.length', 4);
   });
@@ -221,7 +221,7 @@ context('PCAP Tab', () => {
     cy.get('[data-qe-id="end-time"]').click();
     cy.get('.pika-select-year').select('2015');
     cy.get('[data-day="11"] > .pika-button').click();
-    
+
     cy.get('.pcap-search-validation-errors').should('be.visible');
     cy.get('.pcap-search-validation-errors li').should('have.length', 1);
   });

--- a/metron-interface/metron-alerts/cypress/integration/pcap/pcap.spec.js
+++ b/metron-interface/metron-alerts/cypress/integration/pcap/pcap.spec.js
@@ -26,7 +26,7 @@ context('PCAP Tab', () => {
       response: 'user'
     });
 
-    cy.route('GET', 'global/config', 'fixture:config.json');
+    cy.route('GET', '/api/v1/global/config', 'fixture:config.json');
     cy.route('POST', 'search', 'fixture:search.json');
 
     cy.route({
@@ -35,7 +35,7 @@ context('PCAP Tab', () => {
       response: []
     }).as('runningJobs');
 
-    cy.visit('http://localhost:4200/login');
+    cy.visit('login');
     cy.get('[name="user"]').type('user');
     cy.get('[name="password"]').type('password');
     cy.contains('LOG IN').click();

--- a/metron-interface/metron-alerts/package-lock.json
+++ b/metron-interface/metron-alerts/package-lock.json
@@ -20591,6 +20591,16 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
+    "yamljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
+      "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "glob": "^7.0.5"
+      }
+    },
     "yargs": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",

--- a/metron-interface/metron-alerts/package.json
+++ b/metron-interface/metron-alerts/package.json
@@ -13,7 +13,8 @@
     "e2e": "protractor-flake --protractor-path=./node_modules/.bin/protractor --max-attempts=3 -- ./protractor.conf.js",
     "cypress:run": "cypress run",
     "cypress:open": "cypress open",
-    "cypress:ci": "run-p --race start cypress:run"
+    "cypress:ci": "ng build --prod && run-p --race start:ci cypress:run",
+    "start:ci": "node ./scripts/alerts-server.js -c alerts_ui_cypress.yml"
   },
   "private": true,
   "dependencies": {
@@ -75,6 +76,7 @@
     "serve-static": "^1.13.2",
     "ssh2": "^0.5.5",
     "tslint": "~5.0.0",
-    "typescript": "~2.9.2"
+    "typescript": "~2.9.2",
+    "yamljs": "^0.3.0"
   }
 }

--- a/metron-interface/metron-alerts/scripts/alerts-server.js
+++ b/metron-interface/metron-alerts/scripts/alerts-server.js
@@ -60,15 +60,15 @@ var restUrl = 'http://' + uiConfig.rest.host + ':' + uiConfig.rest.port;
 app.use('/api/v1', proxy(restUrl));
 app.use('/logout', proxy(restUrl));
 
-app.use(favicon(path.join(__dirname, '../alerts-ui/favicon.ico')));
+app.use(favicon(path.join(__dirname, '../' + uiConfig.dirPath + '/favicon.ico')));
 
-app.use(serveStatic(path.join(__dirname, '../alerts-ui'), {
+app.use(serveStatic(path.join(__dirname, '../' + uiConfig.dirPath), {
   maxAge: '1d',
   setHeaders: setCustomCacheControl
 }));
 
 app.get('*', function(req, res){
-  res.sendFile(path.join(__dirname, '../alerts-ui/index.html'));
+  res.sendFile(path.join(__dirname, '../' + uiConfig.dirPath + '/index.html'));
 });
 
 app.listen(uiConfig.port, function(){


### PR DESCRIPTION
## Contributor Comments
Link to the original ASF JIRA ticket: https://jira.apache.org/jira/browse/METRON-1958

As described in the ticket, we have a few anti-patterns in place right now in regard to our Cypress configuration. Through local testing, I believe this has led to the recent Travis failures in Pull Requests like #1308 and #1275. 

### Changes Included

* Update npm scripts to use the express server that's already in place vs. the angular cli development server. Lately, we have been running into a race condition where sometimes the Cypress tests are running before the application has been compiled and the server has started. We should be testing the built application after the build is complete.
* Add a baseUrl property to the Cypress config [per their recommendation](https://docs.cypress.io/guides/references/best-practices.html#Setting-a-global-baseUrl).
* Remove the logout click action in the afterEach hook [per the Cypress team's recommendation](https://docs.cypress.io/guides/references/best-practices.html#Using-after-or-afterEach-hooks). While we had to do this to clean up state when the tests were run in protractor, it's unnecessary in Cypress and can cause errors if a test is reloaded before the afterEach executes or loaded before the page reload is complete.
* Add yamljs as a dependency in the alerts ui. This dependency is already part of the project in the config ui and was already used by the express server to parse the configuration file.
* Update the Cypress tests to use the updated global configuration endpoint.

### Testing
Clone either #1308 and #1275 locally. From the command line, navigate to metron-interface/metron-alerts from the root of the project. Install npm dependencies by running `npm ci`. Then, run `npm run cypress:ci`. #1308 will always fail, and #1275 will intermittently fail.

Once you've verified failure on either on of the PRs mentioned above, clone this PR locally. Merge it into #1308 or #1275, run `npm ci`, then run `npm run cypress:ci`. The tests should consistently pass now.

### Other Considerations
The Cypress team recommends the use of the `wait-on` or `start-server-and-test` modules to handle the flow of starting your server, starting Cypress and, once the tests complete, killing your server. However, since the next proposed Metron release is near and this PR will fix failing PRs needed for that release, I decided instead to continue using the npm-run-all module we were already using. Since the express server is so incredibly fast compared to the startup of Cypress, I felt the risk of a race condition happening would be extremely low and this was the best approach for now. I've created a ticket around the addition of the recommended modules to keep track of the task: https://jira.apache.org/jira/browse/METRON-1959

In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
