### PR TITLE
METRON-2123: Expand Stellar JOIN to work on all Iterables

### DIFF
--- a/metron-stellar/stellar-common/README.md
+++ b/metron-stellar/stellar-common/README.md
@@ -704,7 +704,7 @@ Where:
 ### `JOIN`
   * Description: Joins the non-null items in the iterable as strings with the specified delimiter. Null items are dropped.
   * Input:
-    * iterable - iterable (e.g. List, LinkedHashSet, etc.) of items treated as strings
+    * iterable - Java iterable (e.g. List, LinkedHashSet, etc.) of items treated as strings
     * delim - String delimiter
   * Returns: String
 

--- a/metron-stellar/stellar-common/README.md
+++ b/metron-stellar/stellar-common/README.md
@@ -702,9 +702,9 @@ Where:
   * Returns: True if the string is a valid URL and false if otherwise.
 
 ### `JOIN`
-  * Description: Joins the components in the list of strings with the specified delimiter.
+  * Description: Joins the non-null items in the iterable as strings with the specified delimiter. Null items are dropped.
   * Input:
-    * list - List of strings
+    * iterable - iterable (e.g. List, LinkedHashSet, etc.) of items treated as strings
     * delim - String delimiter
   * Returns: String
 

--- a/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/dsl/functions/StringFunctions.java
+++ b/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/dsl/functions/StringFunctions.java
@@ -132,7 +132,7 @@ public class StringFunctions {
 
   @Stellar( name="JOIN"
           , description="Joins the non-null items in the iterable as strings with the specified delimiter. Null items are dropped."
-          , params = { "iterable - iterable (e.g. List, LinkedHashSet, etc.) of items treated as strings", "delim - String delimiter"}
+          , params = { "iterable - Java iterable (e.g. List, LinkedHashSet, etc.) of items treated as strings", "delim - String delimiter"}
           , returns = "String"
           )
   public static class JoinFunction extends BaseStellarFunction {

--- a/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/dsl/functions/StringFunctions.java
+++ b/metron-stellar/stellar-common/src/main/java/org/apache/metron/stellar/dsl/functions/StringFunctions.java
@@ -19,22 +19,20 @@
 package org.apache.metron.stellar.dsl.functions;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.metron.stellar.common.utils.JSONUtils;
-import org.apache.metron.stellar.dsl.BaseStellarFunction;
-import org.apache.metron.stellar.dsl.ParseException;
-import org.apache.metron.stellar.dsl.Stellar;
-import org.apache.metron.stellar.common.utils.ConversionUtils;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.metron.stellar.common.utils.ConversionUtils;
+import org.apache.metron.stellar.common.utils.JSONUtils;
+import org.apache.metron.stellar.dsl.BaseStellarFunction;
+import org.apache.metron.stellar.dsl.ParseException;
+import org.apache.metron.stellar.dsl.Stellar;
 
 public class StringFunctions {
 
@@ -133,15 +131,15 @@ public class StringFunctions {
   }
 
   @Stellar( name="JOIN"
-          , description="Joins the components in the list of strings with the specified delimiter."
-          , params = { "list - List of strings", "delim - String delimiter"}
+          , description="Joins the non-null items in the iterable as strings with the specified delimiter. Null items are dropped."
+          , params = { "iterable - iterable (e.g. List, LinkedHashSet, etc.) of items treated as strings", "delim - String delimiter"}
           , returns = "String"
           )
   public static class JoinFunction extends BaseStellarFunction {
     @Override
     @SuppressWarnings("unchecked")
     public Object apply(List<Object> args) {
-      List<Object> arg1 = (List<Object>) args.get(0);
+      Iterable<Object> arg1 = (Iterable<Object>) args.get(0);
       String delim = (String) args.get(1);
       return Joiner.on(delim).join(Iterables.filter(arg1, x -> x != null));
     }

--- a/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/dsl/functions/BasicStellarTest.java
+++ b/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/dsl/functions/BasicStellarTest.java
@@ -620,6 +620,8 @@ public class BasicStellarTest {
   public void testJoin() {
     String query = "JOIN( [ TO_UPPER(TRIM(foo)), 'bar' ], ',')";
     Assert.assertEquals("CASEY,bar", run(query, ImmutableMap.of("foo", "casey ")));
+    query = "JOIN( SET_INIT( [ 1, 2, 'buckle', 'my', 'shoe', 3 ] ), ',')";
+    Assert.assertEquals("1,2,buckle,my,shoe,3", run(query, new HashMap<>()));
   }
 
   @Test


### PR DESCRIPTION
## Contributor Comments

https://issues.apache.org/jira/browse/METRON-2123

## Pull Request Checklist

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- n/a If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- n/a Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

- n/a Have you ensured that any documentation diagrams have been updated, along with their source files, using [draw.io](https://www.draw.io/)? See [Metron Development Guidelines](https://cwiki.apache.org/confluence/display/METRON/Development+Guidelines) for instructions.

