### PR TITLE
METRON-2155 Cache Maven in Travis CI Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,3 +59,4 @@ cache:
   - $HOME/.m2
   - $HOME/.npm
   - $M2_HOME
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ language: java
 jdk:
   - oraclejdk8
 before_install:
-  - curl --retry 10 -O https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip
+  - wget -nc -q https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip
   - unzip -qq apache-maven-3.3.9-bin.zip
   - export M2_HOME=$PWD/apache-maven-3.3.9
   - export PATH=$M2_HOME/bin:$PATH
@@ -58,3 +58,4 @@ cache:
   - metron-interface/metron-config/node_modules
   - $HOME/.m2
   - $HOME/.npm
+  - apache-maven-3.3.9-bin.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,8 @@ language: java
 jdk:
   - oraclejdk8
 before_install:
-  - wget -nc -q https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip
-  - unzip -qq apache-maven-3.3.9-bin.zip
   - export M2_HOME=$PWD/apache-maven-3.3.9
+  - [[ -d $M2_HOME ]] || wget -nc -q https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip; unzip -qq apache-maven-3.3.9-bin.zip
   - export PATH=$M2_HOME/bin:$PATH
   - npm config set cache $HOME/.npm-cache --global
   - npm config set prefix $HOME/.npm-prefix --global
@@ -58,4 +57,4 @@ cache:
   - metron-interface/metron-config/node_modules
   - $HOME/.m2
   - $HOME/.npm
-  - apache-maven-3.3.9-bin.zip
+  - $M2_HOME

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,10 @@ language: java
 jdk:
   - oraclejdk8
 before_install:
-  - export M2_URL="https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip"
   - export M2_HOME=$PWD/apache-maven-3.3.9
-  - [[ -d $M2_HOME ]] || wget -nc -q $M2_URL; unzip -qq apache-maven-3.3.9-bin.zip
   - export PATH=$M2_HOME/bin:$PATH
+  - [[ -d $M2_HOME ]] || wget -nc -q https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip 
+  - [[ -d $M2_HOME ]] || unzip -qq apache-maven-3.3.9-bin.zip
   - npm config set cache $HOME/.npm-cache --global
   - npm config set prefix $HOME/.npm-prefix --global
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,9 @@ language: java
 jdk:
   - oraclejdk8
 before_install:
+  - export M2_URL="https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip"
   - export M2_HOME=$PWD/apache-maven-3.3.9
-  - [[ -d $M2_HOME ]] || wget -nc -q https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip; unzip -qq apache-maven-3.3.9-bin.zip
+  - [[ -d $M2_HOME ]] || wget -nc -q $M2_URL; unzip -qq apache-maven-3.3.9-bin.zip
   - export PATH=$M2_HOME/bin:$PATH
   - npm config set cache $HOME/.npm-cache --global
   - npm config set prefix $HOME/.npm-prefix --global


### PR DESCRIPTION
This PR attempts to resolve the recent spat of failed Travis CI builds. These builds seem to fail when attempting to download Maven from the Apache Mirrors.

This PR attempts to cache Maven so it does not need to be repeatedly downloaded from the Apache Mirrors.  This would mitigate the issue if there are transient problems with Travis connectivity to the Apache Mirrors or if the Apache Mirrors themselves are having sporadic outages.


## Pull Request Checklist
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
