### PR TITLE
METRON-2161: CSS positioning bugs in Alerts and MGMT UI

### DIFF
--- a/metron-interface/metron-alerts/proxy.conf.json
+++ b/metron-interface/metron-alerts/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/api/v1": {
-    "target": "http://localhost:3000",
+    "target": "http://node1:8082",
     "secure": false
   }
 }

--- a/metron-interface/metron-alerts/proxy.conf.json
+++ b/metron-interface/metron-alerts/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/api/v1": {
-    "target": "http://node1:8082",
+    "target": "http://localhost:3000",
     "secure": false
   }
 }

--- a/metron-interface/metron-alerts/src/app/shared/time-range/time-range.component.scss
+++ b/metron-interface/metron-alerts/src/app/shared/time-range/time-range.component.scss
@@ -28,7 +28,7 @@
   color: $silver;
   cursor: pointer;
   line-height: 1;
-  padding: 2px 20px;
+  padding: 2px 30px 2px 20px;
   border-radius: 0px;
   font-family: Roboto;
   background: $mine-shaft-11;
@@ -44,7 +44,7 @@
     padding-left: 5px;
     color: $dusty-grey;
     position: absolute;
-    top: 13px;
+    top: 12px;
     right: 10px;
   }
 }

--- a/metron-interface/metron-alerts/src/slider.scss
+++ b/metron-interface/metron-alerts/src/slider.scss
@@ -128,5 +128,6 @@ $dialog-4x-width: 1340px;
 @include keyframes("keyframe-dialog-ltr", "-320px", "0px")
 
 .load-left-to-right {
-  @include animation("keyframe-dialog-ltr", "0.5s", "linear")
+  @include animation("keyframe-dialog-ltr", "0.5s", "linear");
+  left: 0;
 }

--- a/metron-interface/metron-config/src/app/shared/metron-alerts.ts
+++ b/metron-interface/metron-config/src/app/shared/metron-alerts.ts
@@ -30,7 +30,7 @@ export class MetronAlerts {
     element.style.top = '5px';
     element.style.right = '35px';
 
-    element.innerHTML = '<div id="alertdiv" class="alert ' + type + '"><a class="close" data-dismiss="alert">×</a><span>' +
+    element.innerHTML = '<div id="alertdiv" class="alert ' + type + ' mx-3"><a class="close px-3 pb-3" data-dismiss="alert">×</a><span>' +
       message + '</span></div>';
     document.body.appendChild(element);
 


### PR DESCRIPTION
## Contributor Comments
Link to ASF Jira ticket: https://issues.apache.org/jira/browse/METRON-2161

This PR fixes a handful of CSS bugs found in the Alerts and Management UI. I've included sceenshots/gifs below to show the issues and fixes.

* Position of the arrow in the Alerts UI time range selector button seem misaligned and too close to text.
**Bug:**
![search-arrow-bug](https://user-images.githubusercontent.com/7304869/60025812-b2c69700-969a-11e9-921a-7918b03ac30b.png)
**Fix in this PR:**
![search-arrow-with-padding](https://user-images.githubusercontent.com/7304869/60025826-b9eda500-969a-11e9-9bab-f062f7b0791b.png)
* Long message notifications will overlap the close button in both Alerts and Management UI.
**Bug:**
![long-message-bug](https://user-images.githubusercontent.com/7304869/60025869-d1c52900-969a-11e9-8f00-980a40116551.png)
**Fix in this PR:**
![long-message-fixed](https://user-images.githubusercontent.com/7304869/60025873-d5f14680-969a-11e9-927f-53fdb1bebf56.png)
* Saved searches panel is opening awkwardly on the right (should open from the left).
**Bug:**
![saved-searches-bug](https://user-images.githubusercontent.com/7304869/60025901-e4d7f900-969a-11e9-9a11-be409fc5adb0.gif)
**Fix in this PR:**
![saved-searches-fix](https://user-images.githubusercontent.com/7304869/60026119-4d26da80-969b-11e9-8540-ce5081925987.gif)

## Testing
All these changes can be tested manually with full dev. Please refer to the screenshots/gifs above for clarification on how it should look and behave.

**Misaligned arrow in the datepicker:** This can be seen by simply opening the Alerts UI and visually checking the button.

**Saved searches panel opens from wrong side:** Open the Alerts UI and click on the Saved Searches button. The panel should open from the left instead of the right.

**Long message notification:** This is a little trickier because message notifications only last for 5 seconds, and you will need to edit the message to simulate a long message. First, start the UI from `metron-interface/metron-config` by running `npm ci` and `scripts/start-dev.sh` (this must be done so the UI can compile with the changes you're about to make in the next step). Open the alert file in metron-interface/metron-config/src/app/shared/metron-alerts.ts and update the SUCESS_MESSAGE_DISPALY_TIME const to something large (like 100000). Stop or start a parser. When the success message pops up, inspect the element and edit the content of the message in the browsers inspector. There should now be plenty of padding between the 'x' close button and the message. The message should also have margin on both the left and right side of it.



## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [ ] N/A ~Have you written or updated unit tests and or integration tests to verify your changes?~
- [ ] N/A ~If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?~
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [ ] N/A ~Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:~

  ```
  cd site-book
  mvn site
  ```

- [ ] N/A ~Have you ensured that any documentation diagrams have been updated, along with their source files, using [draw.io](https://www.draw.io/)? See [Metron Development Guidelines](https://cwiki.apache.org/confluence/display/METRON/Development+Guidelines) for instructions.~

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
