### PR TITLE
METRON-1974 Batch Profiler Should Handle Errant Profiles Better

### DIFF
--- a/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/function/GroupByPeriodFunction.java
+++ b/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/function/GroupByPeriodFunction.java
@@ -47,6 +47,8 @@ public class GroupByPeriodFunction implements MapFunction<MessageRoute, String> 
    */
   private TimeUnit periodDurationUnits;
 
+  private static final String SEPARATOR = "__";
+
   public GroupByPeriodFunction(Properties profilerProperties) {
     periodDurationUnits = TimeUnit.valueOf(PERIOD_DURATION_UNITS.get(profilerProperties, String.class));
     periodDuration = PERIOD_DURATION.get(profilerProperties, Integer.class);
@@ -55,6 +57,52 @@ public class GroupByPeriodFunction implements MapFunction<MessageRoute, String> 
   @Override
   public String call(MessageRoute route) {
     ProfilePeriod period = ProfilePeriod.fromTimestamp(route.getTimestamp(), periodDuration, periodDurationUnits);
-    return route.getProfileDefinition().getProfile() + "-" + route.getEntity() + "-" + period.getPeriod();
+    return new StringBuilder()
+            .append(route.getProfileDefinition().getProfile())
+            .append(SEPARATOR)
+            .append(route.getEntity())
+            .append(SEPARATOR)
+            .append(period.getPeriod())
+            .toString();
   }
+
+  /**
+   * @param groupKey The group key used to group {@link MessageRoute}s.
+   * @return The name of the profile.
+   */
+  public static String profileFromKey(String groupKey) {
+    String[] pieces = groupKey.split(SEPARATOR);
+    if(pieces.length == 3) {
+      return pieces[0];
+    } else {
+      return "unknown";
+    }
+  }
+
+  /**
+   * @param groupKey The group key used to group {@link MessageRoute}s.
+   * @return The name of the entity.
+   */
+  public static String entityFromKey(String groupKey) {
+    String[] pieces = groupKey.split(SEPARATOR);
+    if(pieces.length == 3) {
+      return pieces[1];
+    } else {
+      return "unknown";
+    }
+  }
+
+  /**
+   * @param groupKey The group key used to group {@link MessageRoute}s.
+   * @return The period identifier.
+   */
+  public static String periodFromKey(String groupKey) {
+    String[] pieces = groupKey.split(SEPARATOR);
+    if(pieces.length == 3) {
+      return pieces[2];
+    } else {
+      return "unknown";
+    }
+  }
+
 }

--- a/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/function/ProfileBuilderFunction.java
+++ b/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/function/ProfileBuilderFunction.java
@@ -45,6 +45,8 @@ import static org.apache.metron.profiler.spark.BatchProfilerConfig.PERIOD_DURATI
 
 import static java.lang.String.format;
 
+import static org.apache.metron.profiler.spark.function.GroupByPeriodFunction.*;
+
 /**
  * The function responsible for building profiles in Spark.
  */
@@ -100,12 +102,14 @@ public class ProfileBuilderFunction implements MapGroupsFunction<String, Message
               m.getProfileName(), m.getEntity(), m.getPeriod().getPeriod(), m.getProfileValue());
 
     } else if(measurements.size() == 0) {
-      String msg = format("No profile measurement can be calculated. Review the profile for bugs. group=%s", group);
+      String msg = format("No profile measurement can be calculated. Review the profile for bugs. profile=%s, entity=%s, period=%s",
+              profileFromKey(group), entityFromKey(group), periodFromKey(group));
       LOG.error(msg);
       throw new IllegalStateException(msg);
 
     } else {
-      String msg = format("Expected 1 profile measurement, but got %d. group=%s", measurements.size(), group);
+      String msg = format("Expected 1 profile measurement, but got %d. profile=%s, entity=%s, period=%s",
+              measurements.size(), profileFromKey(group), entityFromKey(group), periodFromKey(group));
       LOG.error(msg);
       throw new IllegalStateException(msg);
     }

--- a/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/function/ProfileBuilderFunction.java
+++ b/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/function/ProfileBuilderFunction.java
@@ -39,13 +39,13 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import static java.lang.String.format;
 import static java.util.Comparator.comparing;
 import static org.apache.metron.profiler.spark.BatchProfilerConfig.PERIOD_DURATION;
 import static org.apache.metron.profiler.spark.BatchProfilerConfig.PERIOD_DURATION_UNITS;
-
-import static java.lang.String.format;
-
-import static org.apache.metron.profiler.spark.function.GroupByPeriodFunction.*;
+import static org.apache.metron.profiler.spark.function.GroupByPeriodFunction.entityFromKey;
+import static org.apache.metron.profiler.spark.function.GroupByPeriodFunction.periodFromKey;
+import static org.apache.metron.profiler.spark.function.GroupByPeriodFunction.profileFromKey;
 
 /**
  * The function responsible for building profiles in Spark.

--- a/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/BatchProfilerIntegrationTest.java
+++ b/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/BatchProfilerIntegrationTest.java
@@ -20,7 +20,6 @@
 package org.apache.metron.profiler.spark;
 
 import org.adrianwalker.multilinestring.Multiline;
-import org.apache.metron.common.configuration.profiler.ProfilerConfig;
 import org.apache.metron.hbase.mock.MockHBaseTableProvider;
 import org.apache.metron.profiler.client.stellar.FixedLookback;
 import org.apache.metron.profiler.client.stellar.GetProfile;
@@ -30,6 +29,7 @@ import org.apache.metron.stellar.common.StellarStatefulExecutor;
 import org.apache.metron.stellar.dsl.Context;
 import org.apache.metron.stellar.dsl.functions.resolver.SimpleFunctionResolver;
 import org.apache.spark.SparkConf;
+import org.apache.spark.SparkException;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.SparkSession;
 import org.junit.AfterClass;
@@ -40,14 +40,15 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import sun.plugin.dom.exception.InvalidStateException;
 
-import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.apache.metron.common.configuration.profiler.ProfilerConfig.fromJSON;
 import static org.apache.metron.profiler.client.stellar.ProfilerClientConfig.PROFILER_COLUMN_FAMILY;
 import static org.apache.metron.profiler.client.stellar.ProfilerClientConfig.PROFILER_HBASE_TABLE;
 import static org.apache.metron.profiler.client.stellar.ProfilerClientConfig.PROFILER_HBASE_TABLE_PROVIDER;
@@ -59,9 +60,10 @@ import static org.apache.metron.profiler.spark.BatchProfilerConfig.TELEMETRY_INP
 import static org.apache.metron.profiler.spark.BatchProfilerConfig.TELEMETRY_INPUT_FORMAT;
 import static org.apache.metron.profiler.spark.BatchProfilerConfig.TELEMETRY_INPUT_PATH;
 import static org.apache.metron.profiler.spark.BatchProfilerConfig.TELEMETRY_INPUT_READER;
+import static org.apache.metron.profiler.spark.reader.TelemetryReaders.JSON;
+import static org.apache.metron.profiler.spark.reader.TelemetryReaders.ORC;
+import static org.apache.metron.profiler.spark.reader.TelemetryReaders.PARQUET;
 import static org.junit.Assert.assertTrue;
-
-import static org.apache.metron.profiler.spark.reader.TelemetryReaders.*;
 
 /**
  * An integration test for the {@link BatchProfiler}.
@@ -166,7 +168,7 @@ public class BatchProfilerIntegrationTest {
     profilerProperties.put(TELEMETRY_INPUT_PATH.getKey(), "src/test/resources/telemetry.json");
 
     BatchProfiler profiler = new BatchProfiler();
-    profiler.run(spark, profilerProperties, getGlobals(), readerProperties, getProfile());
+    profiler.run(spark, profilerProperties, getGlobals(), readerProperties, fromJSON(profileJson));
 
     validateProfiles();
   }
@@ -188,7 +190,7 @@ public class BatchProfilerIntegrationTest {
     profilerProperties.put(TELEMETRY_INPUT_PATH.getKey(), pathToORC);
 
     BatchProfiler profiler = new BatchProfiler();
-    profiler.run(spark, profilerProperties, getGlobals(), readerProperties, getProfile());
+    profiler.run(spark, profilerProperties, getGlobals(), readerProperties, fromJSON(profileJson));
 
     validateProfiles();
   }
@@ -210,7 +212,7 @@ public class BatchProfilerIntegrationTest {
     profilerProperties.put(TELEMETRY_INPUT_PATH.getKey(), inputPath);
 
     BatchProfiler profiler = new BatchProfiler();
-    profiler.run(spark, profilerProperties, getGlobals(), readerProperties, getProfile());
+    profiler.run(spark, profilerProperties, getGlobals(), readerProperties, fromJSON(profileJson));
 
     validateProfiles();
   }
@@ -239,7 +241,7 @@ public class BatchProfilerIntegrationTest {
     readerProperties.put("header", "true");
 
     BatchProfiler profiler = new BatchProfiler();
-    profiler.run(spark, profilerProperties, getGlobals(), readerProperties, getProfile());
+    profiler.run(spark, profilerProperties, getGlobals(), readerProperties, fromJSON(profileJson));
 
     validateProfiles();
   }
@@ -255,7 +257,7 @@ public class BatchProfilerIntegrationTest {
     profilerProperties.put(TELEMETRY_INPUT_END.getKey(), "2018-07-07T15:51:48Z");
 
     BatchProfiler profiler = new BatchProfiler();
-    profiler.run(spark, profilerProperties, getGlobals(), readerProperties, getProfile());
+    profiler.run(spark, profilerProperties, getGlobals(), readerProperties, fromJSON(profileJson));
 
     // the max timestamp in the data is around July 7, 2018
     assign("maxTimestamp", "1530978728982L");
@@ -279,7 +281,7 @@ public class BatchProfilerIntegrationTest {
     profilerProperties.put(TELEMETRY_INPUT_END.getKey(), "");
 
     BatchProfiler profiler = new BatchProfiler();
-    profiler.run(spark, profilerProperties, getGlobals(), readerProperties, getProfile());
+    profiler.run(spark, profilerProperties, getGlobals(), readerProperties, fromJSON(profileJson));
 
     // the max timestamp in the data is around July 7, 2018
     assign("maxTimestamp", "1530978728982L");
@@ -290,6 +292,40 @@ public class BatchProfilerIntegrationTest {
     assertTrue(execute("[14] == PROFILE_GET('count-by-ip', '192.168.66.1', window)", Boolean.class));
     assertTrue(execute("[46] == PROFILE_GET('count-by-ip', '192.168.138.158', window)", Boolean.class));
     assertTrue(execute("[60] == PROFILE_GET('total-count', 'total', window)", Boolean.class));
+  }
+
+  /**
+   * {
+   *   "timestampField": "timestamp",
+   *   "profiles": [
+   *      {
+   *        "profile": "count-by-ip",
+   *        "foreach": "ip_src_addr",
+   *        "init": { "count": 0 },
+   *        "update": { "count" : "count + 1" },
+   *        "result": "count"
+   *      },
+   *      {
+   *        "profile": "invalid-profile",
+   *        "foreach": "'total'",
+   *        "init": { "count": 0 },
+   *        "update": { "count": "count + 1" },
+   *        "result": "INVALID_FUNCTION(count)"
+   *      }
+   *   ]
+   * }
+   */
+  @Multiline
+  private static String invalidProfileJson;
+
+  @Test(expected = SparkException.class)
+  public void testBatchProfilerWithInvalidProfile() throws Exception {
+    profilerProperties.put(TELEMETRY_INPUT_READER.getKey(), JSON.toString());
+    profilerProperties.put(TELEMETRY_INPUT_PATH.getKey(), "src/test/resources/telemetry.json");
+
+    // the batch profiler should error out, if there is a bug in *any* of the profiles
+    BatchProfiler profiler = new BatchProfiler();
+    profiler.run(spark, profilerProperties, getGlobals(), readerProperties, fromJSON(invalidProfileJson));
   }
 
   /**
@@ -314,10 +350,6 @@ public class BatchProfilerIntegrationTest {
 
     // there are 100 messages in all
     assertTrue(execute("[100] == PROFILE_GET('total-count', 'total', window)", Boolean.class));
-  }
-
-  private ProfilerConfig getProfile() throws IOException {
-    return ProfilerConfig.fromJSON(profileJson);
   }
 
   private Properties getGlobals() {

--- a/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/BatchProfilerIntegrationTest.java
+++ b/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/BatchProfilerIntegrationTest.java
@@ -40,7 +40,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.plugin.dom.exception.InvalidStateException;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Collections;

--- a/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/function/GroupByPeriodFunctionTest.java
+++ b/metron-analytics/metron-profiler-spark/src/test/java/org/apache/metron/profiler/spark/function/GroupByPeriodFunctionTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.metron.profiler.spark.function;
+
+import org.adrianwalker.multilinestring.Multiline;
+import org.apache.metron.common.configuration.profiler.ProfileConfig;
+import org.apache.metron.profiler.MessageRoute;
+import org.apache.metron.profiler.ProfilePeriod;
+import org.json.simple.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+public class GroupByPeriodFunctionTest {
+
+  /**
+   * {
+   *    "profile": "my-profile-name",
+   *    "foreach": "'total'",
+   *    "init": { "count": 0 },
+   *    "update": { "count": "count + 1" },
+   *    "result": "count"
+   * }
+   */
+  @Multiline
+  private String profileJSON;
+
+  @Test
+  public void shouldDecodeGroupKey() throws Exception {
+    final ProfileConfig profile = ProfileConfig.fromJSON(profileJSON);
+    final Long timestamp = System.currentTimeMillis();
+    final String entity = "192.168.1.1";
+    final JSONObject message = new JSONObject();
+    final String periodId = new Long(ProfilePeriod.fromTimestamp(timestamp, 15, TimeUnit.MINUTES).getPeriod()).toString();
+
+    MessageRoute route = new MessageRoute(profile, entity, message, timestamp);
+    String groupKey = new GroupByPeriodFunction(new Properties()).call(route);
+
+    // should be able to extract the profile, entity and period from the group key
+    Assert.assertEquals("my-profile-name", GroupByPeriodFunction.profileFromKey(groupKey));
+    Assert.assertEquals(entity, GroupByPeriodFunction.entityFromKey(groupKey));
+    Assert.assertEquals(periodId, GroupByPeriodFunction.periodFromKey(groupKey));
+  }
+
+}


### PR DESCRIPTION
If the Batch Profiler is used to run a profile with invalid or errant logic, the following exception is thrown. This does not indicate to the user what the underlying root cause of the problem is.

```
19/01/28 19:11:28 ERROR TaskSetManager: Task 7 in stage 5.0 failed 4 times; aborting job
Exception in thread "main" org.apache.spark.SparkException: Job aborted due to stage failure: Task 7 in stage 5.0 failed 4 times, most recent failure: Lost task 7.3 in stage 5.0 (TID 12, nat-r7-dwys-metron-3.openstacklocal, executor 2): java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
at java.util.ArrayList.rangeCheck(ArrayList.java:657)
at java.util.ArrayList.get(ArrayList.java:433)
at org.apache.metron.profiler.spark.function.ProfileBuilderFunction.call(ProfileBuilderFunction.java:97)
at org.apache.metron.profiler.spark.function.ProfileBuilderFunction.call(ProfileBuilderFunction.java:49)
at org.apache.spark.sql.KeyValueGroupedDataset$$anonfun$mapGroups$1.apply(KeyValueGroupedDataset.scala:219)
at org.apache.spark.sql.KeyValueGroupedDataset$$anonfun$mapGroups$1.apply(KeyValueGroupedDataset.scala:219)
at org.apache.spark.sql.KeyValueGroupedDataset$$anonfun$1.apply(KeyValueGroupedDataset.scala:196)
...
```

This makes it difficult for a user to understand that the problem is due to their profile definition, rather than a bug in the Profiler itself. With this change, the exception is more clear.  

```
Caused by: java.lang.IllegalStateException: Unknown function: `INVALID_FUNCTION`
	at org.apache.metron.stellar.dsl.functions.resolver.BaseFunctionResolver.apply(BaseFunctionResolver.java:150)
	at org.apache.metron.stellar.dsl.functions.resolver.BaseFunctionResolver.apply(BaseFunctionResolver.java:48)
	at org.apache.metron.stellar.common.StellarCompiler.resolveFunction(StellarCompiler.java:691)
	... 52 more
2019-01-28 16:15:20 DEBUG DefaultProfileBuilder:212 - Flushed profile: profile=invalid-profile, entity=total, maxTime=1530978728982, period=1701087, start=1530978300000, end=1530979200000, duration=900000
2019-01-28 16:15:20 ERROR ProfileBuilderFunction:104 - No profile measurement can be calculated. Review the profile for bugs. profile=my-invalid-profile, entity=total, period=1701087
2019-01-28 16:15:20 ERROR Executor:91 - Exception in task 7.0 in stage 5.0 (TID 12)
java.lang.IllegalStateException: No profile measurement can be calculated. Review the profile for bugs. profile=my-invalid-profile, entity=192.168.1.21, period=1701087
	at org.apache.metron.profiler.spark.function.ProfileBuilderFunction.call(ProfileBuilderFunction.java:105)
	at org.apache.metron.profiler.spark.function.ProfileBuilderFunction.call(ProfileBuilderFunction.java:51)
	at org.apache.spark.sql.KeyValueGroupedDataset$$anonfun$mapGroups$1.apply(KeyValueGroupedDataset.scala:219)
...
```

More specifically, the following phrase should help the user to better understand that the problem is with the profile definition.  The message includes the profile, entity, and period ID which can help a user replicate/debug the problem in the REPL.
```
No profile measurement can be calculated. Review the profile for bugs. 
profile=my-invalid-profile, entity=192.168.1.21, period=1701087
```

The root cause  is that the Batch Profiler was not correctly handling the case where a `ProfileBuilder` returns no `ProfileMeasurement` values, which can occur if the profile definition is errant.

## Testing

Create an invalid profile definition like the following and run it through the Batch Profiler.  
```
    {
      "timestampField": "timestamp",
      "profiles": [
         {
           "profile": "count-by-ip",
           "foreach": "ip_src_addr",
           "init": { "count": 0 },
           "update": { "count" : "count + 1" },
           "result": "count"
         },
         {
           "profile": "my-invalid-profile",
           "foreach": "'total'",
           "init": { "count": 0 },
           "update": { "count": "count + 1" },
           "result": "INVALID_FUNCTION(count)"
         }
      ]
    }
```

## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
