### PR TITLE
METRON-2022: Metron rest creates large number of connections to ZK which causes subsequent connection to zk fail

### DIFF
--- a/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/client/SolrClientFactory.java
+++ b/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/client/SolrClientFactory.java
@@ -59,15 +59,16 @@ public class SolrClientFactory {
    * Closes the SolrClient connection and releases the reference.
    */
   public static void close() {
-    if (solrClient != null) {
-      try {
-        solrClient.close();
-      } catch (IOException e) {
-        LOG.error(e.getMessage(), e);
-      } finally {
-        solrClient = null;
+    synchronized (SolrClientFactory.class) {
+      if (solrClient != null) {
+        try {
+          solrClient.close();
+        } catch (IOException e) {
+          LOG.error(e.getMessage(), e);
+        } finally {
+          solrClient = null;
+        }
       }
-
     }
   }
 

--- a/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/client/SolrClientFactory.java
+++ b/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/client/SolrClientFactory.java
@@ -1,0 +1,35 @@
+package org.apache.metron.solr.client;
+
+import com.google.common.base.Splitter;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.impl.CloudSolrClient;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.metron.solr.SolrConstants.SOLR_ZOOKEEPER;
+
+/**
+ * Factory for creating a SolrClient.  The default implementation of SolrClient is CloudSolrClient.
+ */
+public class SolrClientFactory {
+
+  /**
+   * Creates a SolrClient.
+   * @param globalConfig Global config
+   * @return SolrClient
+   */
+  public static SolrClient create(Map<String, Object> globalConfig) {
+    return new CloudSolrClient.Builder().withZkHost(getZkHosts(globalConfig)).build();
+  }
+
+  /**
+   * Retrieves zookeeper hosts from the global config and formats them for CloudSolrClient instantiation.
+   * @param globalConfig Global config
+   * @return A list of properly formatted zookeeper servers
+   */
+  protected static List<String> getZkHosts(Map<String, Object> globalConfig) {
+    return Splitter.on(',').trimResults()
+            .splitToList((String) globalConfig.getOrDefault(SOLR_ZOOKEEPER, ""));
+  }
+}

--- a/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/client/SolrClientFactory.java
+++ b/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/client/SolrClientFactory.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.metron.solr.client;
 
 import com.google.common.base.Splitter;

--- a/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/dao/SolrDao.java
+++ b/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/dao/SolrDao.java
@@ -17,9 +17,6 @@
  */
 package org.apache.metron.solr.dao;
 
-import static org.apache.metron.solr.SolrConstants.SOLR_ZOOKEEPER;
-
-import com.google.common.base.Splitter;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.List;
@@ -40,8 +37,8 @@ import org.apache.metron.indexing.dao.update.CommentAddRemoveRequest;
 import org.apache.metron.indexing.dao.update.Document;
 import org.apache.metron.indexing.dao.update.OriginalNotFoundException;
 import org.apache.metron.indexing.dao.update.PatchRequest;
+import org.apache.metron.solr.client.SolrClientFactory;
 import org.apache.solr.client.solrj.SolrClient;
-import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.impl.HttpClientUtil;
 import org.apache.solr.client.solrj.impl.Krb5HttpClientConfigurer;
 import org.slf4j.Logger;
@@ -86,7 +83,7 @@ public class SolrDao implements IndexDao {
     }
     if (this.client == null) {
       this.accessConfig = config;
-      this.client = getSolrClient(getZkHosts());
+      this.client = SolrClientFactory.create(config.getGlobalConfigSupplier().get());
       this.solrSearchDao = new SolrSearchDao(this.client, this.accessConfig);
       this.solrRetrieveLatestDao = new SolrRetrieveLatestDao(this.client, this.accessConfig);
       this.solrUpdateDao = new SolrUpdateDao(this.client, this.solrRetrieveLatestDao, this.accessConfig);
@@ -176,24 +173,6 @@ public class SolrDao implements IndexDao {
       throw new IllegalStateException("The SolrDao must be initialized first");
     }
     return this.client;
-  }
-
-  /**
-   * Builds a Solr client using the ZK hosts specified.
-   * @return SolrClient
-   */
-  protected SolrClient getSolrClient(List<String> zkHosts) {
-    return new CloudSolrClient.Builder().withZkHost(zkHosts).build();
-  }
-
-  /**
-   * Get ZK hosts from the global config.
-   * @return List of ZkHosts
-   */
-  public List<String> getZkHosts() {
-    Map<String, Object> globalConfig = accessConfig.getGlobalConfigSupplier().get();
-    return Splitter.on(',').trimResults()
-        .splitToList((String) globalConfig.getOrDefault(SOLR_ZOOKEEPER, ""));
   }
 
   void enableKerberos() {

--- a/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/dao/SolrDao.java
+++ b/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/dao/SolrDao.java
@@ -164,17 +164,6 @@ public class SolrDao implements IndexDao {
     return this.solrUpdateDao.removeCommentFromAlert(request, latest);
   }
 
-  /**
-   * Returns the SolrClient.
-   * @return SolrClient
-   */
-  public SolrClient getSolrClient() {
-    if (this.client == null) {
-      throw new IllegalStateException("The SolrDao must be initialized first");
-    }
-    return this.client;
-  }
-
   void enableKerberos() {
     HttpClientUtil.addConfigurer(new Krb5HttpClientConfigurer());
   }

--- a/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/dao/SolrDao.java
+++ b/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/dao/SolrDao.java
@@ -168,18 +168,21 @@ public class SolrDao implements IndexDao {
   }
 
   /**
-   * Builds a Solr client using the ZK hosts from the global config.
+   * Returns the SolrClient.
    * @return SolrClient
    */
   public SolrClient getSolrClient() {
-    return new CloudSolrClient.Builder().withZkHost(getZkHosts()).build();
+    if (this.client == null) {
+      throw new IllegalStateException("The SolrDao must be initialized first");
+    }
+    return this.client;
   }
 
   /**
    * Builds a Solr client using the ZK hosts specified.
    * @return SolrClient
    */
-  public SolrClient getSolrClient(List<String> zkHosts) {
+  protected SolrClient getSolrClient(List<String> zkHosts) {
     return new CloudSolrClient.Builder().withZkHost(zkHosts).build();
   }
 

--- a/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/dao/SolrMetaAlertDao.java
+++ b/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/dao/SolrMetaAlertDao.java
@@ -47,6 +47,7 @@ import org.apache.metron.indexing.dao.update.CommentAddRemoveRequest;
 import org.apache.metron.indexing.dao.update.Document;
 import org.apache.metron.indexing.dao.update.OriginalNotFoundException;
 import org.apache.metron.indexing.dao.update.PatchRequest;
+import org.apache.metron.solr.client.SolrClientFactory;
 import org.apache.solr.client.solrj.SolrClient;
 
 public class SolrMetaAlertDao implements MetaAlertDao {
@@ -144,7 +145,7 @@ public class SolrMetaAlertDao implements MetaAlertDao {
       }
     };
 
-    SolrClient solrClient = solrDao.getSolrClient();
+    SolrClient solrClient = SolrClientFactory.create(globalConfigSupplier.get());
     this.metaAlertSearchDao = new SolrMetaAlertSearchDao(solrClient, solrDao.getSolrSearchDao(), config);
     this.metaAlertRetrieveLatestDao = new SolrMetaAlertRetrieveLatestDao(solrClient, solrDao);
     this.metaAlertUpdateDao = new SolrMetaAlertUpdateDao(

--- a/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/dao/SolrMetaAlertDao.java
+++ b/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/dao/SolrMetaAlertDao.java
@@ -144,10 +144,11 @@ public class SolrMetaAlertDao implements MetaAlertDao {
       }
     };
 
-    SolrClient solrClient = solrDao.getSolrClient(solrDao.getZkHosts());
+    SolrClient solrClient = solrDao.getSolrClient();
     this.metaAlertSearchDao = new SolrMetaAlertSearchDao(solrClient, solrDao.getSolrSearchDao(), config);
-    this.metaAlertRetrieveLatestDao = new SolrMetaAlertRetrieveLatestDao(solrDao);
+    this.metaAlertRetrieveLatestDao = new SolrMetaAlertRetrieveLatestDao(solrClient, solrDao);
     this.metaAlertUpdateDao = new SolrMetaAlertUpdateDao(
+        solrClient,
         solrDao,
         metaAlertSearchDao,
         metaAlertRetrieveLatestDao,

--- a/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/dao/SolrMetaAlertRetrieveLatestDao.java
+++ b/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/dao/SolrMetaAlertRetrieveLatestDao.java
@@ -27,6 +27,7 @@ import org.apache.metron.indexing.dao.metaalert.MetaAlertConstants;
 import org.apache.metron.indexing.dao.metaalert.MetaAlertRetrieveLatestDao;
 import org.apache.metron.indexing.dao.search.GetRequest;
 import org.apache.metron.indexing.dao.update.Document;
+import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.response.QueryResponse;
@@ -36,8 +37,10 @@ public class SolrMetaAlertRetrieveLatestDao implements
     MetaAlertRetrieveLatestDao {
 
   private SolrDao solrDao;
+  private SolrClient solrClient;
 
-  public SolrMetaAlertRetrieveLatestDao(SolrDao solrDao) {
+  public SolrMetaAlertRetrieveLatestDao(SolrClient client, SolrDao solrDao) {
+    this.solrClient = client;
     this.solrDao = solrDao;
   }
 
@@ -52,8 +55,7 @@ public class SolrMetaAlertRetrieveLatestDao implements
           .setFields("*", "[child parentFilter=" + guidClause + " limit=999]");
 
       try {
-        QueryResponse response = solrDao.getSolrClient(solrDao.getZkHosts())
-            .query(METAALERTS_COLLECTION, query);
+        QueryResponse response = solrClient.query(METAALERTS_COLLECTION, query);
         // GUID is unique, so it's definitely the first result
         if (response.getResults().size() == 1) {
           SolrDocument result = response.getResults().get(0);

--- a/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/dao/SolrMetaAlertUpdateDao.java
+++ b/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/dao/SolrMetaAlertUpdateDao.java
@@ -59,12 +59,13 @@ public class SolrMetaAlertUpdateDao extends AbstractLuceneMetaAlertUpdateDao imp
    * @param retrieveLatestDao A RetrieveLatestDao for getting the current state of items being
    *     mutated.
    */
-  public SolrMetaAlertUpdateDao(SolrDao solrDao,
+  public SolrMetaAlertUpdateDao(SolrClient solrClient,
+          SolrDao solrDao,
       SolrMetaAlertSearchDao metaAlertSearchDao,
       SolrMetaAlertRetrieveLatestDao retrieveLatestDao,
       MetaAlertConfig config) {
     super(solrDao, retrieveLatestDao, config);
-    this.solrClient = solrDao.getSolrClient(solrDao.getZkHosts());
+    this.solrClient = solrClient;
     this.metaAlertSearchDao = metaAlertSearchDao;
   }
 

--- a/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/dao/SolrUpdateDao.java
+++ b/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/dao/SolrUpdateDao.java
@@ -72,6 +72,7 @@ public class SolrUpdateDao implements UpdateDao {
           .getIndex(config.getIndexSupplier(), newVersion.getSensorType(), rawIndex);
       if (index.isPresent()) {
         this.client.add(index.get(), solrInputDocument);
+        System.out.println("Committing doc id " + update.getGuid() + " to index " + update.getSensorType());
         this.client.commit(index.get());
       } else {
         throw new IllegalStateException("Index must be specified or inferred.");

--- a/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/dao/SolrUpdateDao.java
+++ b/metron-platform/metron-solr/src/main/java/org/apache/metron/solr/dao/SolrUpdateDao.java
@@ -72,7 +72,6 @@ public class SolrUpdateDao implements UpdateDao {
           .getIndex(config.getIndexSupplier(), newVersion.getSensorType(), rawIndex);
       if (index.isPresent()) {
         this.client.add(index.get(), solrInputDocument);
-        System.out.println("Committing doc id " + update.getGuid() + " to index " + update.getSensorType());
         this.client.commit(index.get());
       } else {
         throw new IllegalStateException("Index must be specified or inferred.");

--- a/metron-platform/metron-solr/src/test/java/org/apache/metron/solr/client/SolrClientFactoryTest.java
+++ b/metron-platform/metron-solr/src/test/java/org/apache/metron/solr/client/SolrClientFactoryTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.metron.solr.client;
 
 import org.junit.Test;

--- a/metron-platform/metron-solr/src/test/java/org/apache/metron/solr/client/SolrClientFactoryTest.java
+++ b/metron-platform/metron-solr/src/test/java/org/apache/metron/solr/client/SolrClientFactoryTest.java
@@ -1,0 +1,39 @@
+package org.apache.metron.solr.client;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.metron.solr.SolrConstants.SOLR_ZOOKEEPER;
+import static org.junit.Assert.assertEquals;
+
+public class SolrClientFactoryTest {
+
+  @Test
+  public void testGetZkHostsSingle() {
+    Map<String, Object> globalConfig = new HashMap<String, Object>() {{
+      put(SOLR_ZOOKEEPER, "   zookeeper:2181   ");
+    }};
+
+    List<String> actual = SolrClientFactory.getZkHosts(globalConfig);
+    List<String> expected = new ArrayList<>();
+    expected.add("zookeeper:2181");
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testGetZkHostsMultiple() {
+    Map<String, Object> globalConfig = new HashMap<String, Object>() {{
+      put(SOLR_ZOOKEEPER, "   zookeeper:2181    ,   zookeeper2:2181    ");
+    }};
+
+    List<String> actual = SolrClientFactory.getZkHosts(globalConfig);
+    List<String> expected = new ArrayList<>();
+    expected.add("zookeeper:2181");
+    expected.add("zookeeper2:2181");
+    assertEquals(expected, actual);
+  }
+}

--- a/metron-platform/metron-solr/src/test/java/org/apache/metron/solr/dao/SolrMetaAlertDaoTest.java
+++ b/metron-platform/metron-solr/src/test/java/org/apache/metron/solr/dao/SolrMetaAlertDaoTest.java
@@ -19,6 +19,9 @@
 package org.apache.metron.solr.dao;
 
 import static org.apache.metron.solr.SolrConstants.SOLR_ZOOKEEPER;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -42,11 +45,20 @@ import org.apache.metron.indexing.dao.search.SearchResponse;
 import org.apache.metron.indexing.dao.update.CommentAddRemoveRequest;
 import org.apache.metron.indexing.dao.update.Document;
 import org.apache.metron.indexing.dao.update.PatchRequest;
+import org.apache.metron.solr.client.SolrClientFactory;
+import org.apache.solr.client.solrj.SolrClient;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({SolrMetaAlertDao.class, SolrClientFactory.class})
 public class SolrMetaAlertDaoTest {
   private static AccessConfig accessConfig = new AccessConfig();
+  private SolrClient client;
 
   @BeforeClass
   public static void setupBefore() {
@@ -55,6 +67,14 @@ public class SolrMetaAlertDaoTest {
           put(SOLR_ZOOKEEPER, "zookeeper:2181");
         }}
     );
+  }
+
+  @SuppressWarnings("unchecked")
+  @Before
+  public void setUp() {
+    client = mock(SolrClient.class);
+    mockStatic(SolrClientFactory.class);
+    when(SolrClientFactory.create(accessConfig.getGlobalConfigSupplier().get())).thenReturn(client);
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/metron-platform/metron-solr/src/test/java/org/apache/metron/solr/integration/SolrMetaAlertIntegrationTest.java
+++ b/metron-platform/metron-solr/src/test/java/org/apache/metron/solr/integration/SolrMetaAlertIntegrationTest.java
@@ -51,6 +51,7 @@ import org.apache.metron.solr.dao.SolrMetaAlertRetrieveLatestDao;
 import org.apache.metron.solr.dao.SolrMetaAlertSearchDao;
 import org.apache.metron.solr.dao.SolrMetaAlertUpdateDao;
 import org.apache.metron.solr.integration.components.SolrComponent;
+import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.zookeeper.KeeperException;
 import org.junit.After;
@@ -113,12 +114,12 @@ public class SolrMetaAlertIntegrationTest extends MetaAlertIntegrationTest {
       }
     };
 
-
+    SolrClient solrClient = solrDao.getSolrClient();
     SolrMetaAlertSearchDao searchDao = new SolrMetaAlertSearchDao(
-        solrDao.getSolrClient(solrDao.getZkHosts()),
+        solrClient,
         solrDao.getSolrSearchDao(), config);
-    SolrMetaAlertRetrieveLatestDao retrieveLatestDao = new SolrMetaAlertRetrieveLatestDao(solrDao);
-    SolrMetaAlertUpdateDao updateDao = new SolrMetaAlertUpdateDao(solrDao, searchDao,
+    SolrMetaAlertRetrieveLatestDao retrieveLatestDao = new SolrMetaAlertRetrieveLatestDao(solrClient, solrDao);
+    SolrMetaAlertUpdateDao updateDao = new SolrMetaAlertUpdateDao(solrClient, solrDao, searchDao,
         retrieveLatestDao, config);
     metaDao = new SolrMetaAlertDao(solrDao, searchDao, updateDao, retrieveLatestDao);
   }

--- a/metron-platform/metron-solr/src/test/java/org/apache/metron/solr/integration/SolrMetaAlertIntegrationTest.java
+++ b/metron-platform/metron-solr/src/test/java/org/apache/metron/solr/integration/SolrMetaAlertIntegrationTest.java
@@ -45,6 +45,7 @@ import org.apache.metron.indexing.dao.search.GetRequest;
 import org.apache.metron.indexing.dao.search.SearchRequest;
 import org.apache.metron.indexing.dao.search.SearchResponse;
 import org.apache.metron.indexing.dao.search.SortField;
+import org.apache.metron.solr.client.SolrClientFactory;
 import org.apache.metron.solr.dao.SolrDao;
 import org.apache.metron.solr.dao.SolrMetaAlertDao;
 import org.apache.metron.solr.dao.SolrMetaAlertRetrieveLatestDao;
@@ -114,7 +115,7 @@ public class SolrMetaAlertIntegrationTest extends MetaAlertIntegrationTest {
       }
     };
 
-    SolrClient solrClient = solrDao.getSolrClient();
+    SolrClient solrClient = SolrClientFactory.create(globalConfig);
     SolrMetaAlertSearchDao searchDao = new SolrMetaAlertSearchDao(
         solrClient,
         solrDao.getSolrSearchDao(), config);
@@ -134,6 +135,7 @@ public class SolrMetaAlertIntegrationTest extends MetaAlertIntegrationTest {
 
   @AfterClass
   public static void teardown() {
+    SolrClientFactory.close();
     if (solr != null) {
       solr.stop();
     }

--- a/metron-platform/metron-solr/src/test/java/org/apache/metron/solr/integration/SolrRetrieveLatestIntegrationTest.java
+++ b/metron-platform/metron-solr/src/test/java/org/apache/metron/solr/integration/SolrRetrieveLatestIntegrationTest.java
@@ -34,6 +34,7 @@ import org.apache.metron.indexing.dao.AccessConfig;
 import org.apache.metron.indexing.dao.IndexDao;
 import org.apache.metron.indexing.dao.search.GetRequest;
 import org.apache.metron.indexing.dao.update.Document;
+import org.apache.metron.solr.client.SolrClientFactory;
 import org.apache.metron.solr.dao.SolrDao;
 import org.apache.metron.solr.integration.components.SolrComponent;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -85,6 +86,7 @@ public class SolrRetrieveLatestIntegrationTest {
 
   @AfterClass
   public static void teardown() {
+    SolrClientFactory.close();
     solrComponent.stop();
   }
 

--- a/metron-platform/metron-solr/src/test/java/org/apache/metron/solr/integration/SolrSearchIntegrationTest.java
+++ b/metron-platform/metron-solr/src/test/java/org/apache/metron/solr/integration/SolrSearchIntegrationTest.java
@@ -34,6 +34,7 @@ import org.apache.metron.indexing.dao.search.InvalidSearchException;
 import org.apache.metron.indexing.dao.search.SearchRequest;
 import org.apache.metron.indexing.dao.search.SearchResponse;
 import org.apache.metron.integration.InMemoryComponent;
+import org.apache.metron.solr.client.SolrClientFactory;
 import org.apache.metron.solr.dao.SolrDao;
 import org.apache.metron.solr.integration.components.SolrComponent;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -64,6 +65,7 @@ public class SolrSearchIntegrationTest extends SearchIntegrationTest {
 
   @AfterClass
   public static void teardown() {
+    SolrClientFactory.close();
     if (solrComponent != null) {
       solrComponent.stop();
     }

--- a/metron-platform/metron-solr/src/test/java/org/apache/metron/solr/integration/SolrUpdateIntegrationTest.java
+++ b/metron-platform/metron-solr/src/test/java/org/apache/metron/solr/integration/SolrUpdateIntegrationTest.java
@@ -40,6 +40,7 @@ import org.apache.metron.indexing.dao.MultiIndexDao;
 import org.apache.metron.indexing.dao.UpdateIntegrationTest;
 import org.apache.metron.indexing.dao.update.Document;
 import org.apache.metron.indexing.util.IndexingCacheUtil;
+import org.apache.metron.solr.client.SolrClientFactory;
 import org.apache.metron.solr.dao.SolrDao;
 import org.apache.metron.solr.integration.components.SolrComponent;
 import org.junit.After;
@@ -106,6 +107,7 @@ public class SolrUpdateIntegrationTest extends UpdateIntegrationTest {
 
   @AfterClass
   public static void teardown() {
+    SolrClientFactory.close();
     solrComponent.stop();
   }
 


### PR DESCRIPTION
## Contributor Comments
I was able to track down the problem in the `SolrMetaAlertRetrieveLatestDao` class.  Every time the latest meta alert is retrieved in `SolrMetaAlertRetrieveLatestDao.getLatest`, a new `SolrClient` is being created and never closed.  This issue also happens when updating a meta alert because the latest version of the meta alert is retrieved first.

To fix this, the `SolrClient` created in `SolrDao` is now shared with all child Dao classes.  Some slight refactoring was needed to achieve this and I tried to keep it as consistent with other `SolrDao` classes as possible.

### Testing
1. Spin up full dev and create a meta alert:
```
curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' -d '{
  "alerts": [
    {
      "guid": "f130166c-ba0d-4ecd-8395-eaea8aa950fe",
      "sensorType": "bro"
    }
  ],
  "groups": [
    "string"
  ]
}' 'http://user:password@node1:8082/api/v1/metaalert/create'
``` 
2. Record the number of active zookeeper connections by first getting the REST PID:
```
[root@node1 tmp]# ps -ef | grep metron-rest
metron   18151     1  7 00:59 ?        00:01:36 /usr/jdk64/jdk1.8.0_112/bin/java -Dhdp.version=2.6.5.0-292 -cp /etc/hadoop/conf/:/usr/hdp/current/hbase-client/conf:/usr/metron/0.7.1/lib/metron-rest-0.7.1.jar:/usr/metron/0.7.1/lib/metron-parsing-storm-0.7.1-uber.jar:/usr/metron/0.7.1/lib/metron-solr-0.7.1-uber.jar org.apache.metron.rest.MetronRestApplication --spring.config.location=/usr/metron/0.7.1/config/rest_application.yml,classpath:/application.yml --server.port=8082 --spring.profiles.active=dev --index.dao.impl=org.apache.metron.solr.dao.SolrDao,org.apache.metron.indexing.dao.HBaseDao --meta.dao.impl=org.apache.metron.solr.dao.SolrMetaAlertDao --index.writer.name=solr
root     20411   566  0 01:21 pts/0    00:00:00 grep metron-rest
```
Then print the number of connections for that PID:
```
[root@node1 tmp]# netstat -nape | awk '{if ($5 == "::ffff:127.0.0.1:2181") print $9;}' | sort | uniq -c | grep 18151
      2 18151/java
```
3. Update the created meta alert `alert_status` field  several times with different values:
```
curl -X PATCH --header 'Content-Type: application/json' --header 'Accept: application/json' -d '{
  "guid": "f8da66bc-0d26-4f90-9d93-4689e70e9ce3",
  "index": "metaalert",
  "patch": [
   {"op":"add","path":"/alert_status","value":"DISMISSED"}
  ],
  "sensorType": "metaalert"
}' 'http://user:password@node1:8082/api/v1/update/patch'
```
4. Printing the number of zookeeper connections should continue to be 2.  Before this the number of connections would continue to grow as updates are sent.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
