### PR TITLE
METRON-2150: [UI] User not able to filter by multiple values of the same field on Alerts UI

### DIFF
--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/alerts-list.component.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/alerts-list.component.ts
@@ -296,8 +296,6 @@ export class AlertsListComponent implements OnInit, OnDestroy {
     if (timeRangeFilter.value === ALL_TIME) {
       this.queryBuilder.removeFilter(timeRangeFilter.field);
     } else {
-      // only one timerange filter allowed
-      this.queryBuilder.removeFilter(timeRangeFilter.field);
       this.queryBuilder.addOrUpdateFilter(timeRangeFilter);
     }
   }

--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/alerts-list.component.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/alerts-list.component.ts
@@ -296,6 +296,8 @@ export class AlertsListComponent implements OnInit, OnDestroy {
     if (timeRangeFilter.value === ALL_TIME) {
       this.queryBuilder.removeFilter(timeRangeFilter.field);
     } else {
+      // only one timerange filter allowed
+      this.queryBuilder.removeFilter(timeRangeFilter.field);
       this.queryBuilder.addOrUpdateFilter(timeRangeFilter);
     }
   }

--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/alerts-list.component.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/alerts-list.component.ts
@@ -228,8 +228,8 @@ export class AlertsListComponent implements OnInit, OnDestroy {
     this.search();
   }
 
-  onSearch($event) {
-    this.queryBuilder.setSearch($event);
+  onSearch(query: string) {
+    this.queryBuilder.setSearch(query);
     this.timeStampfilterPresent = this.queryBuilder.isTimeStampFieldPresent();
     this.search();
     return false;

--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/query-builder.spec.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/query-builder.spec.ts
@@ -73,6 +73,16 @@ describe('query-builder', () => {
       );
   });
 
+  it('should properly parse excluding filters event with wildcard and whitespaces', () => {
+    const queryBuilder = new QueryBuilder();
+
+    queryBuilder.setSearch('* -alert_status:(RESOLVE OR DISMISS)');
+
+    expect(queryBuilder.searchRequest.query).toBe(
+      '-(alert_status:(RESOLVE OR DISMISS) OR metron_alert.alert_status:(RESOLVE OR DISMISS))'
+      );
+  });
+
   it('should remove wildcard from an excluding filter', () => {
     const queryBuilder = new QueryBuilder();
 
@@ -95,6 +105,16 @@ describe('query-builder', () => {
   it('should escape : chars in ElasticSearch field names', () => {
     const queryBuilder = new QueryBuilder();
 
+    queryBuilder.setSearch('source:type:bro');
+
+    expect(queryBuilder.searchRequest.query).toBe('(source\\:type:bro OR metron_alert.source\\:type:bro)');
+  });
+
+  it('should not multiply escaping in field name', () => {
+    const queryBuilder = new QueryBuilder();
+
+    queryBuilder.setSearch('source:type:bro');
+    queryBuilder.setSearch('source:type:bro');
     queryBuilder.setSearch('source:type:bro');
 
     expect(queryBuilder.searchRequest.query).toBe('(source\\:type:bro OR metron_alert.source\\:type:bro)');

--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/query-builder.spec.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/query-builder.spec.ts
@@ -15,9 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { QueryBuilder } from "./query-builder";
+import { QueryBuilder } from './query-builder';
 
-describe('query-builder', () => {
+fdescribe('query-builder', () => {
 
   it('should be able to handle multiple filters', () => {
     const queryBuilder = new QueryBuilder();
@@ -45,7 +45,27 @@ describe('query-builder', () => {
     queryBuilder.setSearch('alert_status:(RESOLVE OR DISMISS)');
 
     expect(queryBuilder.searchRequest.query).toBe(
-      '(alert_status:\\(RESOLVE\\ OR\\ DISMISS\\) OR metron_alert.alert_status:\\(RESOLVE\\ OR\\ DISMISS\\))'
+      '(alert_status:(RESOLVE OR DISMISS) OR metron_alert.alert_status:(RESOLVE OR DISMISS))'
+      );
+  });
+
+  it('should trim whitespace', () => {
+    const queryBuilder = new QueryBuilder();
+
+    queryBuilder.setSearch(' alert_status:(RESOLVE OR DISMISS) ');
+
+    expect(queryBuilder.searchRequest.query).toBe(
+      '(alert_status:(RESOLVE OR DISMISS) OR metron_alert.alert_status:(RESOLVE OR DISMISS))'
+      );
+  });
+
+  it('should remove wildcard', () => {
+    const queryBuilder = new QueryBuilder();
+
+    queryBuilder.setSearch('* -alert_status:(RESOLVE OR DISMISS)');
+
+    expect(queryBuilder.searchRequest.query).toBe(
+      '(-alert_status:(RESOLVE OR DISMISS) OR -metron_alert.alert_status:(RESOLVE OR DISMISS))'
       );
   });
 

--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/query-builder.spec.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/query-builder.spec.ts
@@ -99,7 +99,8 @@ describe('query-builder', () => {
     queryBuilder.addOrUpdateFilter(new Filter(TIMESTAMP_FIELD_NAME, '[1552863600000 TO 1552950000000]'));
     queryBuilder.addOrUpdateFilter(new Filter(TIMESTAMP_FIELD_NAME, '[1552863700000 TO 1552960000000]'));
 
-    expect(queryBuilder.generateSelect()).toBe('(timestamp:[1552863700000 TO 1552960000000] OR metron_alert.timestamp:[1552863700000 TO 1552960000000])');
+    expect(queryBuilder.generateSelect()).toBe('(timestamp:[1552863700000 TO 1552960000000] OR ' +
+      'metron_alert.timestamp:[1552863700000 TO 1552960000000])');
   });
 
   it('should escape : chars in ElasticSearch field names', () => {
@@ -108,6 +109,15 @@ describe('query-builder', () => {
     queryBuilder.setSearch('source:type:bro');
 
     expect(queryBuilder.searchRequest.query).toBe('(source\\:type:bro OR metron_alert.source\\:type:bro)');
+  });
+
+  it('should escape ALL : chars in ElasticSearch field names', () => {
+    const queryBuilder = new QueryBuilder();
+
+    queryBuilder.setSearch('enrichments:geo:ip_dst_addr:country:US');
+
+    expect(queryBuilder.searchRequest.query).toBe('(enrichments\\:geo\\:ip_dst_addr\\:country:US ' +
+      'OR metron_alert.enrichments\\:geo\\:ip_dst_addr\\:country:US)');
   });
 
   it('should not multiply escaping in field name', () => {

--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/query-builder.spec.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/query-builder.spec.ts
@@ -16,8 +16,12 @@
  * limitations under the License.
  */
 import { QueryBuilder } from './query-builder';
+import { Filter } from 'app/model/filter';
+import { TIMESTAMP_FIELD_NAME } from '../../utils/constants';
+import { Utils } from 'app/utils/utils';
 
-fdescribe('query-builder', () => {
+
+describe('query-builder', () => {
 
   it('should be able to handle multiple filters', () => {
     const queryBuilder = new QueryBuilder();
@@ -67,6 +71,23 @@ fdescribe('query-builder', () => {
     expect(queryBuilder.searchRequest.query).toBe(
       '(-alert_status:(RESOLVE OR DISMISS) OR -metron_alert.alert_status:(RESOLVE OR DISMISS))'
       );
+  });
+
+  it('should allow only one timerange filter', () => {
+    const queryBuilder = new QueryBuilder();
+
+    queryBuilder.addOrUpdateFilter(new Filter(TIMESTAMP_FIELD_NAME, '[1552863600000 TO 1552950000000]'));
+    queryBuilder.addOrUpdateFilter(new Filter(TIMESTAMP_FIELD_NAME, '[1552863700000 TO 1552960000000]'));
+
+    expect(queryBuilder.generateSelect()).toBe('(timestamp:[1552863700000 TO 1552960000000] OR metron_alert.timestamp:[1552863700000 TO 1552960000000])');
+  });
+
+  it('should escape : chars in ElasticSearch field names', () => {
+    const queryBuilder = new QueryBuilder();
+
+    queryBuilder.setSearch('source:type:bro');
+
+    expect(queryBuilder.searchRequest.query).toBe('(source\\:type:bro OR metron_alert.source\\:type:bro)');
   });
 
 });

--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/query-builder.spec.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/query-builder.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { QueryBuilder } from "./query-builder";
+
+describe('query-builder', () => {
+
+  it('should be able to handle multiple filters', () => {
+    const queryBuilder = new QueryBuilder();
+
+    queryBuilder.setSearch('alert_status:RESOLVE AND ip_src_addr:0.0.0.0');
+
+    expect(queryBuilder.searchRequest.query).toBe(
+      '(alert_status:RESOLVE OR metron_alert.alert_status:RESOLVE) AND (ip_src_addr:0.0.0.0 OR metron_alert.ip_src_addr:0.0.0.0)'
+      );
+  });
+
+  it('should be able to handle multiple EXCLUDING filters for the same field', () => {
+    const queryBuilder = new QueryBuilder();
+
+    queryBuilder.setSearch('-alert_status:RESOLVE AND -alert_status:DISMISS');
+
+    expect(queryBuilder.searchRequest.query).toBe(
+      '(-alert_status:RESOLVE OR -metron_alert.alert_status:RESOLVE) AND (-alert_status:DISMISS OR -metron_alert.alert_status:DISMISS)'
+      );
+  });
+
+  it('should be able to handle group multiple clauses to a single field, aka. field grouping', () => {
+    const queryBuilder = new QueryBuilder();
+
+    queryBuilder.setSearch('alert_status:(RESOLVE OR DISMISS)');
+
+    expect(queryBuilder.searchRequest.query).toBe(
+      '(alert_status:\\(RESOLVE\\ OR\\ DISMISS\\) OR metron_alert.alert_status:\\(RESOLVE\\ OR\\ DISMISS\\))'
+      );
+  });
+
+});

--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/query-builder.spec.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/query-builder.spec.ts
@@ -39,7 +39,7 @@ describe('query-builder', () => {
     queryBuilder.setSearch('-alert_status:RESOLVE AND -alert_status:DISMISS');
 
     expect(queryBuilder.searchRequest.query).toBe(
-      '(-alert_status:RESOLVE OR -metron_alert.alert_status:RESOLVE) AND (-alert_status:DISMISS OR -metron_alert.alert_status:DISMISS)'
+      '-(alert_status:RESOLVE OR metron_alert.alert_status:RESOLVE) AND -(alert_status:DISMISS OR metron_alert.alert_status:DISMISS)'
       );
   });
 
@@ -66,10 +66,20 @@ describe('query-builder', () => {
   it('should remove wildcard', () => {
     const queryBuilder = new QueryBuilder();
 
+    queryBuilder.setSearch('* alert_status:(RESOLVE OR DISMISS)');
+
+    expect(queryBuilder.searchRequest.query).toBe(
+      '(alert_status:(RESOLVE OR DISMISS) OR metron_alert.alert_status:(RESOLVE OR DISMISS))'
+      );
+  });
+
+  it('should remove wildcard from an excluding filter', () => {
+    const queryBuilder = new QueryBuilder();
+
     queryBuilder.setSearch('* -alert_status:(RESOLVE OR DISMISS)');
 
     expect(queryBuilder.searchRequest.query).toBe(
-      '(-alert_status:(RESOLVE OR DISMISS) OR -metron_alert.alert_status:(RESOLVE OR DISMISS))'
+      '-(alert_status:(RESOLVE OR DISMISS) OR metron_alert.alert_status:(RESOLVE OR DISMISS))'
       );
   });
 

--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/query-builder.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/query-builder.ts
@@ -78,7 +78,7 @@ export class QueryBuilder {
   addOrUpdateFilter(filter: Filter) {
     let existingFilterIndex = -1;
     let existingFilter = this._filters.find((tFilter, index) => {
-      if (tFilter.field === filter.field) {
+      if (filter.equals(tFilter)) {
         existingFilterIndex = index;
         return true;
       }

--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/query-builder.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/query-builder.ts
@@ -152,8 +152,7 @@ export class QueryBuilder {
     this.searchRequest.sort = [sortField];
   }
 
-  private updateFilters(tQuery: string, updateNameTransform = false) {
-    let query = tQuery;
+  private updateFilters(query: string, updateNameTransform = false) {
     this.removeDisplayedFilters();
 
     if (query && query !== '' && query !== '*') {

--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/query-builder.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/query-builder.ts
@@ -158,17 +158,18 @@ export class QueryBuilder {
     if (query && query !== '' && query !== '*') {
       let terms = query.split(' AND ');
       for (let term of terms) {
-        let separatorPos = term.lastIndexOf(':');
-        let field = term.substring(0, separatorPos).replace('\\', '');
+        let [field, value] = term.split(':');
+        field = field.replace(/\*/, '').trim();
         field = updateNameTransform ? ColumnNamesService.getColumnDisplayKey(field) : field;
-        let value = term.substring(separatorPos + 1, term.length);
+        value = value.trim();
+
         this.addOrUpdateFilter(new Filter(field, value));
       }
     }
   }
 
   private removeDisplayedFilters() {
-    for (let i = this._filters.length-1; i >= 0; i--) {
+    for (let i = this._filters.length - 1; i >= 0; i--) {
       if (this._filters[i].display) {
         this._filters.splice(i, 1);
       }

--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/query-builder.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/query-builder.ts
@@ -168,7 +168,6 @@ export class QueryBuilder {
       let terms = query.split(' AND ');
       for (let term of terms) {
         let [field, value] = this.splitTerm(term);
-        field = field.replace(/\*/, '').replace(/\:/, '\\:').trim();
         field = updateNameTransform ? ColumnNamesService.getColumnDisplayKey(field) : field;
         value = value.trim();
 

--- a/metron-interface/metron-alerts/src/app/model/filter.spec.ts
+++ b/metron-interface/metron-alerts/src/app/model/filter.spec.ts
@@ -95,4 +95,14 @@ describe('model.Filter', () => {
     const filter = new Filter('-testField', 'someValue', false);
     expect(filter.getQueryString()).toBe('-(testField:someValue OR metron_alert.testField:someValue)');
   });
+
+  it('toJSON should return with a JSON representation of a Filter', () => {
+    const filter = new Filter('testField', 'someValue', false);
+    expect(filter.toJSON()).toEqual({ field: 'testField', value: 'someValue', display: false });
+  });
+
+  it('toJSON should return with a JSON representation of a Filter, including exclude operator in field value', () => {
+    const filter = new Filter('-testField', 'someValue', false);
+    expect(filter.toJSON()).toEqual({ field: '-testField', value: 'someValue', display: false });
+  });
 });

--- a/metron-interface/metron-alerts/src/app/model/filter.spec.ts
+++ b/metron-interface/metron-alerts/src/app/model/filter.spec.ts
@@ -91,4 +91,8 @@ describe('model.Filter', () => {
     });
   })
 
+  it('excluding filtering', () => {
+    const filter = new Filter('-testField', 'someValue', false);
+    expect(filter.getQueryString()).toBe('(-testField:someValue OR -metron_alert.testField:someValue)');
+  });
 });

--- a/metron-interface/metron-alerts/src/app/model/filter.spec.ts
+++ b/metron-interface/metron-alerts/src/app/model/filter.spec.ts
@@ -51,8 +51,8 @@ describe('model.Filter', () => {
 
   it('getQueryString for time range filter for display', () => {
     const filter = new Filter(TIMESTAMP_FIELD_NAME, '[1552863600000 TO 1552950000000]', true);
-    expect(filter.getQueryString()).toBe('(timestamp:\\[1552863600000\\ TO\\ 1552950000000\\] OR ' +
-      'metron_alert.timestamp:\\[1552863600000\\ TO\\ 1552950000000\\])');
+    expect(filter.getQueryString()).toBe('(timestamp:[1552863600000 TO 1552950000000] OR ' +
+      'metron_alert.timestamp:[1552863600000 TO 1552950000000])');
   });
 
   /**

--- a/metron-interface/metron-alerts/src/app/model/filter.spec.ts
+++ b/metron-interface/metron-alerts/src/app/model/filter.spec.ts
@@ -67,4 +67,28 @@ describe('model.Filter', () => {
     filter.getQueryString();
     expect(Utils.timeRangeToDateObj).toHaveBeenCalledWith(timeRange);
   });
+
+  describe('equal function', () => {
+    it('should return false if field not equals', () => {
+      const filterA = new Filter('testField', 'someValue', false);
+      const filterB = new Filter('otherField', 'someValue', false);
+
+      expect(filterA.equals(filterB)).toBe(false);
+    });
+
+    it('should return false if value not equals', () => {
+      const filterA = new Filter('testField', 'someValue', false);
+      const filterB = new Filter('testField', 'otherValue', false);
+
+      expect(filterA.equals(filterB)).toBe(false);
+    });
+
+    it('should return true if both field and value are equals', () => {
+      const filterA = new Filter('testField', 'someValue', false);
+      const filterB = new Filter('testField', 'someValue', false);
+
+      expect(filterA.equals(filterB)).toBe(true);
+    });
+  })
+
 });

--- a/metron-interface/metron-alerts/src/app/model/filter.spec.ts
+++ b/metron-interface/metron-alerts/src/app/model/filter.spec.ts
@@ -93,6 +93,6 @@ describe('model.Filter', () => {
 
   it('excluding filtering', () => {
     const filter = new Filter('-testField', 'someValue', false);
-    expect(filter.getQueryString()).toBe('(-testField:someValue OR -metron_alert.testField:someValue)');
+    expect(filter.getQueryString()).toBe('-(testField:someValue OR metron_alert.testField:someValue)');
   });
 });

--- a/metron-interface/metron-alerts/src/app/model/filter.ts
+++ b/metron-interface/metron-alerts/src/app/model/filter.ts
@@ -71,4 +71,8 @@ export class Filter {
     return '(' + Utils.escapeESField(field) + ':' +  value  + ' OR ' +
         Utils.escapeESField('metron_alert.' + field) + ':' +  value + ')';
   }
+
+  equals(filter: Filter): boolean {
+    return this.field === filter.field && this.value === filter.value;
+  }
 }

--- a/metron-interface/metron-alerts/src/app/model/filter.ts
+++ b/metron-interface/metron-alerts/src/app/model/filter.ts
@@ -94,7 +94,7 @@ export class Filter {
   }
 
   private escapingESSpearators(field: string): string {
-    return field.replace(/\:/, '\\:');
+    return field.replace(/\:/g, '\\:');
   }
 
   private operatorToAdd() {

--- a/metron-interface/metron-alerts/src/app/model/filter.ts
+++ b/metron-interface/metron-alerts/src/app/model/filter.ts
@@ -44,16 +44,16 @@ export class Filter {
   getQueryString(): string {
     if (this.field === 'guid') {
       let valueWithQuote = '\"' + this.value + '\"';
-      return this.createNestedQueryWithoutValueEscaping(this.field, valueWithQuote);
+      return this.createNestedQuery(this.field, valueWithQuote);
     }
 
     if (this.field === TIMESTAMP_FIELD_NAME && !this.display) {
       this.dateFilterValue = Utils.timeRangeToDateObj(this.value);
       if (this.dateFilterValue !== null && this.dateFilterValue.toDate !== null) {
-        return this.createNestedQueryWithoutValueEscaping(this.field,
+        return this.createNestedQuery(this.field,
             '[' + this.dateFilterValue.fromDate + ' TO ' + this.dateFilterValue.toDate + ']');
       } else {
-        return this.createNestedQueryWithoutValueEscaping(this.field,  this.value);
+        return this.createNestedQuery(this.field,  this.value);
       }
     }
 
@@ -61,15 +61,7 @@ export class Filter {
   }
 
   private createNestedQuery(field: string, value: string): string {
-
-    return '(' + Utils.escapeESField(field) + ':' +  Utils.escapeESValue(value)  + ' OR ' +
-                Utils.escapeESField(this.addPrefix('metron_alert', field)) + ':' +  Utils.escapeESValue(value) + ')';
-  }
-
-  private createNestedQueryWithoutValueEscaping(field: string, value: string): string {
-
-    return '(' + Utils.escapeESField(field) + ':' +  value  + ' OR ' +
-        Utils.escapeESField(this.addPrefix('metron_alert', field)) + ':' +  value + ')';
+    return '(' + field + ':' +  value  + ' OR ' + this.addPrefix('metron_alert', field) + ':' + value + ')';
   }
 
   private addPrefix(prefix: string, field: string): string {

--- a/metron-interface/metron-alerts/src/app/model/filter.ts
+++ b/metron-interface/metron-alerts/src/app/model/filter.ts
@@ -49,7 +49,7 @@ export class Filter {
   }
 
   constructor(field: string, value: string, display = true) {
-    const { clearedField, isExcluding } = this.parseFieldString(field);
+    const { clearedField, isExcluding } = this.parseAndClearField(field);
 
     this.value = value;
     this.display = display;
@@ -58,9 +58,11 @@ export class Filter {
     this.isExcluding = isExcluding;
   }
 
-  private parseFieldString(field: string): { clearedField: string, isExcluding: boolean } {
-    const isExcluding = this.excludeOperatorRxp.test(field);
-    const clearedField = field.replace(this.excludeOperatorRxp, '');
+  private parseAndClearField(field: string): { clearedField: string, isExcluding: boolean } {
+    field = field.replace(/\*/, ''); // removing wildcard caracter
+    field = field.trim(); // removing whitespaces
+    const isExcluding = this.excludeOperatorRxp.test(field); // looking for excluding operator
+    const clearedField = field.replace(this.excludeOperatorRxp, ''); // removing exlude operator
 
     return { clearedField, isExcluding };
   }
@@ -85,8 +87,14 @@ export class Filter {
   }
 
   private createNestedQuery(field: string, value: string): string {
+    field = this.escapingESSpearators(field);
+
     return this.operatorToAdd() + '(' + field + ':' +  value  + ' OR ' +
       this.addElasticSearchPrefix('metron_alert', field) + ':' + value + ')';
+  }
+
+  private escapingESSpearators(field: string): string {
+    return field.replace(/\:/, '\\:');
   }
 
   private operatorToAdd() {

--- a/metron-interface/metron-alerts/src/app/model/filter.ts
+++ b/metron-interface/metron-alerts/src/app/model/filter.ts
@@ -63,13 +63,22 @@ export class Filter {
   private createNestedQuery(field: string, value: string): string {
 
     return '(' + Utils.escapeESField(field) + ':' +  Utils.escapeESValue(value)  + ' OR ' +
-                Utils.escapeESField('metron_alert.' + field) + ':' +  Utils.escapeESValue(value) + ')';
+                Utils.escapeESField(this.addPrefix('metron_alert', field)) + ':' +  Utils.escapeESValue(value) + ')';
   }
 
   private createNestedQueryWithoutValueEscaping(field: string, value: string): string {
 
     return '(' + Utils.escapeESField(field) + ':' +  value  + ' OR ' +
-        Utils.escapeESField('metron_alert.' + field) + ':' +  value + ')';
+        Utils.escapeESField(this.addPrefix('metron_alert', field)) + ':' +  value + ')';
+  }
+
+  private addPrefix(prefix: string, field: string): string {
+    const excludeOperatorRxp = /^-/;
+    const isExcluding = excludeOperatorRxp.test(field);
+    const operatorToAdd = isExcluding ? '-' : '';
+    const clearedField = field.replace(excludeOperatorRxp, '');
+
+    return operatorToAdd + prefix + '.' + clearedField;
   }
 
   equals(filter: Filter): boolean {

--- a/metron-interface/metron-alerts/src/app/model/filter.ts
+++ b/metron-interface/metron-alerts/src/app/model/filter.ts
@@ -90,7 +90,7 @@ export class Filter {
     field = this.escapingESSpearators(field);
 
     return this.operatorToAdd() + '(' + field + ':' +  value  + ' OR ' +
-      this.addElasticSearchPrefix('metron_alert', field) + ':' + value + ')';
+      this.addMetaAlertPrefix('metron_alert', field) + ':' + value + ')';
   }
 
   private escapingESSpearators(field: string): string {
@@ -101,7 +101,7 @@ export class Filter {
     return this.isExcluding ? this.excludeOperator : '';
   }
 
-  private addElasticSearchPrefix(prefix: string, field: string): string {
+  private addMetaAlertPrefix(prefix: string, field: string): string {
     return prefix + '.' + field;
   }
 

--- a/metron-interface/metron-alerts/src/app/utils/constants.ts
+++ b/metron-interface/metron-alerts/src/app/utils/constants.ts
@@ -26,17 +26,19 @@ export const ALERTS_SAVED_SEARCH = 'metron-alerts-saved-search';
 export const ALERTS_TABLE_METADATA = 'metron-alerts-table-metadata';
 export const ALERTS_COLUMN_NAMES = 'metron-alerts-column-names';
 
-export let TIMESTAMP_FIELD_NAME = 'timestamp';
-export let ALL_TIME = 'all-time';
+export const TIMESTAMP_FIELD_NAME = 'timestamp';
+export const GIUD_FIELD_NAME = 'guid';
 
-export let DEFAULT_TIMESTAMP_FORMAT = 'YYYY-MM-DD HH:mm:ss';
-export let CUSTOMM_DATE_RANGE_LABEL = 'Date Range';
+export const ALL_TIME = 'all-time';
 
-export let TREE_SUB_GROUP_SIZE = 5;
-export let INDEXES =  environment.indices ? environment.indices.split(',') : [];
-export let POLLING_DEFAULT_STATE = !environment.defaultPollingState;
+export const DEFAULT_TIMESTAMP_FORMAT = 'YYYY-MM-DD HH:mm:ss';
+export const CUSTOMM_DATE_RANGE_LABEL = 'Date Range';
 
-export let MAX_ALERTS_IN_META_ALERTS = 350;
+export const TREE_SUB_GROUP_SIZE = 5;
+export const INDEXES =  environment.indices ? environment.indices.split(',') : [];
+export const POLLING_DEFAULT_STATE = !environment.defaultPollingState;
+
+export const MAX_ALERTS_IN_META_ALERTS = 350;
 
 export const DEFAULT_END_TIME = new Date();
 export const DEFAULT_START_TIME = new Date().setDate(DEFAULT_END_TIME.getDate() - 5);

--- a/metron-interface/metron-alerts/src/app/utils/utils.ts
+++ b/metron-interface/metron-alerts/src/app/utils/utils.ts
@@ -17,25 +17,11 @@
  */
 import * as moment from 'moment/moment';
 
-import { DEFAULT_START_TIME, DEFAULT_END_TIME, DEFAULT_TIMESTAMP_FORMAT, META_ALERTS_SENSOR_TYPE } from './constants';
+import { DEFAULT_TIMESTAMP_FORMAT, META_ALERTS_SENSOR_TYPE } from './constants';
 import { Alert } from '../model/alert';
 import { DateFilterValue } from '../model/date-filter-value';
-import { PcapRequest } from '../pcap/model/pcap.request';
-import { PcapFilterFormValue } from '../pcap/pcap-filters/pcap-filters.component';
-import { FormGroup } from '@angular/forms';
 
 export class Utils {
-
-  public static escapeESField(field: string): string {
-    return field.replace(/:/g, '\\:');
-  }
-
-  public static escapeESValue(value: string): string {
-    return String(value)
-    .replace(/[\*\+\-=~><\"\?^\${}\(\)\:\!\/[\]\\\s]/g, '\\$&') // replace single  special characters
-    .replace(/\|\|/g, '\\||') // replace ||
-    .replace(/\&\&/g, '\\&&'); // replace &&
-  }
 
   public static getAlertSensorType(alert: Alert, sourceType: string): string {
     if (alert.source[sourceType] && alert.source[sourceType].length > 0) {


### PR DESCRIPTION
## Contributor Comments
While I was testing filtering in Alerts UI I found a few broken use cases. These broken scenarios of filtering were fixed as a part of this PR. It also contains a few lines of code cleanup around the bugfixes.

## Testing
Build a full dev from this branch or run the Alerts UI in this branch locally against an existing full dev. (The fix contains no backend changes.)
Make sure you have alert entries with status RESOLVE, DISMISS, NEW and OPEN.

### Use the following filters to test:
**Excluding filters:** (currently only works with ElasticSearch)
```-alert_status:DISMISS AND -alert_status:RESOLVE```
```-alert_status:(DISMISS OR RESOLVE)```
**Field grouping:**
```alert_status:(NEW OR OPEN)```
**Whitespace and wildcard:**
```' alert_status:OPEN'```
(don't use the single quotes, but make sure you have a space at the beginning of the query)
```'alert_status:OPEN '```
(don't use the single quotes, but make sure you have a space at the end of the query)
```* -alert_status:OPEN```

None of these queries works with the Alerts UI in the Master. All should work with this fix.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

- [x] Have you ensured that any documentation diagrams have been updated, along with their source files, using [draw.io](https://www.draw.io/)? See [Metron Development Guidelines](https://cwiki.apache.org/confluence/display/METRON/Development+Guidelines) for instructions.

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
