### PR TITLE
METRON-2031 [UI] Turning off initial search request and polling by default on Alerts UI

### DIFF
--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/alerts-list.component.html
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/alerts-list.component.html
@@ -51,8 +51,8 @@
                 </div>
                 <app-configure-rows [srcElement]="settingsIcon" [tableMetaData]="tableMetaData" [(interval)]="refreshInterval" [(size)]="tableMetaData.size" (configRowsChange)="onConfigRowsChange()" > </app-configure-rows>
                 <div class="btn  pause-play" (click)="onPausePlay()">
-                    <i *ngIf="!pauseRefresh" class="fa fa-pause" aria-hidden="true"></i>
-                    <i *ngIf="pauseRefresh" class="fa fa-play" aria-hidden="true"></i>
+                    <i *ngIf="!isRefreshPaused" class="fa fa-pause" aria-hidden="true"></i>
+                    <i *ngIf="isRefreshPaused" class="fa fa-play" aria-hidden="true"></i>
                 </div>
                 <div id="table-actions" class="dropdown d-inline-block">
                     <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">ACTIONS</button>

--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/alerts-list.component.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/alerts-list.component.ts
@@ -63,8 +63,8 @@ export class AlertsListComponent implements OnInit, OnDestroy {
   colNumberTimerId: number;
   refreshInterval = RefreshInterval.TEN_MIN;
   refreshTimer: Subscription;
-  pauseRefresh = POLLING_DEFAULT_STATE;
-  lastPauseRefreshValue = false;
+  isRefreshPaused = POLLING_DEFAULT_STATE;
+  lastIsRefreshPausedValue = false;
   isMetaAlertPresentInSelectedAlerts = false;
   timeStampfilterPresent = false;
   selectedTimeRange = new Filter(TIMESTAMP_FIELD_NAME, ALL_TIME, false);
@@ -256,8 +256,8 @@ export class AlertsListComponent implements OnInit, OnDestroy {
   }
 
   onPausePlay() {
-    this.pauseRefresh = !this.pauseRefresh;
-    if (this.pauseRefresh) {
+    this.isRefreshPaused = !this.isRefreshPaused;
+    if (this.isRefreshPaused) {
       this.tryStopPolling();
     } else {
       this.search(false);
@@ -331,7 +331,7 @@ export class AlertsListComponent implements OnInit, OnDestroy {
   }
 
   restoreRefreshState() {
-    this.pauseRefresh = this.lastPauseRefreshValue;
+    this.isRefreshPaused = this.lastIsRefreshPausedValue;
     this.tryStartPolling();
   }
 
@@ -417,17 +417,17 @@ export class AlertsListComponent implements OnInit, OnDestroy {
   }
 
   saveRefreshState() {
-    this.lastPauseRefreshValue = this.pauseRefresh;
+    this.lastIsRefreshPausedValue = this.isRefreshPaused;
     this.tryStopPolling();
   }
 
   pause() {
-    this.pauseRefresh = true;
+    this.isRefreshPaused = true;
     this.tryStopPolling();
   }
 
   resume() {
-    this.pauseRefresh = false;
+    this.isRefreshPaused = false;
     this.tryStartPolling();
   }
 
@@ -443,7 +443,7 @@ export class AlertsListComponent implements OnInit, OnDestroy {
   }
 
   tryStartPolling() {
-    if (!this.pauseRefresh) {
+    if (!this.isRefreshPaused) {
       this.tryStopPolling();
       this.refreshTimer = this.searchService.pollSearch(this.queryBuilder).subscribe(results => {
         this.setData(results);

--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/alerts-list.component.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/alerts-list.component.ts
@@ -61,7 +61,7 @@ export class AlertsListComponent implements OnInit, OnDestroy {
   alerts: Alert[] = [];
   searchResponse: SearchResponse = new SearchResponse();
   colNumberTimerId: number;
-  refreshInterval = RefreshInterval.ONE_MIN;
+  refreshInterval = RefreshInterval.TEN_MIN;
   refreshTimer: Subscription;
   pauseRefresh = POLLING_DEFAULT_STATE;
   lastPauseRefreshValue = false;
@@ -164,8 +164,15 @@ export class AlertsListComponent implements OnInit, OnDestroy {
         this.configureTableService.getTableMetadata(),
         this.clusterMetaDataService.getDefaultColumns()
     ).subscribe((response: any) => {
-      this.prepareData(response[0], response[1], resetPaginationForSearch);
+      this.prepareData(response[0], response[1]);
+      this.refreshAlertData(resetPaginationForSearch);
     });
+  }
+
+  private refreshAlertData(resetPaginationForSearch: boolean) {
+    if (this.alerts.length) {
+      this.search(resetPaginationForSearch);
+    }
   }
 
   getColumnNamesForQuery() {
@@ -278,14 +285,12 @@ export class AlertsListComponent implements OnInit, OnDestroy {
     this.calcColumnsToDisplay();
   }
 
-  prepareData(tableMetaData: TableMetadata, defaultColumns: ColumnMetadata[], resetPagination: boolean) {
+  prepareData(tableMetaData: TableMetadata, defaultColumns: ColumnMetadata[]) {
     this.tableMetaData = tableMetaData;
     this.refreshInterval = this.tableMetaData.refreshInterval;
 
     this.updateConfigRowsSettings();
     this.prepareColumnData(tableMetaData.tableColumns, defaultColumns);
-
-    this.search(resetPagination);
   }
 
   processEscalate() {

--- a/metron-interface/metron-alerts/src/app/model/table-metadata.ts
+++ b/metron-interface/metron-alerts/src/app/model/table-metadata.ts
@@ -20,7 +20,7 @@ import {ColumnMetadata} from './column-metadata';
 
 export class TableMetadata {
   size = PageSize.TWENTY_FIVE;
-  refreshInterval = RefreshInterval.ONE_MIN;
+  refreshInterval = RefreshInterval.TEN_MIN;
   hideResolvedAlerts = true;
   hideDismissedAlerts = true;
   tableColumns: ColumnMetadata[];

--- a/metron-interface/metron-alerts/src/app/utils/constants.ts
+++ b/metron-interface/metron-alerts/src/app/utils/constants.ts
@@ -34,7 +34,7 @@ export let CUSTOMM_DATE_RANGE_LABEL = 'Date Range';
 
 export let TREE_SUB_GROUP_SIZE = 5;
 export let INDEXES =  environment.indices ? environment.indices.split(',') : [];
-export let POLLING_DEFAULT_STATE = environment.defaultPollingState;
+export let POLLING_DEFAULT_STATE = !environment.defaultPollingState;
 
 export let MAX_ALERTS_IN_META_ALERTS = 350;
 


### PR DESCRIPTION
## Contributor Comments

The metron alert UI by default searches for everything, on login.
It also has a default refresh rate of 1 min.

This search is activated every time a user login to metron alerts UI. This is causing a heavy load on elastic search and as a result, slows down the RA indexing.

Furthermore, the 1-minute refresh rate sends another search request even before the first search results are returned.

We have to wait for the first query to finish before changing the refresh rate.

As part of this PR I fixing this issue by turning off polling by default (actually there was a previous atempt to turn it off but it had bug) and eliminating inital search request after login.

## Testing
- Clone this branch locally, spin up the Alerts UI manually by navigating to the alerts directory (metron-interface/metron-alerts) and running scripts/start-dev.sh, then navigate to localhost:4201
- Make sure there is no search request sent automatically after login
- Make sure polling is paused by default (there should be a 'play' icon on the top right of the page to start polling)

Please review and merge if you find it ok!
Thx

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
