### PR TITLE
METRON-2075 Site book build support for MacOS that has GNU sed installed

### DIFF
--- a/site-book/bin/generate-md.sh
+++ b/site-book/bin/generate-md.sh
@@ -265,7 +265,7 @@ for (( i=0; i<${#HREF_REWRITE_LIST[@]} ; i+=2 )) ; do
             ;;
         darwin*)
             # MacOS sed needs an empty-string argument after -i option to get the same result
-            sed -i '' -e "${HREF_REWRITE_LIST[ $(( i + 1 )) ]}" "${HREF_REWRITE_LIST[$i]}"
+            /usr/bin/sed -i '' -e "${HREF_REWRITE_LIST[ $(( i + 1 )) ]}" "${HREF_REWRITE_LIST[$i]}"
             ;;
         *)
             echo "ERROR: Unable to determine 'sed' argument list for OS ${OSTYPE}" > /dev/stderr

--- a/site-book/bin/generate-md.sh
+++ b/site-book/bin/generate-md.sh
@@ -264,6 +264,7 @@ for (( i=0; i<${#HREF_REWRITE_LIST[@]} ; i+=2 )) ; do
             sed -i -e "${HREF_REWRITE_LIST[ $(( i + 1 )) ]}" "${HREF_REWRITE_LIST[$i]}"
             ;;
         darwin*)
+	    # Use absolute path to ensure that MacOS sed is being used
             # MacOS sed needs an empty-string argument after -i option to get the same result
             /usr/bin/sed -i '' -e "${HREF_REWRITE_LIST[ $(( i + 1 )) ]}" "${HREF_REWRITE_LIST[$i]}"
             ;;


### PR DESCRIPTION
## Contributor Comments
The site-book build script at "site-book/bin/generate-md.sh" relies on the MacOS version of sed being on the path of the script environment when run under MacOS.  If the GNU version of sed appears earlier in the path then errors will occur during site book construction.

This patch forces the build script to use the MacOS version of sed during the regex processing loop. This allows the site book build script to execute successfully when run on a MacOS machine that has GNU sed installed. There are two further calls to sed that remain untouched by this patch as the sed arguments used by the script in these instances are compatible with both versions of sed.

## Testing
Build script runs successfully after patching.  The modified code path is only executed when the script is run under a MacOS environment.


## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [ ] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.