### PR TITLE
METRON-2152 Add debug logging for when sensor batchTimeout exceeds the calculated maximum

### DIFF
--- a/metron-platform/metron-writer/metron-writer-common/src/main/java/org/apache/metron/writer/BatchTimeoutPolicy.java
+++ b/metron-platform/metron-writer/metron-writer-common/src/main/java/org/apache/metron/writer/BatchTimeoutPolicy.java
@@ -100,7 +100,7 @@ public class BatchTimeoutPolicy<MESSAGE_T> implements FlushPolicy<MESSAGE_T> {
   protected long getBatchTimeout(String sensorType, WriterConfiguration configurations) {
     int batchTimeoutSecs = configurations.getBatchTimeout(sensorType);
     if (batchTimeoutSecs <= 0 || batchTimeoutSecs > maxBatchTimeout) {
-      LOG.debug("The configured batch timeout '{}' is <=0 or > the maximum allowable batch timeout '{}'. Setting the batch timeout to the maximum allowable.", batchTimeoutSecs, maxBatchTimeout);
+      LOG.debug("The configured batch timeout '{}' for sensor type '{}' is <=0 or > the maximum allowable batch timeout '{}'. Setting the batch timeout to the maximum allowable.", batchTimeoutSecs, sensorType, maxBatchTimeout);
       batchTimeoutSecs = maxBatchTimeout;
     }
     return TimeUnit.SECONDS.toMillis(batchTimeoutSecs);

--- a/metron-platform/metron-writer/metron-writer-common/src/main/java/org/apache/metron/writer/BatchTimeoutPolicy.java
+++ b/metron-platform/metron-writer/metron-writer-common/src/main/java/org/apache/metron/writer/BatchTimeoutPolicy.java
@@ -100,6 +100,7 @@ public class BatchTimeoutPolicy<MESSAGE_T> implements FlushPolicy<MESSAGE_T> {
   protected long getBatchTimeout(String sensorType, WriterConfiguration configurations) {
     int batchTimeoutSecs = configurations.getBatchTimeout(sensorType);
     if (batchTimeoutSecs <= 0 || batchTimeoutSecs > maxBatchTimeout) {
+      LOG.debug("The configured batch timeout '{}' is <=0 or > the maximum allowable batch timeout '{}'. Setting the batch timeout to the maximum allowable.", batchTimeoutSecs, maxBatchTimeout);
       batchTimeoutSecs = maxBatchTimeout;
     }
     return TimeUnit.SECONDS.toMillis(batchTimeoutSecs);


### PR DESCRIPTION
## Contributor Comments

https://issues.apache.org/jira/browse/METRON-2152

This enables some additional debug logging.

**Testing**

- In the Storm UI, click on the random_access_indexing topology.
- Click "Change Log Level"
- Add a `org.apache.metron.writer` logger set to DEBUG with timeout 5000.
- Pull down the latest ZK configs
    ```
    $METRON_HOME/bin/zk_load_configs.sh -m PULL -o ${METRON_HOME}/config/zookeeper -z $ZOOKEEPER -f
    ```
- Update the bro config for ES indexing at `$METRON_HOME/config/zookeeper/indexing/bro.json`. Add a batchTimeout of 15 to elasticsearch, e.g.
    ```
    "elasticsearch" : {
        "index": "bro",
        "batchSize": 5,
        "batchTimeout": 15,
        "enabled" : true
    },
    ```
- Push the changes back up to ZK
    ```
    $METRON_HOME/bin/zk_load_configs.sh -m PUSH -i $METRON_HOME/config/zookeeper/ -z $ZOOKEEPER
    ```
- Open the Storm worker logs for random_access_indexing. You should see the following in the logs:
    ```
    The configured batch timeout '15' for sensor type 'bro' is <=0 or > the maximum allowable batch timeout '14'. Setting the batch timeout to the maximum allowable.
    ```

## Pull Request Checklist

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- n/a Have you written or updated unit tests and or integration tests to verify your changes?
- n/a If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- n/a Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

- n/a Have you ensured that any documentation diagrams have been updated, along with their source files, using [draw.io](https://www.draw.io/)? See [Metron Development Guidelines](https://cwiki.apache.org/confluence/display/METRON/Development+Guidelines) for instructions.
