### PR TITLE
METRON-2145 Clarify RPM build documentation

### DIFF
--- a/metron-deployment/packaging/docker/deb-docker/README.md
+++ b/metron-deployment/packaging/docker/deb-docker/README.md
@@ -28,7 +28,7 @@ If you are installing Metron using Ambari, these packages are necessary prerequi
 
 ### Quick Start
 
-1. Execute the following command from the project's root directory.
+1. Execute the following command from the project's root directory. This will build/package **all** of Metron prior to building the DEBs. See [Build Packages](#build-packages) below to only build the DEBs.
     ```
     mvn clean package -DskipTests -Pbuild-debs
     ```

--- a/metron-deployment/packaging/docker/rpm-docker/README.md
+++ b/metron-deployment/packaging/docker/rpm-docker/README.md
@@ -26,7 +26,7 @@ If you are installing Metron using Ambari, these packages are necessary prerequi
 
 ### Quick Start
 
-1. Execute the following command from the project's root directory.
+1. Execute the following command from the project's root directory. This will build/package **all** of Metron prior to building the RPMs. See [Build Packages](#build-packages) below to only build the RPMs.
     ```
     mvn clean package -DskipTests -Pbuild-rpms
     ```
@@ -41,7 +41,7 @@ If you are installing Metron using Ambari, these packages are necessary prerequi
 If Metron has already been built, just the RPM packages can be built by executing the following commands.
   ```
   cd metron-deployment
-  mvn clean package -Pbuild-debs
+  mvn clean package -Pbuild-rpms
   ```
 
 ### How does this work?


### PR DESCRIPTION
## Contributor Comments

https://issues.apache.org/jira/browse/METRON-2145

The context for building **only** the RPMs comes after the Quick Start, so when looking for a quick reference to building only the RPMs you'll unwittingly end up building all of Metron first as well. Added a brief note before the command to make that more apparent. Also fixed a typo for the rpm profile name in the build packages section.


## Pull Request Checklist

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- n/a Have you written or updated unit tests and or integration tests to verify your changes?
- n/a If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- n/a Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

- n/a Have you ensured that any documentation diagrams have been updated, along with their source files, using [draw.io](https://www.draw.io/)? See [Metron Development Guidelines](https://cwiki.apache.org/confluence/display/METRON/Development+Guidelines) for instructions.

