### PR TITLE
METRON-1986 Batch Profiler Fails to Resolve Stats Stellar Functions

### DIFF
--- a/metron-analytics/metron-profiler-spark/pom.xml
+++ b/metron-analytics/metron-profiler-spark/pom.xml
@@ -52,13 +52,17 @@
             <groupId>org.apache.metron</groupId>
             <artifactId>metron-profiler-client</artifactId>
             <version>${project.parent.version}</version>
-            <scope>test</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.antlr</groupId>
                     <artifactId>antlr4-runtime</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.metron</groupId>
+            <artifactId>stellar-common</artifactId>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.metron</groupId>
@@ -182,8 +186,7 @@
                                 </excludes>
                             </artifactSet>
                             <transformers>
-                                <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>.yaml</resource>
                                         <resource>LICENSE.txt</resource>
@@ -191,16 +194,36 @@
                                         <resource>NOTICE.txt</resource>
                                     </resources>
                                 </transformer>
-                                <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                                <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass></mainClass>
                                 </transformer>
+                                <!--
+                                    The ClassIndex library is used to create an index of all Stellar functions at
+                                    compile-time. This index is packaged in the JAR as
+                                    `META-INF/annotations/org.apache.metron.stellar.dsl.Stellar`.
+
+                                    When creating a shaded jar using the Maven Shade Plugin, the index files created by
+                                    ClassIndex are overwritten by default. ClassIndex provides a special transformer for
+                                    Maven which merges the index files instead of overwriting them.
+
+                                    Without using this transformer, the index files are overwritten and Stellar function
+                                    resolution will not work.
+
+                                    https://github.com/atteo/classindex#making-shaded-jar
+                                    -->
+                                <transformer implementation="org.atteo.classindex.ClassIndexTransformer"/>
                             </transformers>
                         </configuration>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.atteo.classindex</groupId>
+                        <artifactId>classindex-transformer</artifactId>
+                        <version>${global_classindex_version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
The Batch Profiler does not seem to see the STATS_* functions. When I attempt to run a profile using any of those functions, it fails. It is able to 'see' a limited subset of functions, but not all those that I would expect.

## Root Cause

The ClassIndex library is used to create an index of all Stellar functions at compile-time. This index is packaged in the JAR as `META-INF/annotations/org.apache.metron.stellar.dsl.Stellar`.

When creating a shaded jar using the Maven Shade Plugin, the index files created by ClassIndex are overwritten by default. ClassIndex provides a special transformer for Maven which merges the index files instead of overwriting them.

Without using this transformer, the index files are overwritten and Stellar function resolution will not work. This is why Stellar function resolution is not working.

https://github.com/atteo/classindex#making-shaded-jar

## Testing

1. Spin-up this profile in the Batch Profiler.  It should write successfully to HBase.

```
{
  "profiles": [
    {
      "profile": "profile-using-stats",
      "foreach": "ip_src_addr",
      "update": { "s": "STATS_ADD(s, length)" },
      "result": "STATS_SUM(s)"
    }
  ],
  "timestampField":"timestamp"
}
```


## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
