### PR TITLE
METRON-2084 Add documentation notice for MacOS Mojave users for new security permissions

### DIFF
--- a/metron-deployment/development/README.md
+++ b/metron-deployment/development/README.md
@@ -61,3 +61,12 @@ To setup this up, start full dev.
 
 Now, when you go to Swagger or the UIs, you should be able to give a user and password.
 "admin" will have the roles ROLE_ADMIN and ROLE_USER, which can be verified via the "/whoami/roles" endpoint in Swagger. Similarly, there is a user "sam" that only has ROLE_USER. A third user, "tom" has neither role.
+
+## Common Problems
+
+### Mac Mojave - Operation Not Permitted Error
+
+`tee: /etc/exports: Operation not permitted on macOS 10.14 Mojave with nfs exports`
+
+If you have the Mojave OS or newer, you may run into this issue when running `vagrant up`. In order to correct this you will need to grant permissions to your relevant terminal application.
+Navigate to `System Preferences -> Security & Privacy -> Privacy` and add your terminal application to "Full Disk Access". See [https://github.com/hashicorp/vagrant/issues/10234](https://github.com/hashicorp/vagrant/issues/10234) for more details.


### PR DESCRIPTION
## Contributor Comments

https://issues.apache.org/jira/browse/METRON-2084

Doc update that addresses a common developer issue with getting full dev working on Mac OS Mojave. I verified the site-book looks correct and the referenced link works as intended.

## Pull Request Checklist

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- n/a Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- n/a Have you included steps or a guide to how the change may be verified and tested manually?
- n/a Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- n/a Have you written or updated unit tests and or integration tests to verify your changes?
- n/a If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- n/a Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

- n/a Have you ensured that any documentation diagrams have been updated, along with their source files, using [draw.io](https://www.draw.io/)? See [Metron Development Guidelines](https://cwiki.apache.org/confluence/display/METRON/Development+Guidelines) for instructions.

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
