### PR TITLE
METRON-2005: Batch Writer writes 0-byte files to HDFS on rotation

### DIFF
--- a/metron-platform/metron-writer/README.md
+++ b/metron-platform/metron-writer/README.md
@@ -65,6 +65,9 @@ To manage the output path, a base path argument is provided by the Flux file, wi
 This means that all output will land in `/apps/metron/`.  With no further adjustment, it will be `/apps/metron/<sensor>/`.
 However, by modifying the sensor's JSON config, it is possible to provide additional pathing based on the the message itself.
 
+The output format of a file will be `{prefix}{componentId}-{taskId}-{rotationNum}-{timestamp}{extension}`. Notably, because of the way
+file rotations are handled by the HdfsWriter, `rotationNum` will always be 0, but RotationActions still get executed normally.
+
 E.g.
 ```
 {

--- a/metron-platform/metron-writer/pom.xml
+++ b/metron-platform/metron-writer/pom.xml
@@ -213,6 +213,11 @@
             <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.metron</groupId>
+            <artifactId>stellar-common</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/ClonedSyncPolicyCreator.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/ClonedSyncPolicyCreator.java
@@ -37,6 +37,7 @@ public class ClonedSyncPolicyCreator implements SyncPolicyCreator {
       // SyncPolicy object does not implement Cloneable, so we'll need to clone it via serialization
       //to get a fresh policy object.  Note: this would be expensive if it was in the critical path,
       // but should be called infrequently (once per sync).
+
       // Reset the SyncPolicy to ensure that the new count properly resets.
       syncPolicy.reset();
       byte[] serializedForm = SerDeUtils.toBytes(syncPolicy);

--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/ClonedSyncPolicyCreator.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/ClonedSyncPolicyCreator.java
@@ -37,6 +37,8 @@ public class ClonedSyncPolicyCreator implements SyncPolicyCreator {
       // SyncPolicy object does not implement Cloneable, so we'll need to clone it via serialization
       //to get a fresh policy object.  Note: this would be expensive if it was in the critical path,
       // but should be called infrequently (once per sync).
+      // Reset the SyncPolicy to ensure that the new count properly resets.
+      syncPolicy.reset();
       byte[] serializedForm = SerDeUtils.toBytes(syncPolicy);
       return SerDeUtils.fromBytes(serializedForm, SyncPolicy.class);
     }

--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/HdfsWriter.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/HdfsWriter.java
@@ -17,29 +17,37 @@
  */
 package org.apache.metron.writer.hdfs;
 
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.apache.metron.common.configuration.IndexingConfigurations;
+import org.apache.metron.common.configuration.writer.WriterConfiguration;
+import org.apache.metron.common.writer.BulkMessageWriter;
+import org.apache.metron.common.writer.BulkWriterResponse;
+import org.apache.metron.stellar.common.StellarProcessor;
 import org.apache.metron.stellar.dsl.Context;
 import org.apache.metron.stellar.dsl.MapVariableResolver;
 import org.apache.metron.stellar.dsl.StellarFunctions;
 import org.apache.metron.stellar.dsl.VariableResolver;
-import org.apache.metron.stellar.common.StellarProcessor;
-import org.apache.storm.task.TopologyContext;
-import org.apache.storm.tuple.Tuple;
-import org.apache.metron.common.configuration.writer.WriterConfiguration;
-import org.apache.metron.common.writer.BulkMessageWriter;
-import org.apache.metron.common.writer.BulkWriterResponse;
 import org.apache.storm.hdfs.bolt.format.FileNameFormat;
 import org.apache.storm.hdfs.bolt.rotation.FileRotationPolicy;
 import org.apache.storm.hdfs.bolt.rotation.NoRotationPolicy;
 import org.apache.storm.hdfs.bolt.sync.CountSyncPolicy;
 import org.apache.storm.hdfs.bolt.sync.SyncPolicy;
 import org.apache.storm.hdfs.common.rotation.RotationAction;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.tuple.Tuple;
 import org.json.simple.JSONObject;
-
-import java.io.*;
-import java.util.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class HdfsWriter implements BulkMessageWriter<JSONObject>, Serializable {
+  private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
   List<RotationAction> rotationActions = new ArrayList<>();
   FileRotationPolicy rotationPolicy = new NoRotationPolicy();
   SyncPolicy syncPolicy;
@@ -82,10 +90,12 @@ public class HdfsWriter implements BulkMessageWriter<JSONObject>, Serializable {
     this.fileNameFormat.prepare(stormConfig,topologyContext);
     if(syncPolicy != null) {
       //if the user has specified the sync policy, we don't want to override their wishes.
+      LOG.debug("Using user specified sync policy {}", syncPolicy.getClass().getSimpleName());
       syncPolicyCreator = new ClonedSyncPolicyCreator(syncPolicy);
     }
     else {
       //if the user has not, then we want to have the sync policy depend on the batch size.
+      LOG.debug("No user specified sync policy, using CountSyncPolicy based on batch size");
       syncPolicyCreator = (source, config) -> new CountSyncPolicy(config == null?1:config.getBatchSize(source));
     }
   }
@@ -109,10 +119,12 @@ public class HdfsWriter implements BulkMessageWriter<JSONObject>, Serializable {
                 (String)configurations.getSensorConfig(sourceType).getOrDefault(IndexingConfigurations.OUTPUT_PATH_FUNCTION_CONF, ""),
                 message
         );
+        LOG.trace("Writing message {} to path: {}", message.toJSONString(), path);
         SourceHandler handler = getSourceHandler(sourceType, path, configurations);
         handler.handle(message, sourceType, configurations, syncPolicyCreator);
       }
     } catch (Exception e) {
+      LOG.error("HdfsWriter encountered error writing", e);
       response.addAllErrors(e, tuples);
     }
 
@@ -123,6 +135,7 @@ public class HdfsWriter implements BulkMessageWriter<JSONObject>, Serializable {
   public String getHdfsPathExtension(String sourceType, String stellarFunction, JSONObject message) {
     // If no function is provided, just use the sourceType directly
     if(stellarFunction == null || stellarFunction.trim().isEmpty()) {
+      LOG.debug("No HDFS path extension provided; using source type {} directly", sourceType);
       return sourceType;
     }
 
@@ -130,7 +143,9 @@ public class HdfsWriter implements BulkMessageWriter<JSONObject>, Serializable {
     VariableResolver resolver = new MapVariableResolver(message);
     Object objResult = stellarProcessor.parse(stellarFunction, resolver, StellarFunctions.FUNCTION_RESOLVER(), Context.EMPTY_CONTEXT());
     if(objResult != null && !(objResult instanceof String)) {
-      throw new IllegalArgumentException("Stellar Function <" + stellarFunction + "> did not return a String value. Returned: " + objResult);
+      String errorMsg = "Stellar Function <" + stellarFunction + "> did not return a String value. Returned: " + objResult;
+      LOG.error(errorMsg);
+      throw new IllegalArgumentException(errorMsg);
     }
     return objResult == null ? "" : (String)objResult;
   }
@@ -143,6 +158,7 @@ public class HdfsWriter implements BulkMessageWriter<JSONObject>, Serializable {
   @Override
   public void close() {
     for(SourceHandler handler : sourceHandlerMap.values()) {
+      LOG.debug("Closing SourceHandler {}", handler.toString());
       handler.close();
     }
     // Everything is closed, so just clear it
@@ -154,13 +170,16 @@ public class HdfsWriter implements BulkMessageWriter<JSONObject>, Serializable {
     SourceHandler ret = sourceHandlerMap.get(key);
     if(ret == null) {
       if(sourceHandlerMap.size() >= maxOpenFiles) {
-        throw new IllegalStateException("Too many HDFS files open!");
+        String errorMsg = "Too many HDFS files open! Maximum number of open files is: " + maxOpenFiles;
+        LOG.error(errorMsg);
+        throw new IllegalStateException(errorMsg);
       }
       ret = new SourceHandler(rotationActions,
                               rotationPolicy,
                               syncPolicyCreator.create(sourceType, config),
                               new PathExtensionFileNameFormat(key.getStellarResult(), fileNameFormat),
                               new SourceHandlerCallback(sourceHandlerMap, key));
+      LOG.debug("Placing key in sourceHandlerMap: {}", key);
       sourceHandlerMap.put(key, ret);
     }
     return ret;

--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/SourceHandler.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/SourceHandler.java
@@ -152,6 +152,9 @@ public class SourceHandler {
   }
 
   private Path createOutputFile() throws IOException {
+    // The rotation is set to 0. With the way open files are tracked and managed with the callback, there will
+    // never be data that would go into a rotation > 0. Instead a new SourceHandler, and by extension file, will
+    // be created.
     Path path = new Path(this.fileNameFormat.getPath(), this.fileNameFormat.getName(0, System.currentTimeMillis()));
     LOG.debug("Creating new output file: {}", path.getName());
     if(fs.getScheme().equals("file")) {

--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/SourceHandler.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/SourceHandler.java
@@ -177,7 +177,9 @@ public class SourceHandler {
   public void close() {
     try {
       closeOutputFile();
-      rotationTimer.cancel();
+      if(rotationTimer != null) {
+        rotationTimer.cancel();
+      }
       // Don't call cleanup, to avoid HashMap's ConcurrentModificationException while iterating
     } catch (IOException e) {
       throw new RuntimeException("Unable to close output file.", e);

--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/SourceHandler.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/SourceHandler.java
@@ -49,7 +49,6 @@ public class SourceHandler {
   FileNameFormat fileNameFormat;
   SourceHandlerCallback cleanupCallback;
   private long offset = 0;
-  private int rotation = 0;
   private transient FSDataOutputStream out;
   private transient final Object writeLock = new Object();
   protected transient Timer rotationTimer; // only used for TimedRotationPolicy
@@ -153,7 +152,7 @@ public class SourceHandler {
   }
 
   private Path createOutputFile() throws IOException {
-    Path path = new Path(this.fileNameFormat.getPath(), this.fileNameFormat.getName(this.rotation, System.currentTimeMillis()));
+    Path path = new Path(this.fileNameFormat.getPath(), this.fileNameFormat.getName(0, System.currentTimeMillis()));
     LOG.debug("Creating new output file: {}", path.getName());
     if(fs.getScheme().equals("file")) {
       //in the situation where we're running this in a local filesystem, flushing doesn't work.
@@ -194,7 +193,6 @@ public class SourceHandler {
             ", syncPolicy=" + syncPolicy +
             ", fileNameFormat=" + fileNameFormat +
             ", offset=" + offset +
-            ", rotation=" + rotation +
             ", out=" + out +
             ", writeLock=" + writeLock +
             ", rotationTimer=" + rotationTimer +

--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/SourceHandler.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/SourceHandler.java
@@ -43,7 +43,6 @@ import org.slf4j.LoggerFactory;
 
 public class SourceHandler {
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
   List<RotationAction> rotationActions = new ArrayList<>();
   FileRotationPolicy rotationPolicy;
   SyncPolicy syncPolicy;
@@ -89,9 +88,7 @@ public class SourceHandler {
       }
       this.offset += bytes.length;
 
-      LOG.debug("Checking if hsync necessary");
       if (this.syncPolicy.mark(null, this.offset)) {
-        LOG.debug("Calling hsync on {}", this.out.getClass().getSimpleName());
         if (this.out instanceof HdfsDataOutputStream) {
           ((HdfsDataOutputStream) this.out)
               .hsync(EnumSet.of(HdfsDataOutputStream.SyncFlag.UPDATE_LENGTH));
@@ -100,17 +97,14 @@ public class SourceHandler {
         }
         //recreate the sync policy for the next batch just in case something changed in the config
         //and the sync policy depends on the config.
-        LOG.debug("Recreating sync policy for next batch");
         this.syncPolicy = syncPolicyCreator.create(sensor, config);
       }
     }
 
-    LOG.debug("checking for rotation");
     if (this.rotationPolicy.mark(null, this.offset)) {
-      LOG.debug("Rotating output File from handle()");
       rotateOutputFile(); // synchronized
-//      this.offset = 0;
-//      this.rotationPolicy.reset();
+      this.offset = 0;
+      this.rotationPolicy.reset();
     }
   }
 
@@ -118,21 +112,18 @@ public class SourceHandler {
     this.fs = FileSystem.get(new Configuration());
     this.currentFile = createOutputFile();
     if(this.rotationPolicy instanceof TimedRotationPolicy){
-      LOG.debug("Creating timer task");
       long interval = ((TimedRotationPolicy)this.rotationPolicy).getInterval();
       this.rotationTimer = new Timer(true);
       TimerTask task = new TimerTask() {
         @Override
         public void run() {
           try {
-            LOG.debug("Rotating output file from TimerTask");
             rotateOutputFile();
           } catch(IOException e){
             LOG.warn("IOException during scheduled file rotation.", e);
           }
         }
       };
-      LOG.debug("Scheduling TimerTask at interval {}", interval);
       this.rotationTimer.scheduleAtFixedRate(task, interval, interval);
     }
   }
@@ -152,8 +143,6 @@ public class SourceHandler {
         action.execute(this.fs, this.currentFile);
       }
       this.currentFile = newFile;
-      this.offset = 0;
-      this.rotationPolicy.reset();
     }
     long time = System.currentTimeMillis() - start;
     LOG.info("File rotation took {} ms", time);
@@ -161,27 +150,22 @@ public class SourceHandler {
 
   private Path createOutputFile() throws IOException {
     Path path = new Path(this.fileNameFormat.getPath(), this.fileNameFormat.getName(this.rotation, System.currentTimeMillis()));
-    LOG.debug("Creating new output file {}", path);
     if(fs.getScheme().equals("file")) {
-      LOG.debug("Running on local file system");
       //in the situation where we're running this in a local filesystem, flushing doesn't work.
       fs.mkdirs(path.getParent());
       this.out = new FSDataOutputStream(new FileOutputStream(path.toString()), null);
     }
     else {
-      LOG.debug("Running on remote file system");
       this.out = this.fs.create(path);
     }
     return path;
   }
 
   protected void closeOutputFile() throws IOException {
-    LOG.debug("Closing output file");
     this.out.close();
   }
 
   private void cleanupCallback() {
-    LOG.debug("Performing cleanupCallback");
     this.cleanupCallback.removeKey();
   }
 

--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/SourceHandler.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/SourceHandler.java
@@ -111,7 +111,7 @@ public class SourceHandler {
   }
 
   private void initialize() throws IOException {
-    LOG.info("Initializing Source Handler");
+    LOG.debug("Initializing Source Handler");
     this.fs = FileSystem.get(new Configuration());
     this.currentFile = createOutputFile();
     LOG.debug("Source Handler initialized with starting file: {}", currentFile);
@@ -135,14 +135,14 @@ public class SourceHandler {
 
   // Closes the output file, but ensures any RotationActions are performed.
   protected void rotateOutputFile() throws IOException {
-    LOG.info("Rotating output file...");
+    LOG.debug("Rotating output file...");
     long start = System.currentTimeMillis();
     synchronized (this.writeLock) {
       closeOutputFile();
       // Want to use the callback to make sure we have an accurate count of open files.
       cleanupCallback();
 
-      LOG.info("Performing {} file rotation actions.", this.rotationActions.size());
+      LOG.debug("Performing {} file rotation actions.", this.rotationActions.size());
       for (RotationAction action : this.rotationActions) {
         action.execute(this.fs, this.currentFile);
       }

--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/SourceHandlerCallback.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/SourceHandlerCallback.java
@@ -35,6 +35,7 @@ public class SourceHandlerCallback {
 
   public void removeKey() {
     SourceHandler removed = sourceHandlerMap.remove(key);
+    removed.close(); // If it's getting removed, we want to close it to ensure things like Timers are ended.
     LOG.debug("Removed {} -> {}", key, removed);
     LOG.debug("Current state of sourceHandlerMap: {}", sourceHandlerMap);
   }

--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/SourceHandlerCallback.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/SourceHandlerCallback.java
@@ -23,6 +23,10 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Callback intended to be able to manage open files in {@link HdfsWriter}. This callback will close
+ * the associated {@link SourceHandler} and remove it from the map of open files.
+ */
 public class SourceHandlerCallback {
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
@@ -33,11 +37,20 @@ public class SourceHandlerCallback {
     this.key = key;
   }
 
+  /**
+   * Removes {@link SourceHandler} from the map of open files. Also closes it to ensure resources such as
+   * {@link java.util.Timer} is closed.
+   */
   public void removeKey() {
     SourceHandler removed = sourceHandlerMap.remove(key);
-    removed.close(); // If it's getting removed, we want to close it to ensure things like Timers are ended.
-    LOG.debug("Removed {} -> {}", key, removed);
-    LOG.debug("Current state of sourceHandlerMap: {}", sourceHandlerMap);
+    if(removed != null) {
+      removed.close();
+    }
+    LOG.debug("Removed {} -> {}. Current state of sourceHandlerMap: {}",
+        key,
+        removed,
+        sourceHandlerMap
+    );
   }
 }
 

--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/SourceHandlerCallback.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/SourceHandlerCallback.java
@@ -18,9 +18,14 @@
 
 package org.apache.metron.writer.hdfs;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SourceHandlerCallback {
+  private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
   Map<SourceHandlerKey, SourceHandler> sourceHandlerMap;
   SourceHandlerKey key;
   SourceHandlerCallback(Map<SourceHandlerKey, SourceHandler> sourceHandlerMap, SourceHandlerKey key) {
@@ -29,7 +34,9 @@ public class SourceHandlerCallback {
   }
 
   public void removeKey() {
-    sourceHandlerMap.remove(key);
+    SourceHandler removed = sourceHandlerMap.remove(key);
+    LOG.debug("Removed {} -> {}", key, removed);
+    LOG.debug("Current state of sourceHandlerMap: {}", sourceHandlerMap);
   }
 }
 

--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/SourceHandlerKey.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/hdfs/SourceHandlerKey.java
@@ -58,5 +58,13 @@ class SourceHandlerKey {
     result = 31 * result + (stellarResult != null ? stellarResult.hashCode() : 0);
     return result;
   }
+
+  @Override
+  public String toString() {
+    return "SourceHandlerKey{" +
+        "sourceType='" + sourceType + '\'' +
+        ", stellarResult='" + stellarResult + '\'' +
+        '}';
+  }
 }
 

--- a/metron-platform/metron-writer/src/test/java/org/apache/metron/writer/hdfs/SourceHandlerTest.java
+++ b/metron-platform/metron-writer/src/test/java/org/apache/metron/writer/hdfs/SourceHandlerTest.java
@@ -1,0 +1,86 @@
+package org.apache.metron.writer.hdfs;/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import org.apache.storm.hdfs.bolt.format.DefaultFileNameFormat;
+import org.apache.storm.hdfs.bolt.format.FileNameFormat;
+import org.apache.storm.hdfs.bolt.rotation.FileSizeRotationPolicy;
+import org.apache.storm.hdfs.bolt.rotation.FileSizeRotationPolicy.Units;
+import org.apache.storm.hdfs.bolt.sync.CountSyncPolicy;
+import org.apache.storm.hdfs.common.rotation.RotationAction;
+import org.json.simple.JSONObject;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import static org.mockito.Mockito.*;
+
+public class SourceHandlerTest {
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  private static final String SENSOR_NAME = "sensor";
+  private static final String WRITER_NAME = "writerName";
+
+  private File folder;
+  private FileNameFormat testFormat;
+
+  RotationAction rotAction1 = mock(RotationAction.class);
+  RotationAction rotAction2 = mock(RotationAction.class);
+  List<RotationAction> rotActions;
+
+  SourceHandlerCallback callback = mock(SourceHandlerCallback.class);
+
+  @Before
+  public void setup() throws IOException {
+    // Ensure each test has a unique folder to work with.
+    folder = tempFolder.newFolder();
+    testFormat = new DefaultFileNameFormat()
+        .withPath(folder.toString())
+        .withExtension(".json")
+        .withPrefix("prefix-");
+
+    rotActions = new ArrayList<>();
+    rotActions.add(rotAction1);
+    rotActions.add(rotAction2);
+  }
+
+  @Test
+  public void testRotateOutputFile() throws IOException {
+    SourceHandler handler = new SourceHandler(
+        rotActions,
+        new FileSizeRotationPolicy(10000, Units.MB), // Don't actually care about the rotation
+        new CountSyncPolicy(1),
+        testFormat,
+        callback
+    );
+
+    handler.rotateOutputFile();
+
+    // Function should ensure rotation actions and callback are called.
+    verify(rotAction1).execute(any(), any());
+    verify(rotAction2).execute(any(), any());
+    verify(callback).removeKey();
+  }
+}


### PR DESCRIPTION
## Contributor Comments
https://issues.apache.org/jira/browse/METRON-2005 has more info, but the short story is that file rotations were incorrectly creating extra 0-byte files.

This adds a bunch of logging used while debugging the issue, along with a couple minor changes / cleanups (e.g. making sure to close the SourceHandlers that were removed, etc.).

To reproduce the problem without this PR, in the Ambari config for Metron go to Indexing and set `HDFS Rotation Policy Units` and `HDFS Rotation Policy Count` to something small (e.g. a couple minutes). You should see 0 byte files being produced.  The format of a file name is `enrichment-hdfsIndexingBolt-3-0-1550181963674.json`.  The `-0-` is the rotation number.  All nonzero rotation numbers will be 0-byte files, while all zero rotation numbers will contain data.

With the PR, all files should have a zero rotation number (with further explanation in the JIRA, as noted before). The file should change as expected still, e.g. for a 2 minute rotation, you'll see something like 
```
[metron@node1 ~]$ hdfs dfs -ls /apps/metron/indexing/indexed/*
Found 5 items
-rw-r--r--   1 storm hadoop    5852029 2019-02-14 22:40 /apps/metron/indexing/indexed/bro/enrichment-hdfsIndexingBolt-3-0-1550181964099.json
-rw-r--r--   1 storm hadoop    2950408 2019-02-14 22:50 /apps/metron/indexing/indexed/bro/enrichment-hdfsIndexingBolt-3-0-1550184487351.json
-rw-r--r--   1 storm hadoop     736045 2019-02-14 22:52 /apps/metron/indexing/indexed/bro/enrichment-hdfsIndexingBolt-3-0-1550184609455.json
-rw-r--r--   1 storm hadoop     765852 2019-02-14 22:54 /apps/metron/indexing/indexed/bro/enrichment-hdfsIndexingBolt-3-0-1550184732852.json
-rw-r--r--   1 storm hadoop     588054 2019-02-14 22:54 /apps/metron/indexing/indexed/bro/enrichment-hdfsIndexingBolt-3-0-1550184855769.json
...
```

Note that the latest two dates may be the same (e.g. in the example, there are two `22:54`. This is because one file is closed and done, and the newer one was just opened and hasn't been completed yet. Once closed the second one will be `22:56`).

The main change to tests was just to remove a unit test that showed handling of a now incorrect state. I added a fairly basic test to ensure rotation actions and the callback are called, but I'm definitely open to new tests if anyone has any suggestions on what they'd like to see.

I also had to add stellar-common as a dependency.  I hadn't changed anything that would have broken that, but still was failing tests locally.  I thought it was a transitive dependency, but I'm surprised it broke now. I'm open to thoughts about it.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
