### PR TITLE
METRON-1970 Add Metadata to Error Messages Generated During Parsing

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/Constants.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/Constants.java
@@ -93,6 +93,7 @@ public class Constants {
     ,RAW_MESSAGE_BYTES("raw_message_bytes")
     ,ERROR_FIELDS("error_fields")
     ,ERROR_HASH("error_hash")
+    ,METADATA("metadata")
     ;
 
     private String name;

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/error/MetronError.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/error/MetronError.java
@@ -25,10 +25,14 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.metron.common.Constants;
@@ -45,6 +49,7 @@ public class MetronError {
   private ErrorType errorType = ErrorType.DEFAULT_ERROR;
   private Set<String> errorFields;
   private List<Object> rawMessages;
+  private Map<String, Object> metadata = new HashMap<>();
 
   public MetronError withMessage(String message) {
     this.message = message;
@@ -71,6 +76,10 @@ public class MetronError {
     return this;
   }
 
+  public MetronError withMetadata(Map<String, Object> metadata) {
+    this.metadata.putAll(metadata);
+    return this;
+  }
 
   public MetronError addRawMessage(Object rawMessage) {
     if (rawMessage != null) {
@@ -95,12 +104,11 @@ public class MetronError {
   public JSONObject getJSONObject() {
     JSONObject errorMessage = new JSONObject();
     errorMessage.put(Constants.GUID, UUID.randomUUID().toString());
-    errorMessage.put(Constants.SENSOR_TYPE, "error");
+    errorMessage.put(Constants.SENSOR_TYPE, Constants.ERROR_TYPE);
     if (sensorTypes.size() == 1) {
       errorMessage.put(ErrorFields.FAILED_SENSOR_TYPE.getName(), sensorTypes.iterator().next());
     } else {
-      errorMessage
-          .put(ErrorFields.FAILED_SENSOR_TYPE.getName(), new JSONArray().addAll(sensorTypes));
+      errorMessage.put(ErrorFields.FAILED_SENSOR_TYPE.getName(), new JSONArray().addAll(sensorTypes));
     }
     errorMessage.put(ErrorFields.ERROR_TYPE.getName(), errorType.getType());
 
@@ -110,6 +118,7 @@ public class MetronError {
     addHostname(errorMessage);
     addRawMessages(errorMessage);
     addErrorHash(errorMessage);
+    addMetadata(errorMessage);
 
     return errorMessage;
   }
@@ -192,44 +201,31 @@ public class MetronError {
     }
   }
 
+  private void addMetadata(JSONObject errorMessage) {
+    if(metadata != null && metadata.keySet().size() > 0) {
+      // add each metadata element directly to the message. each metadata key already has
+      // a standard prefix, no need to add another prefix to avoid collisions. this mimics
+      // the behavior of merging metadata.
+      errorMessage.putAll(metadata);
+    }
+  }
+
   @Override
   public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
+    if (this == o) return true;
+    if (!(o instanceof MetronError)) return false;
     MetronError that = (MetronError) o;
-
-    if (message != null ? !message.equals(that.message) : that.message != null) {
-      return false;
-    }
-    if (getThrowable() != null ? !getThrowable().equals(that.getThrowable())
-        : that.getThrowable() != null) {
-      return false;
-    }
-    if (sensorTypes != null ? !sensorTypes.equals(that.sensorTypes) : that.sensorTypes != null) {
-      return false;
-    }
-    if (errorType != that.errorType) {
-      return false;
-    }
-    if (errorFields != null ? !errorFields.equals(that.errorFields) : that.errorFields != null) {
-      return false;
-    }
-    return rawMessages != null ? rawMessages.equals(that.rawMessages) : that.rawMessages == null;
+    return Objects.equals(message, that.message) &&
+            Objects.equals(throwable, that.throwable) &&
+            Objects.equals(sensorTypes, that.sensorTypes) &&
+            errorType == that.errorType &&
+            Objects.equals(errorFields, that.errorFields) &&
+            Objects.equals(rawMessages, that.rawMessages) &&
+            Objects.equals(metadata, that.metadata);
   }
 
   @Override
   public int hashCode() {
-    int result = message != null ? message.hashCode() : 0;
-    result = 31 * result + (getThrowable() != null ? getThrowable().hashCode() : 0);
-    result = 31 * result + (sensorTypes != null ? sensorTypes.hashCode() : 0);
-    result = 31 * result + (errorType != null ? errorType.hashCode() : 0);
-    result = 31 * result + (errorFields != null ? errorFields.hashCode() : 0);
-    result = 31 * result + (rawMessages != null ? rawMessages.hashCode() : 0);
-    return result;
+    return Objects.hash(message, throwable, sensorTypes, errorType, errorFields, rawMessages, metadata);
   }
 }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/error/MetronError.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/error/MetronError.java
@@ -105,13 +105,8 @@ public class MetronError {
     JSONObject errorMessage = new JSONObject();
     errorMessage.put(Constants.GUID, UUID.randomUUID().toString());
     errorMessage.put(Constants.SENSOR_TYPE, Constants.ERROR_TYPE);
-    if (sensorTypes.size() == 1) {
-      errorMessage.put(ErrorFields.FAILED_SENSOR_TYPE.getName(), sensorTypes.iterator().next());
-    } else {
-      errorMessage.put(ErrorFields.FAILED_SENSOR_TYPE.getName(), new JSONArray().addAll(sensorTypes));
-    }
     errorMessage.put(ErrorFields.ERROR_TYPE.getName(), errorType.getType());
-
+    addFailedSensorType(errorMessage);
     addMessageString(errorMessage);
 		addStacktrace(errorMessage);
     addTimestamp(errorMessage);
@@ -121,6 +116,14 @@ public class MetronError {
     addMetadata(errorMessage);
 
     return errorMessage;
+  }
+
+  private void addFailedSensorType(JSONObject errorMessage) {
+    if (sensorTypes.size() == 1) {
+      errorMessage.put(ErrorFields.FAILED_SENSOR_TYPE.getName(), sensorTypes.iterator().next());
+    } else {
+      errorMessage.put(ErrorFields.FAILED_SENSOR_TYPE.getName(), new JSONArray().addAll(sensorTypes));
+    }
   }
 
   @SuppressWarnings({"unchecked"})

--- a/metron-platform/metron-parsing/metron-parsers-common/src/main/java/org/apache/metron/parsers/ParserRunnerImpl.java
+++ b/metron-platform/metron-parsing/metron-parsers-common/src/main/java/org/apache/metron/parsers/ParserRunnerImpl.java
@@ -162,6 +162,7 @@ public class ParserRunnerImpl implements ParserRunner<JSONObject>, Serializable 
                 .withErrorType(Constants.ErrorType.PARSER_ERROR)
                 .withThrowable(throwable)
                 .withSensorType(Collections.singleton(sensorType))
+                .withMetadata(rawMessage.getMetadata())
                 .addRawMessage(rawMessage.getMessage())));
 
         // If exceptions are thrown by the MessageParser, wrap them with MetronErrors and add them to the list of errors
@@ -169,6 +170,7 @@ public class ParserRunnerImpl implements ParserRunner<JSONObject>, Serializable 
                 .withErrorType(Constants.ErrorType.PARSER_ERROR)
                 .withThrowable(entry.getValue())
                 .withSensorType(Collections.singleton(sensorType))
+                .withMetadata(rawMessage.getMetadata())
                 .addRawMessage(entry.getKey())).collect(Collectors.toList()));
       }
     } else {
@@ -264,6 +266,7 @@ public class ParserRunnerImpl implements ParserRunner<JSONObject>, Serializable 
         MetronError error = new MetronError()
                 .withErrorType(Constants.ErrorType.PARSER_INVALID)
                 .withSensorType(Collections.singleton(sensorType))
+                .withMetadata(rawMessage.getMetadata())
                 .addRawMessage(message);
         Set<String> errorFields = failedValidators == null ? null : failedValidators.stream()
                 .flatMap(fieldValidator -> fieldValidator.getInput().stream())

--- a/metron-platform/metron-parsing/metron-parsers-common/src/test/java/org/apache/metron/parsers/ParserRunnerImplTest.java
+++ b/metron-platform/metron-parsing/metron-parsers-common/src/test/java/org/apache/metron/parsers/ParserRunnerImplTest.java
@@ -327,9 +327,14 @@ public class ParserRunnerImplTest {
 
   @Test
   public void shouldReturnMetronErrorOnInvalidMessage() {
+    Map<String, Object> metadata = new HashMap<>();
+    metadata.put("metron.metadata.topic", "bro");
+    metadata.put("metron.metadata.partition", 0);
+    metadata.put("metron.metadata.offset", 123);
+
     JSONObject inputMessage = new JSONObject();
     inputMessage.put("guid", "guid");
-    RawMessage rawMessage = new RawMessage("raw_message".getBytes(), new HashMap<>());
+    RawMessage rawMessage = new RawMessage("raw_message".getBytes(), metadata);
 
     JSONObject expectedOutput  = new JSONObject();
     expectedOutput.put("guid", "guid");
@@ -337,6 +342,7 @@ public class ParserRunnerImplTest {
     MetronError expectedMetronError = new MetronError()
             .withErrorType(Constants.ErrorType.PARSER_INVALID)
             .withSensorType(Collections.singleton("bro"))
+            .withMetadata(metadata)
             .addRawMessage(inputMessage);
 
     when(stellarFilter.emit(expectedOutput, parserRunner.getStellarContext())).thenReturn(true);
@@ -355,11 +361,16 @@ public class ParserRunnerImplTest {
 
   @Test
   public void shouldReturnMetronErrorOnFailedFieldValidator() {
+    Map<String, Object> metadata = new HashMap<>();
+    metadata.put("metron.metadata.topic", "bro");
+    metadata.put("metron.metadata.partition", 0);
+    metadata.put("metron.metadata.offset", 123);
+
     JSONObject inputMessage = new JSONObject();
     inputMessage.put("guid", "guid");
     inputMessage.put("ip_src_addr", "test");
     inputMessage.put("ip_dst_addr", "test");
-    RawMessage rawMessage = new RawMessage("raw_message".getBytes(), new HashMap<>());
+    RawMessage rawMessage = new RawMessage("raw_message".getBytes(), metadata);
 
     JSONObject expectedOutput  = new JSONObject();
     expectedOutput.put("guid", "guid");
@@ -370,6 +381,7 @@ public class ParserRunnerImplTest {
             .withErrorType(Constants.ErrorType.PARSER_INVALID)
             .withSensorType(Collections.singleton("bro"))
             .addRawMessage(inputMessage)
+            .withMetadata(metadata)
             .withErrorFields(new HashSet<>(Arrays.asList("ip_src_addr", "ip_dst_addr")));
 
     when(stellarFilter.emit(expectedOutput, parserRunner.getStellarContext())).thenReturn(true);


### PR DESCRIPTION
A user can choose to add metadata to each parsed message using the `readMetadata` parser option.  The error messages that are generated when a parser error occurs, do not include this metadata. This means that the metadata is lost when an error occurs. The metadata should be persisted with the error message.

For example, with this change the metadata field containing the Kafka topic will be included in the error message as a field named `metron.metadata.topic`.
```
{
  "exception": "java.lang.IllegalStateException: Unable to parse Message: \"this is an invalid synthetic message\" }",
  "stack": "java.lang.IllegalStateException: Unable to parse Message: ..",
  "raw_message": "\"this is an invalid synthetic message\" }",
  "error_hash": "3d498968e8df7f28d05db3037d4ad2a3a0095c22c14d881be45fac3f184dbcc3",
  "message": "Unable to parse Message: \"this is an invalid synthetic message\" }",
  "source.type": "error",
  "failed_sensor_type": "bro",
  "hostname": "node1",
  "error_type": "parser_error",
  "guid": "563d8d2a-1493-4758-be2f-5613bfd2d615",
  "timestamp": 1548366516634,
  "metron.metadata.topic": "bro"
}
```

## Testing

1. In Ambari, change the parser error topic to `parser_errors`.  Then restart the parsers.

1. Launch the Stellar REPL.

1. Capture metadata for Bro by setting the value of `readMetadata` to true.
    ```
    [Stellar]>>> conf := CONFIG_GET("PARSER","bro")
    {
      ...
    }
    ```

    ```
    [Stellar]>>> conf := SHELL_EDIT(conf)
    {
      ...
      "readMetadata" : true,
      ...
    }
    ```

    ```
    [Stellar]>>>
    [Stellar]>>> CONFIG_PUT("PARSER", conf, "bro")
    ```

1. Push a message into the `bro` topic which will fail to parser.

    ```
    [Stellar]>>> msg := SHELL_EDIT()
    "this is an invalid synthetic message" }
    ```
    ```
    [Stellar]>>> KAFKA_PUT("bro", msg)
    1
    ```

1. Wait for a bit until the message is processed.  When it has been processed, pull the error message off of the error topic.  The error message should contain a field `metron.metadata.topic`.

    ```
    [Stellar]>>> KAFKA_GET("parser_errors")
    [{
      "exception": "java.lang.IllegalStateException: Unable to parse Message: \"this is an invalid synthetic message\" }",
      "stack": "java.lang.IllegalStateException: Unable to parse Message: \"this is an invalid synthetic message\" }\n\tat org.apache.metron.parsers.bro.BasicBroParser.parse(BasicBroParser.java:145)\n\tat org.apache.metron.parsers.interfaces.MessageParser.parseOptional(MessageParser.java:54)\n\tat org.apache.metron.parsers.interfaces.MessageParser.parseOptionalResult(MessageParser.java:67)\n\tat org.apache.metron.parsers.ParserRunnerImpl.execute(ParserRunnerImpl.java:144)\n\tat org.apache.metron.parsers.bolt.ParserBolt.execute(ParserBolt.java:252)\n\tat org.apache.storm.daemon.executor$fn__10252$tuple_action_fn__10254.invoke(executor.clj:735)\n\tat org.apache.storm.daemon.executor$mk_task_receiver$fn__10171.invoke(executor.clj:466)\n\tat org.apache.storm.disruptor$clojure_handler$reify__9685.onEvent(disruptor.clj:40)\n\tat org.apache.storm.utils.DisruptorQueue.consumeBatchToCursor(DisruptorQueue.java:472)\n\tat org.apache.storm.utils.DisruptorQueue.consumeBatchWhenAvailable(DisruptorQueue.java:451)\n\tat org.apache.storm.disruptor$consume_batch_when_available.invoke(disruptor.clj:73)\n\tat org.apache.storm.daemon.executor$fn__10252$fn__10265$fn__10320.invoke(executor.clj:855)\n\tat org.apache.storm.util$async_loop$fn__553.invoke(util.clj:484)\n\tat clojure.lang.AFn.run(AFn.java:22)\n\tat java.lang.Thread.run(Thread.java:745)\nCaused by: Unexpected token RIGHT BRACE(}) at position 39.\n\tat org.json.simple.parser.JSONParser.parse(JSONParser.java:146)\n\tat org.json.simple.parser.JSONParser.parse(JSONParser.java:81)\n\tat org.json.simple.parser.JSONParser.parse(JSONParser.java:75)\n\tat org.apache.metron.parsers.bro.JSONCleaner.clean(JSONCleaner.java:49)\n\tat org.apache.metron.parsers.bro.BasicBroParser.parse(BasicBroParser.java:68)\n\t... 14 more\n",
      "raw_message": "\"this is an invalid synthetic message\" }",
      "error_hash": "3d498968e8df7f28d05db3037d4ad2a3a0095c22c14d881be45fac3f184dbcc3",
      "message": "Unable to parse Message: \"this is an invalid synthetic message\" }",
      "source.type": "error",
      "failed_sensor_type": "bro",
      "hostname": "node1",
      "error_type": "parser_error",
      "guid": "563d8d2a-1493-4758-be2f-5613bfd2d615",
      "timestamp": 1548366516634,
      "metron.metadata.topic": "bro"
    }]
    ```

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
