### PR TITLE
METRON-2038 Enrichment Loader Fails When Run as MR Job

### DIFF
--- a/dependencies_with_url.csv
+++ b/dependencies_with_url.csv
@@ -194,6 +194,7 @@ com.google.guava:guava:jar:18.0:compile,ASLv2,
 com.google.inject.extensions:guice-servlet:jar:3.0:compile,ASLv2,
 com.google.inject:guice:jar:3.0:compile,ASLv2,
 com.googlecode.disruptor:disruptor:jar:2.10.4:compile,The Apache Software License, Version 2.0,http://code.google.com/p/disruptor/
+com.lmax:disruptor:jar:3.3.0:compile,The Apache Software License, Version 2.0,https://github.com/LMAX-Exchange/disruptor/
 com.lmax:disruptor:jar:3.3.2:compile,The Apache Software License, Version 2.0,https://github.com/LMAX-Exchange/disruptor/
 com.googlecode.json-simple:json-simple:jar:1.1:compile,The Apache Software License, Version 2.0,http://code.google.com/p/json-simple/
 com.googlecode.json-simple:json-simple:jar:1.1.1:compile,The Apache Software License, Version 2.0,http://code.google.com/p/json-simple/
@@ -301,6 +302,10 @@ org.jboss.resteasy:resteasy-jaxrs:jar:3.0.1.Final:compile,ASLv2,
 org.joda:joda-convert:jar:1.2:compile,Apache 2,http://joda-convert.sourceforge.net
 org.mortbay.jetty:jetty-util:jar:6.1.26:compile,ASLv2,
 org.mortbay.jetty:jetty:jar:6.1.26:compile,ASLv2,
+org.mortbay.jetty:jetty-sslengine:jar:6.1.26:compile,ASLv2,
+org.mortbay.jetty:jsp-2.1:jar:6.1.14:compile,ASLv2,
+org.mortbay.jetty:jsp-api-2.1:jar:6.1.14:compile,ASLv2,
+org.mortbay.jetty:servlet-api-2.5:jar:6.1.14:compile,ASLv2,
 org.noggit:noggit:jar:0.6:compile,Apache License, Version 2.0,http://github.com/yonik/noggit
 org.scannotation:scannotation:jar:1.0.3:compile,Apache License V2.0,http://scannotation.sf.net
 org.slf4j:log4j-over-slf4j:jar:1.6.6:compile,Apache Software Licenses,http://www.slf4j.org
@@ -498,4 +503,4 @@ joda-time:joda-time:jar:2.10:compile
 org.elasticsearch:securesm:jar:1.2:compile
 com.github.stephenc.jcip:jcip-annotations:jar:1.0-1:compile,ASLv2,http://stephenc.github.io/jcip-annotations/
 com.nimbusds:nimbus-jose-jwt:jar:4.41.2:compile,ASLv2,https://bitbucket.org/connect2id/nimbus-jose-jwt/wiki/Home
-
+tomcat:jasper-compiler:jar:5.5.23:compile,ASLv2,https://tomcat.apache.org/

--- a/metron-platform/metron-data-management/pom.xml
+++ b/metron-platform/metron-data-management/pom.xml
@@ -245,6 +245,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-minicluster</artifactId>
+            <version>${global_hadoop_version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-testing-util</artifactId>
             <version>${global_hbase_version}</version>

--- a/metron-platform/metron-data-management/pom.xml
+++ b/metron-platform/metron-data-management/pom.xml
@@ -186,7 +186,6 @@
                 <artifactId>hadoop-common</artifactId>
               </exclusion>
             </exclusions>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>
@@ -210,7 +209,6 @@
                     <artifactId>hadoop-common</artifactId>
                 </exclusion>
             </exclusions>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.opencsv</groupId>
@@ -245,18 +243,6 @@
             <version>${global_hadoop_version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-minicluster</artifactId>
-            <version>${global_hadoop_version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>
@@ -344,7 +330,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>
@@ -380,7 +365,6 @@
                                 </relocation>
                              </relocations>
                              <transformers>
-                                 <transformer implementation="org.atteo.classindex.ClassIndexTransformer"/>
                                 <transformer
                                   implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                      <resources>
@@ -395,6 +379,11 @@
                                     <addHeader>false</addHeader>
                                     <projectName>${project.name}</projectName>
                                 </transformer-->
+                                <!--
+                                  ClassIndexTransformer needs to go LAST. For some reason it will clobber other
+                                  transformers from operating when it is put first.
+                                -->
+                                <transformer implementation="org.atteo.classindex.ClassIndexTransformer"/>
                             </transformers>
                             <artifactSet>
                                 <excludes>

--- a/metron-platform/metron-data-management/src/main/scripts/flatfile_loader.sh
+++ b/metron-platform/metron-data-management/src/main/scripts/flatfile_loader.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -7,15 +7,15 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# 
+#
 
 BIGTOP_DEFAULTS_DIR=${BIGTOP_DEFAULTS_DIR-/etc/default}
 [ -n "${BIGTOP_DEFAULTS_DIR}" -a -r ${BIGTOP_DEFAULTS_DIR}/hbase ] && . ${BIGTOP_DEFAULTS_DIR}/hbase
@@ -31,21 +31,14 @@ export METRON_VERSION=${project.version}
 export METRON_HOME=/usr/metron/$METRON_VERSION
 export CLASSNAME="org.apache.metron.dataloads.nonbulk.flatfile.SimpleEnrichmentFlatFileLoader"
 export DM_JAR=${project.artifactId}-$METRON_VERSION.jar
-export HBASE_HOME=${HBASE_HOME:-/usr/hdp/current/hbase-client}
+export HBASE_CONF=${HBASE_CONF:-/etc/hbase/conf}
 export HADOOP_OPTS="$HADOOP_OPTS $METRON_JVMFLAGS"
 if [ $(which hadoop) ]
 then
-  HADOOP_CLASSPATH=${HBASE_HOME}/lib/hbase-server.jar:`${HBASE_HOME}/bin/hbase classpath`
-  for jar in $(echo $HADOOP_CLASSPATH | sed 's/:/ /g');do
-    if [ -f $jar ];then
-      LIBJARS="$jar,$LIBJARS"
-    fi
-  done
-  export HADOOP_CLASSPATH
-  hadoop jar $METRON_HOME/lib/$DM_JAR $CLASSNAME -libjars ${LIBJARS} "$@"
+  export HADOOP_CLASSPATH="$HBASE_CONF"
+  hadoop jar $METRON_HOME/lib/$DM_JAR $CLASSNAME "$@"
 else
   echo "Warning: Metron cannot find the hadoop client on this node.  This means that loading via Map Reduce will NOT function."
-  CP=$METRON_HOME/lib/$DM_JAR:/usr/metron/${METRON_VERSION}/lib/taxii-1.1.0.1.jar:`${HBASE_HOME}/bin/hbase classpath`
+  CP=$METRON_HOME/lib/$DM_JAR:$HBASE_CONF
   java $METRON_JVMFLAGS -cp $CP $CLASSNAME "$@"
 fi
-


### PR DESCRIPTION
The enrichment loader fails when run as an MR job on YARN. It runs successfully when run in local mode.  See [METRON-2038](https://issues.apache.org/jira/browse/METRON-2038) for more information.

## Changes

#1345 unexpectedly changed how Maven packages the `metron-data-management` JAR even though  #1345 was completely unrelated to `metron-data-management`.

#### Why did #1345 impact `metron-data-management`?  

This is due to the problematic dependency on `metron-enrichment` from other projects like `metron-data-management`.  This can cause dependency changes in unrelated projects like `metron-profiler-client` to impact completely unrelated projects like `metron-data-management`.  This problematic dependency chain is in the process of being cleaned up as part of other ongoing work.

#### Why did the enrichment loader not work in MR, but work in local mode?

The problem occurs because Maven packaged `org.apache.hadoop.hbase.HBaseConfiguration` in the `metron-data-management` jar, even though HBase is marked as a `provided` dependency.  This really should not be packaged in the JAR, but I have been unable to determine why Maven was doing this.

When the enrichment loader is executed by the `flatfile_loader.sh` script, a large number of HBase dependencies are added at runtime.  The underlying MR code requires a different, conflicting version of this class. Unfortunately, it would find the conflicting `org.apache.hadoop.hbase.HBaseConfiguration` class definition in the `metron-data-management` jar rather than in its runtime dependencies. 

#### How was this fixed?

Rather than load the HBase dependency at runtime, now we package the HBase dependency in the JAR and do not add any of these dependencies at runtime.  This approach avoids the conflict and helps ensure that the integration tests run more similarly to how the tool is used in production.

## Testing

Follow the steps to replicate from [METRON-2038](https://issues.apache.org/jira/browse/METRON-2038) in Full Dev.  Ensure that the enrichments are loaded to the enrichments table in HBase.

## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
