### PR TITLE
METRON-2093: Metron RC check script is outdated

### DIFF
--- a/dev-utilities/release-utils/metron-rc-check
+++ b/dev-utilities/release-utils/metron-rc-check
@@ -30,7 +30,9 @@ function help {
   echo " "
 }
 
-METRON_DIST="https://dist.apache.org/repos/dist/dev/metron/"
+APACHE_REPO="https://dist.apache.org/repos/dist/"
+METRON_DIST=${APACHE_REPO}"dev/metron/"
+METRON_KEYS=${APACHE_REPO}"release/metron/KEYS"
 # print help, if the user just runs this without any args
 if [ "$#" -eq 0 ]; then
     help
@@ -156,14 +158,13 @@ if [ ! -d "$WORK" ]; then
 fi
 echo "Working directory $WORK"
 
-KEYS="$METRON_RC_DIST/KEYS"
-METRON_ASSEMBLY="$METRON_RC_DIST/apache-metron-$METRON_VERSION-$RC.tar.gz"
+METRON_ASSEMBLY="$METRON_RC_DIST/apache-metron_$METRON_VERSION-$RC.tar.gz"
 METRON_ASSEMBLY_SIG="$METRON_ASSEMBLY.asc"
 
 
-echo "Downloading $KEYS"
-if ! wget -P "$WORK" "$KEYS" ; then
-  echo "[ERROR] Failed to download $KEYS"
+echo "Downloading $METRON_KEYS"
+if ! wget -P "$WORK" "$METRON_KEYS" ; then
+  echo "[ERROR] Failed to download $METRON_KEYS"
   exit 1
 fi
 
@@ -206,7 +207,7 @@ if ! gpg --import KEYS ; then
 fi
 
 echo "Verifying Metron Assembly"
-if ! gpg --verify ./"apache-metron-$METRON_VERSION-$RC.tar.gz.asc" "apache-metron-$METRON_VERSION-$RC.tar.gz" ; then
+if ! gpg --verify ./"apache-metron_$METRON_VERSION-$RC.tar.gz.asc" "apache-metron_$METRON_VERSION-$RC.tar.gz" ; then
   echo "[ERROR] failed to verify Metron Assembly"
   exit 1
 fi
@@ -227,7 +228,7 @@ if [ -n "$BRO" ]; then
 fi
 
 echo "Unpacking Assemblies"
-if ! tar -xzf "apache-metron-$METRON_VERSION-$RC.tar.gz" ; then
+if ! tar -xzf "apache-metron_$METRON_VERSION-$RC.tar.gz" ; then
   echo "[ERROR] failed to unpack Metron Assembly"
   exit 1
 fi

--- a/dev-utilities/release-utils/metron-rc-check
+++ b/dev-utilities/release-utils/metron-rc-check
@@ -239,7 +239,7 @@ read -p "  run test suite [install, unit tests, integration tests, ui tests, lic
 echo
 DID_BUILD=0
 if [[ $REPLY =~ ^[Yy]$ ]]; then
-  cd "apache-metron-$METRON_VERSION-$RC" || exit 1
+  cd "apache-metron_${METRON_VERSION}-$RC" || exit 1
   if ! mvn -q -T 2C -DskipTests clean install  ; then
     echo "[ERROR] failed to mvn install metron"
     exit 1
@@ -274,7 +274,7 @@ echo ""
 read -p "  run vagrant full_dev? [yN] " -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]; then
-  cd "$WORK/apache-metron-$METRON_VERSION-$RC/metron-deployment/development/centos6" || exit 1
+  cd "$WORK/apache-metron_${METRON_VERSION}-$RC/metron-deployment/development/centos6" || exit 1
   if [[ ${DID_BUILD} -ne 1 ]]; then
     vagrant up
   else

--- a/dev-utilities/release-utils/prepare-release-candidate
+++ b/dev-utilities/release-utils/prepare-release-candidate
@@ -299,7 +299,7 @@ if [[ $? -ne 0 ]]; then
   exit 1
 fi
 
-printf "Extracting LICENSE, NOTICE, and KEYS from tarball\n" # Only pull from core
+printf "Extracting LICENSE and NOTICE from tarball\n" # Only pull from core
 cd ${ART_DIR}
 
 if [ "${CHOSEN_REPO}" = "${BRO_PLUGIN_REPO_NAME}" ]; then
@@ -311,7 +311,6 @@ fi
 
 # TODO figure out what to do for bro repo here. The KEYS file only needs to live in the /dist root, rather than in each sub repo.
 # Should we have a separate process for adding to the KEYS file without doing a Metron release?
-#tar --strip-components=1 -zxvf "${ARTIFACT}.tar.gz" "${ARTIFACT}/KEYS"
 tar --strip-components=1 -zxvf "${ARTIFACT}.tar.gz" "${ARTIFACT}/NOTICE"
 
 # Add the directory and commit to subversion


### PR DESCRIPTION
## Contributor Comments
Updates the RC script, and adjusts rc prep re: KEYS file

To test, run against the latest RC
```
./dev-utilities/release-utils/metron-rc-check -v=0.7.1 -c=1
```

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
