### PR TITLE
METRON-2092: Config UI does not require you to set a grok timestamp field by default

### DIFF
--- a/metron-interface/metron-config/src/app/model/sensor-parser-config.ts
+++ b/metron-interface/metron-config/src/app/model/sensor-parser-config.ts
@@ -35,11 +35,13 @@ export class SensorParserConfig {
   errorWriterNumTasks: number;
   spoutConfig: {};
   stormConfig: {};
+  timestampField: string;
 
   constructor() {
     this.parserConfig = {};
     this.fieldTransformations = [];
     this.spoutConfig = {};
     this.stormConfig = {};
+    this.timestampField = 'timestamp';
   }
 }

--- a/metron-interface/metron-config/src/app/sensors/sensor-parser-config/sensor-parser-config.component.html
+++ b/metron-interface/metron-config/src/app/sensors/sensor-parser-config/sensor-parser-config.component.html
@@ -83,7 +83,7 @@
                     </div>
                 </div>
 
-                <div class="form-group" *ngIf="isGrokParser(sensorParserConfig)">
+                <div class="form-group" *ngIf="isGrokParser(sensorParserConfig)" data-qe-id="timestamp-field">
                     <label attr.for="timestampField">TIMESTAMP *</label>
                     <input type="text" class="form-control" name="timestampField" formControlName="timestampField" [(ngModel)]="sensorParserConfig.timestampField">
                     <label *ngIf="!sensorParserConfig.timestampField"><span class="warning-text">Field is required. </span></label>

--- a/metron-interface/metron-config/src/app/sensors/sensor-parser-config/sensor-parser-config.component.html
+++ b/metron-interface/metron-config/src/app/sensors/sensor-parser-config/sensor-parser-config.component.html
@@ -71,7 +71,7 @@
                 </div>
 
                 <div class="form-group" [ngClass]="{'panel-selected': showGrokValidator }" *ngIf="isGrokParser(sensorParserConfig)" >
-                    <label attr.for="grokStatement">GROK STATEMENT</label>
+                    <label attr.for="grokStatement">GROK STATEMENT *</label>
                     <div  class="input-group" [attr.disabled]="!sensorNameValid || !parserClassValid">
                         <input type="text" class="form-control" formControlName="grokStatement"  [(ngModel)]="this.grokStatement" readonly>
                         <span class="input-group-btn">
@@ -81,6 +81,12 @@
                             </button>
                         </span>
                     </div>
+                </div>
+
+                <div class="form-group" *ngIf="isGrokParser(sensorParserConfig)">
+                    <label attr.for="timestampField">TIMESTAMP *</label>
+                    <input type="text" class="form-control" name="timestampField" formControlName="timestampField" [(ngModel)]="sensorParserConfig.timestampField">
+                    <label *ngIf="!sensorParserConfig.timestampField"><span class="warning-text">Field is required. </span></label>
                 </div>
 
                 <div class="form-group" [ngClass]="{'panel-selected': showFieldSchema }" >

--- a/metron-interface/metron-config/src/app/sensors/sensor-parser-config/sensor-parser-config.component.spec.ts
+++ b/metron-interface/metron-config/src/app/sensors/sensor-parser-config/sensor-parser-config.component.spec.ts
@@ -583,7 +583,7 @@ describe('Component: SensorParserConfig', () => {
     );
     component.createForms();
 
-    expect(Object.keys(component.sensorConfigForm.controls).length).toEqual(16);
+    expect(Object.keys(component.sensorConfigForm.controls).length).toEqual(17);
     expect(
       Object.keys(component.transformsValidationForm.controls).length
     ).toEqual(2);

--- a/metron-interface/metron-config/src/app/sensors/sensor-parser-config/sensor-parser-config.component.spec.ts
+++ b/metron-interface/metron-config/src/app/sensors/sensor-parser-config/sensor-parser-config.component.spec.ts
@@ -1118,4 +1118,21 @@ describe('Component: SensorParserConfig', () => {
 
     expect(component.showAdvancedParserConfiguration).toEqual(false);
   }));
+
+  it('should be timestamp by default', () => {
+    expect(component.sensorParserConfig.timestampField).toEqual('timestamp');
+  });
+
+  it('should be invalid if timestamp field is empty', () => {
+    component.sensorNameValid = true;
+    component.kafkaTopicValid = true;
+    component.parserClassValid = true;
+    component.grokStatement = 'grokStatement';
+    component.sensorParserConfig = new SensorParserConfig();
+    component.sensorParserConfig.parserClassName = 'org.apache.metron.parsers.GrokParser'
+    component.sensorParserConfig.timestampField = '';
+    expect(component.isConfigValid()).toEqual(false);
+    component.sensorParserConfig.timestampField = 'timestamp';
+    expect(component.isConfigValid()).toEqual(true);
+  });
 });

--- a/metron-interface/metron-config/src/app/sensors/sensor-parser-config/sensor-parser-config.component.ts
+++ b/metron-interface/metron-config/src/app/sensors/sensor-parser-config/sensor-parser-config.component.ts
@@ -210,6 +210,10 @@ export class SensorParserConfigComponent implements OnInit {
       this.sensorParserConfig.parserClassName,
       Validators.required
     );
+    group['timestampField'] = new FormControl(
+      this.sensorParserConfig.timestampField,
+      Validators.required
+    );
     group['grokStatement'] = new FormControl(this.grokStatement);
     group['transforms'] = new FormControl(
       this.sensorParserConfig['transforms']
@@ -333,7 +337,8 @@ export class SensorParserConfigComponent implements OnInit {
     return this.sensorNameValid &&
             this.kafkaTopicValid &&
             this.parserClassValid &&
-            (!isGrokParser || this.isGrokStatementValid());
+            (!isGrokParser || this.isGrokStatementValid()) &&
+            (!isGrokParser || !!this.sensorParserConfig.timestampField);
   }
 
   getKafkaStatus() {
@@ -572,4 +577,6 @@ export class SensorParserConfigComponent implements OnInit {
   onAdvancedConfigFormClose(): void {
     this.showAdvancedParserConfiguration = false;
   }
+
+  log(v) {console.log(v)}
 }

--- a/metron-interface/metron-config/src/app/sensors/sensor-parser-config/sensor-parser-config.component.ts
+++ b/metron-interface/metron-config/src/app/sensors/sensor-parser-config/sensor-parser-config.component.ts
@@ -329,7 +329,7 @@ export class SensorParserConfigComponent implements OnInit {
   }
 
   isGrokStatementValid(): boolean {
-    return this.grokStatement !== undefined && Object.keys(this.grokStatement).length > 0;
+    return !!this.grokStatement;
   }
 
   isConfigValid() {
@@ -469,13 +469,7 @@ export class SensorParserConfigComponent implements OnInit {
   }
 
   isGrokParser(sensorParserConfig: SensorParserConfig): boolean {
-    if (sensorParserConfig && sensorParserConfig.parserClassName) {
-      return (
-        sensorParserConfig.parserClassName ===
-        'org.apache.metron.parsers.GrokParser'
-      );
-    }
-    return false;
+    return sensorParserConfig && sensorParserConfig.parserClassName === 'org.apache.metron.parsers.GrokParser';
   }
 
   getTransformationCount(): number {
@@ -577,6 +571,4 @@ export class SensorParserConfigComponent implements OnInit {
   onAdvancedConfigFormClose(): void {
     this.showAdvancedParserConfiguration = false;
   }
-
-  log(v) {console.log(v)}
 }


### PR DESCRIPTION
## Contributor Comments

Link to the original ASF Jira: https://issues.apache.org/jira/browse/METRON-2092

Issue
====

> A Grok parser requires a timestampField attribute. Currently the UI allows the user to add a new Grok parser without any timestampField. When you start the parser, nothing happens and there are no error messages.

> The UI should either default the timestampField attribute to timestamp or pop up an error message when the user tries to save a grok parser with no timestampField attribute.

Testing
=====

1. Go to metron config
2. Try to add a new sensor which has a Grok parser
3. Make sure the TIMESTAMP field is there
4. It should have the default value `timestamp`
5. Try to remove it completely and save the sensor (you should not be able)
6. Try to save when it has a value `timestamp` or something else (it should work)

It should be the same in case of editing the sensor. If there's no timestamp field value, there should be an error message below the input field.



## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [X] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [X] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [X] Have you included steps or a guide to how the change may be verified and tested manually?
- [X] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [X] Have you written or updated unit tests and or integration tests to verify your changes?
- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [X] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [X] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
