### PR TITLE
METRON-2016: Parser aggregate groups should be persisted and available through REST

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/parser_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/parser_commands.py
@@ -74,7 +74,7 @@ class ParserCommands:
         parserList = []
         parsers = shlex.shlex(params.parsers)
         for name in parsers:
-            sensors = name.strip('"').split(",")
+            sensors = name.strip('",').split(",")
             # if name contains multiple sensors, sort them alphabetically
             if len(sensors) > 1:
                 sensors.sort()

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/parser_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/parser_commands.py
@@ -65,14 +65,20 @@ class ParserCommands:
     def __get_aggr_parsers(self, params):
         """
         Fetches the list of aggregated (and regular) parsers and returns a list.
-        If the input list of parsers were "bro,snort,yaf", "bro,snort" and yaf, for example,
-        then this method will return ["bro,snort,yaf", "bro,snort", "yaf"]
+        If the input list of parsers were "bro,yaf,snort", "bro,snort" and yaf, for example,
+        then this method will return ["bro,snort,yaf", "bro,snort", "yaf"].  Sensors within
+        a group are sorted alphabetically.
         :param params:
         :return: List containing the names of parsers
         """
         parserList = []
         parsers = shlex.shlex(params.parsers)
         for name in parsers:
+            sensors = name.strip('"').split(",")
+            # if name contains multiple sensors, sort them alphabetically
+            if len(sensors) > 1:
+                sensors.sort()
+                name = '"' + ",".join(sensors) + '"'
             parserList.append(name.strip(','))
         return [s.translate(None, "'[]") for s in filter(None, parserList)]
 

--- a/metron-interface/metron-rest/README.md
+++ b/metron-interface/metron-rest/README.md
@@ -344,6 +344,10 @@ Request and Response objects are JSON formatted.  The JSON schemas are available
 | [ `GET /api/v1/sensor/parser/config/reload/available`](#get-apiv1sensorparserconfigreloadavailable)|
 | [ `DELETE /api/v1/sensor/parser/config/{name}`](#delete-apiv1sensorparserconfigname)|
 | [ `GET /api/v1/sensor/parser/config/{name}`](#get-apiv1sensorparserconfigname)|
+| [ `POST /api/v1/sensor/parser/group`](#post-apiv1sensorparsergroup)|
+| [ `GET /api/v1/sensor/parser/group/{name}`](#get-apiv1sensorparsergroupname)|
+| [ `GET /api/v1/sensor/parser/group`](#get-apiv1sensorparsergroup)|
+| [ `DELETE /api/v1/sensor/parser/group/{name}`](#delete-apiv1sensorparsergroupname)|
 | [ `POST /api/v1/stellar/apply/transformations`](#post-apiv1stellarapplytransformations)|
 | [ `GET /api/v1/stellar/list`](#get-apiv1stellarlist)|
 | [ `GET /api/v1/stellar/list/functions`](#get-apiv1stellarlistfunctions)|
@@ -787,6 +791,35 @@ Request and Response objects are JSON formatted.  The JSON schemas are available
   * Returns:
     * 200 - Returns SensorParserConfig
     * 404 - SensorParserConfig is missing
+    
+### `POST /api/v1/sensor/parser/group`
+  * Description: Updates or creates a SensorParserGroup in Zookeeper
+  * Input:
+    * sensorParserGroup - SensorParserGroup
+  * Returns:
+    * 200 - SensorParserGroup updated. Returns saved SensorParserGroup
+    * 201 - SensorParserGroup created. Returns saved SensorParserGroup
+    
+### `GET /api/v1/sensor/parser/group/{name}`
+  * Description: Retrieves a SensorParserGroup from Zookeeper
+  * Input:
+    * name - SensorParserGroup name
+  * Returns:
+    * 200 - Returns SensorParserGroup
+    * 404 - SensorParserGroup is missing
+    
+### `GET /api/v1/sensor/parser/group`
+  * Description: Retrieves all SensorParserGroups from Zookeeper
+  * Returns:
+    * 200 - Returns all SensorParserGroups
+    
+### `DELETE /api/v1/sensor/parser/group/{name}`
+  * Description: Deletes a SensorParserGroup from Zookeeper
+  * Input:
+    * name - SensorParserGroup name
+  * Returns:
+    * 200 - SensorParserGroup was deleted
+    * 404 - SensorParserGroup is missing
 
 ### `POST /api/v1/stellar/apply/transformations`
   * Description: Executes transformations against a sample message

--- a/metron-interface/metron-rest/pom.xml
+++ b/metron-interface/metron-rest/pom.xml
@@ -300,6 +300,12 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+        <groupId>org.apache.metron</groupId>
+        <artifactId>metron-parsing-storm</artifactId>
+        <version>${project.parent.version}</version>
+        <scope>provided</scope>
+      </dependency>
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>

--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/controller/SensorParserGroupController.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/controller/SensorParserGroupController.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.rest.controller;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.apache.metron.common.configuration.SensorParserConfig;
+import org.apache.metron.common.configuration.SensorParserGroup;
+import org.apache.metron.rest.RestException;
+import org.apache.metron.rest.model.ParseMessageRequest;
+import org.apache.metron.rest.service.SensorParserConfigService;
+import org.apache.metron.rest.service.SensorParserGroupService;
+import org.json.simple.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collection;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/sensor/parser/group")
+public class SensorParserGroupController {
+
+  @Autowired
+  private SensorParserGroupService sensorParserGroupService;
+
+  @ApiOperation(value = "Updates or creates a SensorParserGroup in Zookeeper")
+  @ApiResponses(value = { @ApiResponse(message = "SensorParserGroup updated. Returns saved SensorParserGroup", code = 200),
+          @ApiResponse(message = "SensorParserGroup created. Returns saved SensorParserGroup", code = 201) })
+  @RequestMapping(method = RequestMethod.POST)
+  ResponseEntity<SensorParserGroup> save(@ApiParam(name="sensorParserGroup", value="SensorParserGroup", required=true)@RequestBody SensorParserGroup sensorParserGroup) throws RestException {
+    if (sensorParserGroupService.findOne(sensorParserGroup.getName()) == null) {
+      return new ResponseEntity<>(sensorParserGroupService.save(sensorParserGroup), HttpStatus.CREATED);
+    } else {
+      return new ResponseEntity<>(sensorParserGroupService.save(sensorParserGroup), HttpStatus.OK);
+    }
+  }
+
+  @ApiOperation(value = "Retrieves a SensorParserGroup from Zookeeper")
+  @ApiResponses(value = { @ApiResponse(message = "Returns SensorParserGroup", code = 200),
+          @ApiResponse(message = "SensorParserGroup is missing", code = 404) })
+  @RequestMapping(value = "/{name}", method = RequestMethod.GET)
+  ResponseEntity<SensorParserGroup> findOne(@ApiParam(name="name", value="SensorParserGroup name", required=true)@PathVariable String name) throws RestException {
+    SensorParserGroup sensorParserGroup = sensorParserGroupService.findOne(name);
+    if (sensorParserGroup != null) {
+      return new ResponseEntity<>(sensorParserGroup, HttpStatus.OK);
+    }
+
+    return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+  }
+
+  @ApiOperation(value = "Retrieves all SensorParserGroups from Zookeeper")
+  @ApiResponse(message = "Returns all SensorParserGroups", code = 200)
+  @RequestMapping(method = RequestMethod.GET)
+  ResponseEntity<Map<String, SensorParserGroup>> findAll() throws RestException {
+    return new ResponseEntity<>(sensorParserGroupService.getAll(), HttpStatus.OK);
+  }
+
+  @ApiOperation(value = "Deletes a SensorParserGroup from Zookeeper")
+  @ApiResponses(value = { @ApiResponse(message = "SensorParserGroup was deleted", code = 200),
+          @ApiResponse(message = "SensorParserGroup is missing", code = 404) })
+  @RequestMapping(value = "/{name}", method = RequestMethod.DELETE)
+  ResponseEntity<Void> delete(@ApiParam(name="name", value="SensorParserGroup name", required=true)@PathVariable String name) throws RestException {
+    if (sensorParserGroupService.delete(name)) {
+      return new ResponseEntity<>(HttpStatus.OK);
+    } else {
+      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    }
+  }
+}

--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/service/SensorParserGroupService.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/service/SensorParserGroupService.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.rest.service;
+
+import org.apache.metron.common.configuration.SensorParserGroup;
+import org.apache.metron.rest.RestException;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Exposes CRUD operations for SensorParserGroup objects stored in Zookeeper.  An array of SensorParserGroups are stored
+ * in the Global Config using the 'parser.groups' key.
+ */
+public interface SensorParserGroupService {
+
+  SensorParserGroup save(SensorParserGroup sensorParserGroup) throws RestException;
+
+  SensorParserGroup findOne(String name);
+
+  Map<String, SensorParserGroup> getAll();
+
+  boolean delete(String name) throws RestException;
+}

--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/service/impl/SensorParserGroupServiceImpl.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/service/impl/SensorParserGroupServiceImpl.java
@@ -1,0 +1,136 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.rest.service.impl;
+
+import org.apache.metron.common.configuration.ParserConfigurations;
+import org.apache.metron.common.configuration.SensorParserGroup;
+import org.apache.metron.common.zookeeper.ConfigurationsCache;
+import org.apache.metron.rest.RestException;
+import org.apache.metron.rest.service.GlobalConfigService;
+import org.apache.metron.rest.service.SensorParserConfigService;
+import org.apache.metron.rest.service.SensorParserGroupService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@Service
+public class SensorParserGroupServiceImpl implements SensorParserGroupService {
+
+  private ConfigurationsCache cache;
+  private GlobalConfigService globalConfigService;
+  private SensorParserConfigService sensorParserConfigService;
+
+  @Autowired
+  public SensorParserGroupServiceImpl(ConfigurationsCache cache, GlobalConfigService globalConfigService, SensorParserConfigService sensorParserConfigService) {
+    this.cache = cache;
+    this.globalConfigService = globalConfigService;
+    this.sensorParserConfigService = sensorParserConfigService;
+  }
+
+  /**
+   * Saves a SensorParserGroup in Zookeeper.  Checks for various error conditions including empty sensors field, missing
+   * configs for each sensor and sensors already included in another group.
+   * @param sensorParserGroup
+   * @return
+   * @throws RestException
+   */
+  @Override
+  public SensorParserGroup save(SensorParserGroup sensorParserGroup) throws RestException {
+    ParserConfigurations parserConfigurations = cache.get( ParserConfigurations.class);
+    Map<String, SensorParserGroup> groups = new HashMap<>(parserConfigurations.getSensorParserGroups());
+    groups.remove(sensorParserGroup.getName());
+
+    if (sensorParserGroup.getSensors().size() == 0) {
+      throw new RestException("A parser group must contain sensors");
+    }
+
+    for(String sensor: sensorParserGroup.getSensors()) {
+      // check if sensor config exists
+      if (sensorParserConfigService.findOne(sensor) == null) {
+        throw new RestException(String.format("Could not find config for sensor %s", sensor));
+      }
+      // check if sensor is in another group
+      for (SensorParserGroup group : groups.values()) {
+        Set<String> groupSensors = group.getSensors();
+        if (groupSensors.contains(sensor)) {
+          throw new RestException(String.format("Sensor %s is already in group %s", sensor, group.getName()));
+        }
+      }
+    }
+    groups.put(sensorParserGroup.getName(), sensorParserGroup);
+    saveGroups(parserConfigurations, new HashSet<>(groups.values()));
+    return sensorParserGroup;
+  }
+
+  /**
+   * Retrieves a single SensorParserGroup by name.
+   * @param name SensorParserGroup name
+   * @return SensorParserGroup or null if group is missing
+   */
+  @Override
+  public SensorParserGroup findOne(String name) {
+    return getAll().get(name);
+  }
+
+  /**
+   * Retrieves all SensorParserGroups as a Map with key being the SensorParserGroup name
+   * @return All SensorParserGroups
+   */
+  @Override
+  public Map<String, SensorParserGroup> getAll() {
+    ParserConfigurations configs = cache.get( ParserConfigurations.class);
+    return configs.getSensorParserGroups();
+  }
+
+  /**
+   * Deletes a SensorParserGroup from Zookeeper.
+   * @param name SensorParserGroup name
+   * @return True if a SensorParserGroup was deleted
+   * @throws RestException Writing to Zookeeper resulted in an error
+   */
+  @Override
+  public boolean delete(String name) throws RestException {
+    ParserConfigurations parserConfigurations = cache.get( ParserConfigurations.class);
+    Map<String, SensorParserGroup> groups = parserConfigurations.getSensorParserGroups();
+    boolean deleted = false;
+    if (groups.containsKey(name)) {
+      groups.remove(name);
+      saveGroups(parserConfigurations, new HashSet<>(groups.values()));
+      deleted = true;
+    }
+    return deleted;
+  }
+
+  /**
+   * Saves SensorParserGroups in Zookeeper.
+   * @param parserConfigurations ParserConfigurations
+   * @param groups SensorParserGroups
+   * @throws RestException Writing to Zookeeper resulted in an error
+   */
+  private void saveGroups(ParserConfigurations parserConfigurations, Collection<SensorParserGroup> groups) throws RestException {
+    Map<String, Object> globalConfig = parserConfigurations.getGlobalConfig(true);
+    globalConfig.put(ParserConfigurations.PARSER_GROUPS_CONF, groups);
+    globalConfigService.save(globalConfig);
+  }
+
+}

--- a/metron-interface/metron-rest/src/test/java/org/apache/metron/rest/controller/SensorParserGroupControllerIntegrationTest.java
+++ b/metron-interface/metron-rest/src/test/java/org/apache/metron/rest/controller/SensorParserGroupControllerIntegrationTest.java
@@ -1,0 +1,251 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.rest.controller;
+
+import org.adrianwalker.multilinestring.Multiline;
+import org.apache.commons.io.FileUtils;
+import org.apache.metron.common.configuration.SensorParserConfig;
+import org.apache.metron.common.configuration.SensorParserGroup;
+import org.apache.metron.integration.utils.TestUtils;
+import org.apache.metron.rest.MetronRestConstants;
+import org.apache.metron.rest.service.GlobalConfigService;
+import org.apache.metron.rest.service.SensorParserConfigService;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.metron.integration.utils.TestUtils.assertEventually;
+import static org.apache.metron.rest.MetronRestConstants.TEST_PROFILE;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment= SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles(TEST_PROFILE)
+public class SensorParserGroupControllerIntegrationTest {
+
+  /**
+   {
+   "name":"group1",
+   "description":"group1 description",
+   "sensors":["bro","snort"]
+   }
+   */
+  @Multiline
+  public static String group1BroSnort;
+
+  /**
+   {
+   "name":"group1",
+   "description":"group1 description",
+   "sensors":["bro","squid"]
+   }
+   */
+  @Multiline
+  public static String group1BroSquid;
+
+  /**
+   {
+   "name":"group2",
+   "description":"group2 description",
+   "sensors":["yaf","jsonMap"]
+   }
+   */
+  @Multiline
+  public static String group2YafJsonMap;
+
+  /**
+   {
+   "name":"errorGroup",
+   "description":"error description",
+   "sensors":["bro"]
+   }
+   */
+  @Multiline
+  public static String errorGroup;
+
+  @Autowired
+  private Environment environment;
+
+  @Autowired
+  private GlobalConfigService globalConfigService;
+
+  @Autowired
+  private SensorParserConfigService sensorParserConfigService;
+
+  @Autowired
+  private WebApplicationContext wac;
+
+  private MockMvc mockMvc;
+
+  private String sensorParserGroupUrl = "/api/v1/sensor/parser/group";
+  private String user = "user";
+  private String password = "password";
+
+  @Before
+  public void setup() throws Exception {
+    this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).apply(springSecurity()).build();
+  }
+
+  @Test
+  public void testSecurity() throws Exception {
+    this.mockMvc.perform(post(sensorParserGroupUrl).with(csrf()).contentType(MediaType.parseMediaType("application/json;charset=UTF-8")).content(group1BroSnort))
+            .andExpect(status().isUnauthorized());
+
+    this.mockMvc.perform(get(sensorParserGroupUrl + "/group1"))
+            .andExpect(status().isUnauthorized());
+
+    this.mockMvc.perform(get(sensorParserGroupUrl))
+            .andExpect(status().isUnauthorized());
+
+    this.mockMvc.perform(delete(sensorParserGroupUrl + "/group1").with(csrf()))
+            .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  public void test() throws Exception {
+    this.globalConfigService.save(new HashMap<>());
+    this.sensorParserConfigService.save("bro", new SensorParserConfig());
+    this.sensorParserConfigService.save("snort", new SensorParserConfig());
+    this.sensorParserConfigService.save("squid", new SensorParserConfig());
+    this.sensorParserConfigService.save("yaf", new SensorParserConfig());
+    this.sensorParserConfigService.save("jsonMap", new SensorParserConfig());
+    Method[] method = SensorParserGroup.class.getMethods();
+    final AtomicInteger numFields = new AtomicInteger(0);
+    for(Method m : method) {
+      if(m.getName().startsWith("set")) {
+        numFields.set(numFields.get() + 1);
+      }
+    }
+    this.mockMvc.perform(post(sensorParserGroupUrl).with(httpBasic(user, password)).with(csrf()).contentType(MediaType.parseMediaType("application/json;charset=UTF-8")).content(group1BroSnort))
+            .andExpect(status().isCreated())
+            .andExpect(content().contentType(MediaType.parseMediaType("application/json;charset=UTF-8")))
+            .andExpect(jsonPath("$.*", hasSize(numFields.get())))
+            .andExpect(jsonPath("$.name").value("group1"))
+            .andExpect(jsonPath("$.description").value("group1 description"))
+            .andExpect(jsonPath("$.sensors[0]").value("bro"))
+            .andExpect(jsonPath("$.sensors[1]").value("snort"));
+
+    this.mockMvc.perform(post(sensorParserGroupUrl).with(httpBasic(user, password)).with(csrf()).contentType(MediaType.parseMediaType("application/json;charset=UTF-8")).content(group2YafJsonMap))
+            .andExpect(status().isCreated())
+            .andExpect(content().contentType(MediaType.parseMediaType("application/json;charset=UTF-8")))
+            .andExpect(jsonPath("$.*", hasSize(numFields.get())))
+            .andExpect(jsonPath("$.name").value("group2"))
+            .andExpect(jsonPath("$.description").value("group2 description"))
+            .andExpect(jsonPath("$.sensors[0]").value("jsonMap"))
+            .andExpect(jsonPath("$.sensors[1]").value("yaf"));
+
+    this.mockMvc.perform(post(sensorParserGroupUrl).with(httpBasic(user, password)).with(csrf()).contentType(MediaType.parseMediaType("application/json;charset=UTF-8")).content(group1BroSquid))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.parseMediaType("application/json;charset=UTF-8")))
+            .andExpect(jsonPath("$.*", hasSize(numFields.get())))
+            .andExpect(jsonPath("$.name").value("group1"))
+            .andExpect(jsonPath("$.description").value("group1 description"))
+            .andExpect(jsonPath("$.sensors[0]").value("squid"))
+            .andExpect(jsonPath("$.sensors[1]").value("bro"));
+
+    assertEventually(() -> this.mockMvc.perform(get(sensorParserGroupUrl + "/group1").with(httpBasic(user,password)))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.parseMediaType("application/json;charset=UTF-8")))
+            .andExpect(jsonPath("$.*", hasSize(numFields.get())))
+            .andExpect(jsonPath("$.name").value("group1"))
+            .andExpect(jsonPath("$.description").value("group1 description"))
+            .andExpect(jsonPath("$.sensors[0]").value("squid"))
+            .andExpect(jsonPath("$.sensors[1]").value("bro"))
+    );
+
+    this.mockMvc.perform(get(sensorParserGroupUrl).with(httpBasic(user,password)))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.parseMediaType("application/json;charset=UTF-8")))
+            .andExpect(jsonPath("$.*", hasSize(2)))
+            .andExpect(jsonPath("$.group1.*", hasSize(numFields.get())))
+            .andExpect(jsonPath("$.group1.name").value("group1"))
+            .andExpect(jsonPath("$.group1.description").value("group1 description"))
+            .andExpect(jsonPath("$.group1.sensors[0]").value("squid"))
+            .andExpect(jsonPath("$.group1.sensors[1]").value("bro"))
+            .andExpect(jsonPath("$.group2.*", hasSize(numFields.get())))
+            .andExpect(jsonPath("$.group2.name").value("group2"))
+            .andExpect(jsonPath("$.group2.description").value("group2 description"))
+            .andExpect(jsonPath("$.group2.sensors[0]").value("jsonMap"))
+            .andExpect(jsonPath("$.group2.sensors[1]").value("yaf"));
+
+    this.mockMvc.perform(get(sensorParserGroupUrl + "/missingGroup").with(httpBasic(user,password)))
+            .andExpect(status().isNotFound());
+
+    this.mockMvc.perform(post(sensorParserGroupUrl).with(httpBasic(user, password)).with(csrf()).contentType(MediaType.parseMediaType("application/json;charset=UTF-8")).content(errorGroup))
+            .andExpect(status().isInternalServerError())
+            .andExpect(content().contentType(MediaType.parseMediaType("application/json;charset=UTF-8")))
+            .andExpect(jsonPath("$.responseCode").value(500))
+            .andExpect(jsonPath("$.message").value("Sensor bro is already in group group1"))
+            .andExpect(jsonPath("$.fullMessage").value("RestException: Sensor bro is already in group group1"));
+
+    this.mockMvc.perform(delete(sensorParserGroupUrl + "/group1").with(httpBasic(user,password)).with(csrf()))
+            .andExpect(status().isOk());
+
+    this.mockMvc.perform(delete(sensorParserGroupUrl + "/missingGroup").with(httpBasic(user,password)))
+            .andExpect(status().isNotFound());
+
+    {
+      //we must wait for the config to find its way into the config.
+      TestUtils.assertEventually(() -> Assert.assertNull(sensorParserConfigService.findOne("group1")));
+    }
+
+    assertEventually(() -> this.mockMvc.perform(get(sensorParserGroupUrl).with(httpBasic(user,password)))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.parseMediaType("application/json;charset=UTF-8")))
+            .andExpect(jsonPath("$.*", hasSize(1)))
+            .andExpect(jsonPath("$.group2.*", hasSize(numFields.get())))
+            .andExpect(jsonPath("$.group2.name").value("group2"))
+            .andExpect(jsonPath("$.group2.description").value("group2 description"))
+            .andExpect(jsonPath("$.group2.sensors[0]").value("jsonMap"))
+            .andExpect(jsonPath("$.group2.sensors[1]").value("yaf"))
+    );
+
+    this.globalConfigService.delete();
+    this.sensorParserConfigService.delete("bro");
+    this.sensorParserConfigService.delete("snort");
+    this.sensorParserConfigService.delete("squid");
+    this.sensorParserConfigService.delete("yaf");
+    this.sensorParserConfigService.delete("jsonMap");
+  }
+}
+

--- a/metron-interface/metron-rest/src/test/java/org/apache/metron/rest/service/impl/SensorParserGroupServiceImplTest.java
+++ b/metron-interface/metron-rest/src/test/java/org/apache/metron/rest/service/impl/SensorParserGroupServiceImplTest.java
@@ -1,0 +1,203 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.rest.service.impl;
+
+import org.apache.metron.common.configuration.ParserConfigurations;
+import org.apache.metron.common.configuration.SensorParserConfig;
+import org.apache.metron.common.configuration.SensorParserGroup;
+import org.apache.metron.common.zookeeper.ConfigurationsCache;
+import org.apache.metron.rest.RestException;
+import org.apache.metron.rest.service.GlobalConfigService;
+import org.apache.metron.rest.service.SensorParserConfigService;
+import org.apache.metron.rest.service.SensorParserGroupService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import static org.apache.metron.common.configuration.ParserConfigurations.PARSER_GROUPS_CONF;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class SensorParserGroupServiceImplTest {
+
+  @Rule
+  public final ExpectedException exception = ExpectedException.none();
+
+  private ConfigurationsCache cache;
+  private GlobalConfigService globalConfigService;
+  private SensorParserConfigService sensorParserConfigService;
+  private SensorParserGroupService sensorParserGroupService;
+
+  @Before
+  public void setUp() throws Exception {
+    cache = mock(ConfigurationsCache.class);
+    globalConfigService = mock(GlobalConfigService.class);
+    sensorParserConfigService = mock(SensorParserConfigService.class);
+    sensorParserGroupService = new SensorParserGroupServiceImpl(cache, globalConfigService, sensorParserConfigService);
+  }
+
+  @Test
+  public void shouldSaveNewGroup() throws Exception {
+    when(cache.get(ParserConfigurations.class)).thenReturn(new ParserConfigurations());
+    when(sensorParserConfigService.findOne("bro")).thenReturn(new SensorParserConfig());
+
+    SensorParserGroup sensorParserGroup = new SensorParserGroup();
+    sensorParserGroup.setName("group1");
+    sensorParserGroup.setDescription("description 1");
+    sensorParserGroup.setSensors(Collections.singleton("bro"));
+
+    Map<String, Object> expectedGlobalConfig = new HashMap<>();
+    Collection<SensorParserGroup> expectedGroup = Collections.singleton(sensorParserGroup);
+    expectedGlobalConfig.put(PARSER_GROUPS_CONF, expectedGroup);
+
+    assertEquals(sensorParserGroup, sensorParserGroupService.save(sensorParserGroup));
+    verify(globalConfigService, times(1)).save(expectedGlobalConfig);
+
+    verifyNoMoreInteractions(globalConfigService);
+  }
+
+  @Test
+  public void shouldSaveExistingGroup() throws Exception {
+    SensorParserGroup oldGroup = new SensorParserGroup();
+    oldGroup.setName("oldGroup");
+    oldGroup.setDescription("old description");
+    oldGroup.setSensors(Collections.singleton("oldSensor"));
+
+    ParserConfigurations parserConfigurations = mock(ParserConfigurations.class);
+    when(cache.get(ParserConfigurations.class)).thenReturn(new ParserConfigurations());
+    when(parserConfigurations.getSensorParserGroups()).thenReturn(new HashMap<String, SensorParserGroup>() {{
+      put("newSensor", oldGroup);
+    }});
+    when(sensorParserConfigService.findOne("newSensor")).thenReturn(new SensorParserConfig());
+
+    SensorParserGroup newGroup = new SensorParserGroup();
+    newGroup.setName("newGroup");
+    newGroup.setDescription("new description");
+    newGroup.setSensors(Collections.singleton("newSensor"));
+
+    Map<String, Object> expectedGlobalConfig = new HashMap<>();
+    Collection<SensorParserGroup> expectedGroup = Collections.singleton(newGroup);
+    expectedGlobalConfig.put(PARSER_GROUPS_CONF, expectedGroup);
+
+    assertEquals(newGroup, sensorParserGroupService.save(newGroup));
+    verify(globalConfigService, times(1)).save(expectedGlobalConfig);
+
+    verifyNoMoreInteractions(globalConfigService);
+  }
+
+  @Test
+  public void saveShouldThrowExceptionOnMissingSensor() throws Exception {
+    exception.expect(RestException.class);
+    exception.expectMessage("A parser group must contain sensors");
+
+    when(cache.get(ParserConfigurations.class)).thenReturn(new ParserConfigurations());
+
+    sensorParserGroupService.save(new SensorParserGroup());
+  }
+
+  @Test
+  public void saveShouldThrowExceptionOnMissingConfig() throws Exception {
+    exception.expect(RestException.class);
+    exception.expectMessage("Could not find config for sensor bro");
+
+    when(cache.get(ParserConfigurations.class)).thenReturn(new ParserConfigurations());
+
+    SensorParserGroup sensorParserGroup = new SensorParserGroup();
+    sensorParserGroup.setSensors(Collections.singleton("bro"));
+
+    sensorParserGroupService.save(sensorParserGroup);
+  }
+
+  @Test
+  public void saveShouldThrowExceptionOnSensorInAnotherGroup() throws Exception {
+    exception.expect(RestException.class);
+    exception.expectMessage("Sensor bro is already in group existingGroup");
+
+    SensorParserGroup existingGroup = new SensorParserGroup();
+    existingGroup.setName("existingGroup");
+    existingGroup.setSensors(Collections.singleton("bro"));
+    ParserConfigurations parserConfigurations = mock(ParserConfigurations.class);
+    when(parserConfigurations.getSensorParserGroups()).thenReturn(new HashMap<String, SensorParserGroup>() {{
+      put("existingGroup", existingGroup);
+    }});
+    when(cache.get(ParserConfigurations.class)).thenReturn(parserConfigurations);
+    when(sensorParserConfigService.findOne("bro")).thenReturn(new SensorParserConfig());
+
+    SensorParserGroup newGroup = new SensorParserGroup();
+    newGroup.setName("newGroup");
+    newGroup.setSensors(Collections.singleton("bro"));
+
+    sensorParserGroupService.save(newGroup);
+  }
+
+  @Test
+  public void shouldFindSensorParserGroup() throws Exception {
+    ParserConfigurations parserConfigurations = mock(ParserConfigurations.class);
+    SensorParserGroup group1 = new SensorParserGroup();
+    group1.setName("group1");
+    group1.setDescription("group1 description");
+    group1.setSensors(Collections.singleton("group1Sensor"));
+    SensorParserGroup group2 = new SensorParserGroup();
+    group2.setName("group2");
+    group2.setDescription("group2 description");
+    group2.setSensors(Collections.singleton("group2Sensor"));
+    when(parserConfigurations.getSensorParserGroups()).thenReturn(new HashMap<String, SensorParserGroup>() {{
+      put("group1", group1);
+      put("group2", group2);
+    }});
+    when(cache.get(ParserConfigurations.class)).thenReturn(parserConfigurations);
+
+    assertEquals(group2, sensorParserGroupService.findOne("group2"));
+  }
+
+
+  @Test
+  public void shouldDeleteSensorParserGroup() throws Exception {
+    ParserConfigurations parserConfigurations = mock(ParserConfigurations.class);
+    SensorParserGroup group1 = new SensorParserGroup();
+    group1.setName("group1");
+    group1.setDescription("group1 description");
+    group1.setSensors(Collections.singleton("group1Sensor"));
+    when(parserConfigurations.getSensorParserGroups()).thenReturn(new HashMap<String, SensorParserGroup>() {{
+      put("group1", group1);
+    }});
+    when(cache.get(ParserConfigurations.class)).thenReturn(parserConfigurations);
+
+    Map<String, Object> expectedGlobalConfig = new HashMap<>();
+    expectedGlobalConfig.put(PARSER_GROUPS_CONF, new HashSet<>());
+
+    assertEquals(true, sensorParserGroupService.delete("group1"));
+    assertEquals(false, sensorParserGroupService.delete("group2"));
+
+    verify(globalConfigService, times(1)).save(expectedGlobalConfig);
+    verifyNoMoreInteractions(globalConfigService);
+  }
+
+
+}

--- a/metron-interface/metron-rest/src/test/java/org/apache/metron/rest/service/impl/StormAdminServiceImplTest.java
+++ b/metron-interface/metron-rest/src/test/java/org/apache/metron/rest/service/impl/StormAdminServiceImplTest.java
@@ -18,17 +18,24 @@
 package org.apache.metron.rest.service.impl;
 
 import org.apache.metron.common.configuration.SensorParserConfig;
+import org.apache.metron.common.configuration.SensorParserGroup;
 import org.apache.metron.rest.model.TopologyResponse;
+import org.apache.metron.rest.model.TopologyStatus;
 import org.apache.metron.rest.model.TopologyStatusCode;
 import org.apache.metron.rest.service.GlobalConfigService;
 import org.apache.metron.rest.service.SensorParserConfigService;
+import org.apache.metron.rest.service.SensorParserGroupService;
 import org.apache.metron.rest.service.StormAdminService;
+import org.apache.metron.rest.service.StormStatusService;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -44,13 +51,17 @@ public class StormAdminServiceImplTest {
   StormAdminService stormAdminService;
   GlobalConfigService globalConfigService;
   SensorParserConfigService sensorParserConfigService;
+  SensorParserGroupService sensorParserGroupService;
+  StormStatusService stormStatusService;
 
   @Before
   public void setUp() throws Exception {
     stormCLIClientWrapper = mock(StormCLIWrapper.class);
     globalConfigService = mock(GlobalConfigService.class);
     sensorParserConfigService = mock(SensorParserConfigService.class);
-    stormAdminService = new StormAdminServiceImpl(stormCLIClientWrapper, globalConfigService, sensorParserConfigService);
+    sensorParserGroupService = mock(SensorParserGroupService.class);
+    stormStatusService = mock(StormStatusService.class);
+    stormAdminService = new StormAdminServiceImpl(stormCLIClientWrapper, globalConfigService, sensorParserConfigService, sensorParserGroupService, stormStatusService);
   }
 
   @Test
@@ -62,6 +73,28 @@ public class StormAdminServiceImplTest {
     TopologyResponse expected = new TopologyResponse();
     expected.setSuccessMessage(TopologyStatusCode.STARTED.toString());
     TopologyResponse actual = stormAdminService.startParserTopology("bro");
+
+    assertEquals(expected, actual);
+    assertEquals(expected.hashCode(), actual.hashCode());
+  }
+
+  @Test
+  public void startParserTopologyByGroupShouldProperlyReturnSuccessTopologyResponse() throws Exception {
+    SensorParserGroup group = new SensorParserGroup();
+    group.setName("group");
+    group.setSensors(new HashSet<String>() {{
+      add("bro");
+      add("snort");
+    }});
+    when(sensorParserGroupService.findOne("group")).thenReturn(group);
+    when(stormCLIClientWrapper.startParserTopology("bro,snort")).thenReturn(0);
+    when(globalConfigService.get()).thenReturn(new HashMap<String, Object>());
+    when(sensorParserConfigService.findOne("bro")).thenReturn(new SensorParserConfig());
+    when(sensorParserConfigService.findOne("snort")).thenReturn(new SensorParserConfig());
+
+    TopologyResponse expected = new TopologyResponse();
+    expected.setSuccessMessage(TopologyStatusCode.STARTED.toString());
+    TopologyResponse actual = stormAdminService.startParserTopology("group");
 
     assertEquals(expected, actual);
     assertEquals(expected.hashCode(), actual.hashCode());
@@ -90,9 +123,10 @@ public class StormAdminServiceImplTest {
 
   @Test
   public void stopParserTopologyShouldProperlyReturnErrorTopologyResponse() throws Exception {
+    TopologyStatus topologyStatus = new TopologyStatus();
+    topologyStatus.setName("bro");
     when(stormCLIClientWrapper.stopParserTopology("bro", false)).thenReturn(1);
-    when(globalConfigService.get()).thenReturn(new HashMap<String, Object>());
-    when(sensorParserConfigService.findOne("bro")).thenReturn(new SensorParserConfig());
+    when(stormStatusService.getTopologyStatus("bro")).thenReturn(topologyStatus);
 
     TopologyResponse expected = new TopologyResponse();
     expected.setErrorMessage(TopologyStatusCode.STOP_ERROR.toString());

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/ParserConfigurations.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/ParserConfigurations.java
@@ -17,16 +17,21 @@
  */
 package org.apache.metron.common.configuration;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.metron.common.utils.JSONUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class ParserConfigurations extends Configurations {
   public static final Integer DEFAULT_KAFKA_BATCH_SIZE = 15;
+  public static final String PARSER_GROUPS_CONF = "parser.groups";
 
   public SensorParserConfig getSensorParserConfig(String sensorType) {
     return (SensorParserConfig) getConfigurations().get(getKey(sensorType));
@@ -44,6 +49,18 @@ public class ParserConfigurations extends Configurations {
   public void updateSensorParserConfig(String sensorType, SensorParserConfig sensorParserConfig) {
     sensorParserConfig.init();
     getConfigurations().put(getKey(sensorType), sensorParserConfig);
+  }
+
+  /**
+   * Retrieves all the sensor groups from the global config
+   * @return Map of sensor groups with the group name as the key
+   */
+  public Map<String, SensorParserGroup> getSensorParserGroups() {
+    Object groups = getGlobalConfig(true).getOrDefault(PARSER_GROUPS_CONF, new ArrayList<>());
+    Collection<SensorParserGroup> sensorParserGroups = JSONUtils.INSTANCE.getMapper()
+            .convertValue(groups, new TypeReference<Collection<SensorParserGroup>>() {{}});
+    return sensorParserGroups.stream()
+            .collect(Collectors.toMap(SensorParserGroup::getName, sensorParserGroup -> sensorParserGroup));
   }
 
   public List<String> getTypes() {

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/SensorParserGroup.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/SensorParserGroup.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.metron.common.configuration;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Represents a group of sensors.  Sensor parser groups are used to execute parsers in a single execution context (Storm
+ * bolt for example).
+ */
+public class SensorParserGroup {
+
+  private String name;
+  private String description;
+  private Set<String> sensors = new HashSet<>();
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public Set<String> getSensors() {
+    return sensors;
+  }
+
+  public void setSensors(Set<String> sensors) {
+    this.sensors = sensors;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    SensorParserGroup that = (SensorParserGroup) o;
+    return Objects.equals(name, that.name) &&
+            Objects.equals(description, that.description) &&
+            Objects.equals(sensors, that.sensors);
+  }
+
+  @Override
+  public int hashCode() {
+
+    return Objects.hash(name, description, sensors);
+  }
+
+  @Override
+  public String toString() {
+    return "SensorParserGroup{" +
+            "name='" + name + '\'' +
+            ", description='" + description + '\'' +
+            ", sensors=" + sensors +
+            '}';
+  }
+}


### PR DESCRIPTION
## Contributor Comments
This PR adds a REST endpoint that manages parser groups in the global config.  The endpoint exposes CRUD operations for a new `SensorParserGroup` object used to store a group name, description and sensor list.

### Changes Included
- `SensorParserGroup` type was added.
- Method added to `ParserConfigurations` for converting the objects stored in the global config to an array of `SensorParserGroup` objects.
- REST classes added to support CRUD operations (`SensorParserGroupController`, `SensorParserGroupService`, `SensorParserGroupServiceImpl`).
- Logic added to the existing `StormAdminServiceImpl` and `StormStatusServiceImpl` classes for converting a `SensorParserGroup` to the corresponding Storm topology name.
- The `parser_commands.py` Ambari mpack script was updated to sort the sensors before starting/stopping topologies.  This is needed so that both Ambari and REST can correctly generate a topology name from a list of sensors.
- Slightly refactored `ParserTopologyCLI` to use a constant sensor separator.
- Added tests and javadocs where appropriate.

### Changes NOT Included
- The `ParserTopologyCLI` still expects a comma-separated list of sensors when starting a topology.  The concept of a `SensorParserGroup` is limited to REST at this point.  We could add group name support to `ParserTopologyCLI` but I don't see a requirement.  If desired I believe this should be a follow on.

### Testing
This has been tested in full dev.

1. Spin up full dev and verify data is flowing to ES.
2. Create a sensor group:
```
curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' -d '{
"description": "group1 description",
"name": "group1",
"sensors": [
"bro","snort","yaf"
]
}' 'http://user:password@node1:8082/api/v1/sensor/parser/group'
```
A 201 status with the new group should be returned.

3. Create another group:
```
curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' -d '{
"description": "group2 description",
"name": "group2",
"sensors": [
"jsonMap","jsonMapQuery"
]
}' 'http://user:password@node1:8082/api/v1/sensor/parser/group'
```
4. Get all groups and verify both groups are returned:
```
curl -X GET --header 'Accept: application/json' 'http://user:password@node1:8082/api/v1/sensor/parser/group'
```
5. The groups should also be visible in the global config:
```
curl -X GET --header 'Accept: application/json' 'http://user:password@node1:8082/api/v1/global/config'
```
6. Verify a group can be retrieved by name:
```
curl -X GET --header 'Accept: application/json' 'http://user:password@node1:8082/api/v1/sensor/parser/group/group1'
```
7. Try to create a new group with a sensor that is already contained in another group:
```
curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' -d '{
"description": "group3 description",
"name": "group3",
"sensors": [
  "bro"
]
}' 'http://user:password@node1:8082/api/v1/sensor/parser/group'
```
You should get an error with an obvious and descriptive message.

8. Try to create a new group with a sensor that does not exist:
```
curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' -d '{
"description": "group3 description",
"name": "group3",
"sensors": [
  "test"
]
}' 'http://user:password@node1:8082/api/v1/sensor/parser/group'
```
You should get an error with an obvious and descriptive message.

9. Try to create a group with an empty sensor list:
```
curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' -d '{
"description": "group3 description",
"name": "group3",
"sensors": [
]
}' 'http://user:password@node1:8082/api/v1/sensor/parser/group'
```
You should get an error with an obvious and descriptive message.

10. Delete a group:
```
curl -X DELETE --header 'Accept: */*' 'http://user:password@node1:8082/api/v1/sensor/parser/group/group2'
```
You should get a 200 and the group should no longer be in the global config.

11. Try to delete the same group again:
```
curl -X DELETE --header 'Accept: */*' 'http://user:password@node1:8082/api/v1/sensor/parser/group/group2'
```
You should get a 404 since the group no longer exists.

12. Navigate to Ambari > Metron > Configs > Parsers and change "Metron Parsers" to `"yaf,bro,snort",squid`.  This will test the Ambari change to ensure sensors are sorted in the job name and multiple topologies are still supported.  Restart the Parser component.
13. Verify that both the `bro__snort__yaf` and `squid` topologies are running with the Storm UI.
14. Get the topology status with REST for `group1` that contains the `bro`, `snort` and `yaf` sensors:
```
curl -X GET --header 'Accept: application/json' 'http://user:password@node1:8082/api/v1/storm/group1'
```
An `ACTIVE` status should be returned.

15. Verify the `group1` topology can be successfully stopped with REST:
```
curl -X GET --header 'Accept: application/json' 'http://user:password@node1:8082/api/v1/storm/parser/stop/group1?stopNow=true'
```
16. Verify the `group1` topology can be successfully started with REST:
```
curl -X GET --header 'Accept: application/json' 'curl -X GET --header 'Accept: application/json' 'http://user:password@node1:8082/api/v1/storm/parser/start/group1''
```
## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
