### PR TITLE
METRON-1996 : Index search using group for Solr throws NPE if the group parameter is null

### DIFF
--- a/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/dao/SolrSearchDao.java
+++ b/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/dao/SolrSearchDao.java
@@ -105,6 +105,9 @@ public class SolrSearchDao implements SearchDao {
   @Override
   public GroupResponse group(GroupRequest groupRequest) throws InvalidSearchException {
     try {
+      if (groupRequest.getGroups() == null || groupRequest.getGroups().size() == 0) {
+        throw new InvalidSearchException("At least 1 group must be provided.");
+      }
       String groupNames = groupRequest.getGroups().stream().map(Group::getField).collect(
           Collectors.joining(","));
       SolrQuery query = new SolrQuery()

--- a/metron-platform/metron-solr/src/test/java/org/apache/metron/solr/dao/SolrSearchDaoTest.java
+++ b/metron-platform/metron-solr/src/test/java/org/apache/metron/solr/dao/SolrSearchDaoTest.java
@@ -136,6 +136,42 @@ public class SolrSearchDaoTest {
   }
 
   @Test
+  public void searchShouldThrowInvalidSearchExceptionOnNullGroup() throws Exception {
+    exception.expect(InvalidSearchException.class);
+    exception.expectMessage("At least 1 group must be provided.");
+
+    GroupRequest groupRequest = mock(GroupRequest.class);
+    GroupResponse groupResponse = mock(GroupResponse.class);
+
+    solrSearchDao = spy(new SolrSearchDao(client, accessConfig));
+    when(groupRequest.getQuery()).thenReturn("query");
+    when(groupRequest.getGroups()).thenReturn(null);
+    when(groupRequest.getScoreField()).thenReturn(Optional.of("scoreField"));
+    when(groupRequest.getIndices()).thenReturn(Arrays.asList("bro", "snort"));
+
+    assertEquals(groupResponse, solrSearchDao.group(groupRequest));
+    verifyNoMoreInteractions(client);
+  }
+
+  @Test
+  public void searchShouldThrowInvalidSearchExceptionOnEmptyGroup() throws Exception {
+    exception.expect(InvalidSearchException.class);
+    exception.expectMessage("At least 1 group must be provided.");
+
+    GroupRequest groupRequest = mock(GroupRequest.class);
+    GroupResponse groupResponse = mock(GroupResponse.class);
+
+    solrSearchDao = spy(new SolrSearchDao(client, accessConfig));
+    when(groupRequest.getQuery()).thenReturn("query");
+    when(groupRequest.getGroups()).thenReturn(Collections.EMPTY_LIST);
+    when(groupRequest.getScoreField()).thenReturn(Optional.of("scoreField"));
+    when(groupRequest.getIndices()).thenReturn(Arrays.asList("bro", "snort"));
+
+    assertEquals(groupResponse, solrSearchDao.group(groupRequest));
+    verifyNoMoreInteractions(client);
+  }
+
+  @Test
   public void searchShouldThrowSearchResultSizeException() throws Exception {
     exception.expect(InvalidSearchException.class);
     exception.expectMessage("Search result size must be less than 100");


### PR DESCRIPTION
## Contributor Comments
Index search using group for Solr throws NPE if the group parameter is null, also returns no content message if the group list is empty.

### Testing instructions 
1. spin-up a development cluster 
2. login to the swagger http://node1:8082/swagger-ui.html/
3. got to http://node1:8082/swagger-ui.html#/search-controller
4. Try out group search /api/v1/search/group with below payload

`{
	"scoreField": "threat:triage:score",
	"query": "*",
	"indices": ["bro", "snort"],
	"groups": null
}`

You will see the below unhandled exception, also there will be NPE logs in metron-rest 

`{
  "timestamp": "2019-02-13 10:57:04",
  "status": 500,
  "error": "Internal Server Error",
  "message": "No message available",
  "path": "/api/v1/search/group"
}`

5. If you do the same steps after this fix you will see below exception message 

`{
	"responseCode": 500,
	"message": "At least 1 group must be provided.",
	"fullMessage": "InvalidSearchException: At least 1 group must be provided."
}`

## Pull Request Checklist
Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [ ] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
