### PR TITLE
METRON-2172 Solr Updates Not Tested in Integration Test

### DIFF
--- a/metron-platform/metron-elasticsearch/metron-elasticsearch-common/pom.xml
+++ b/metron-platform/metron-elasticsearch/metron-elasticsearch-common/pom.xml
@@ -26,7 +26,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <guava_version>${global_guava_version}</guava_version>
+        <guava_version>${global_hbase_guava_version}</guava_version>
     </properties>
     <dependencies>
         <dependency>

--- a/metron-platform/metron-elasticsearch/metron-elasticsearch-common/pom.xml
+++ b/metron-platform/metron-elasticsearch/metron-elasticsearch-common/pom.xml
@@ -26,7 +26,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <guava_version>${global_hbase_guava_version}</guava_version>
+        <guava_version>${global_guava_version}</guava_version>
     </properties>
     <dependencies>
         <dependency>
@@ -59,7 +59,21 @@
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>commons-httpclient</artifactId>
+                    <groupId>commons-httpclient</groupId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.4.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.4.9</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -177,6 +191,10 @@
                 <exclusion>
                     <groupId>io.netty</groupId>
                     <artifactId>netty-all</artifactId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>commons-httpclient</artifactId>
+                    <groupId>commons-httpclient</groupId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/metron-platform/metron-elasticsearch/metron-elasticsearch-common/src/main/java/org/apache/metron/elasticsearch/dao/ElasticsearchUpdateDao.java
+++ b/metron-platform/metron-elasticsearch/metron-elasticsearch-common/src/main/java/org/apache/metron/elasticsearch/dao/ElasticsearchUpdateDao.java
@@ -17,13 +17,12 @@
  */
 package org.apache.metron.elasticsearch.dao;
 
+import org.apache.metron.elasticsearch.bulk.BulkDocumentWriterResults;
 import org.apache.metron.elasticsearch.bulk.ElasticsearchBulkDocumentWriter;
 import org.apache.metron.elasticsearch.bulk.WriteFailure;
-import org.apache.metron.elasticsearch.bulk.BulkDocumentWriterResults;
 import org.apache.metron.elasticsearch.client.ElasticsearchClient;
 import org.apache.metron.elasticsearch.utils.ElasticsearchUtils;
 import org.apache.metron.indexing.dao.AccessConfig;
-import org.apache.metron.indexing.dao.search.AlertComment;
 import org.apache.metron.indexing.dao.update.CommentAddRemoveRequest;
 import org.apache.metron.indexing.dao.update.Document;
 import org.apache.metron.indexing.dao.update.UpdateDao;
@@ -33,15 +32,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
-
-import static org.apache.metron.indexing.dao.IndexDao.COMMENTS_FIELD;
 
 import static java.lang.String.format;
 
@@ -113,64 +107,9 @@ public class ElasticsearchUpdateDao implements UpdateDao {
 
   @Override
   @SuppressWarnings("unchecked")
-  public Document addCommentToAlert(CommentAddRemoveRequest request, Document latest) throws IOException {
-    if (latest == null || latest.getDocument() == null) {
-      throw new IOException(String.format("Unable to add comment. Document with guid %s cannot be found.",
-              request.getGuid()));
-    }
-    List<Map<String, Object>> commentsField = (List<Map<String, Object>>) latest.getDocument()
-        .getOrDefault(COMMENTS_FIELD, new ArrayList<>());
-    List<Map<String, Object>> originalComments = new ArrayList<>(commentsField);
-
-    originalComments.add(
-        new AlertComment(request.getComment(), request.getUsername(), request.getTimestamp())
-            .asMap());
-
-    Document newVersion = new Document(latest);
-    newVersion.getDocument().put(COMMENTS_FIELD, originalComments);
-    return update(newVersion, Optional.empty());
-  }
-
-  @Override
-  @SuppressWarnings("unchecked")
   public Document removeCommentFromAlert(CommentAddRemoveRequest request) throws IOException {
     Document latest = retrieveLatestDao.getLatest(request.getGuid(), request.getSensorType());
     return removeCommentFromAlert(request, latest);
-  }
-
-  @Override
-  @SuppressWarnings("unchecked")
-  public Document removeCommentFromAlert(CommentAddRemoveRequest request, Document latest) throws IOException {
-    if (latest == null || latest.getDocument() == null) {
-      throw new IOException(String.format("Unable to remove comment. Document with guid %s cannot be found.",
-              request.getGuid()));
-    }
-    List<Map<String, Object>> commentMap = (List<Map<String, Object>>) latest.getDocument().get(COMMENTS_FIELD);
-    // Can't remove anything if there's nothing there
-    if (commentMap == null) {
-      throw new IOException(String.format("Unable to remove comment. Document with guid %s has no comments.",
-              request.getGuid()));
-    }
-    List<Map<String, Object>> originalComments = new ArrayList<>(commentMap);
-
-    List<AlertComment> alertComments = new ArrayList<>();
-    for (Map<String, Object> commentRaw : originalComments) {
-      alertComments.add(new AlertComment(commentRaw));
-    }
-
-    alertComments.remove(
-        new AlertComment(request.getComment(), request.getUsername(), request.getTimestamp()));
-    List<Map<String, Object>> commentsFinal = alertComments.stream().map(AlertComment::asMap)
-        .collect(Collectors.toList());
-    Document newVersion = new Document(latest);
-    if (commentsFinal.size() > 0) {
-      newVersion.getDocument().put(COMMENTS_FIELD, commentsFinal);
-      update(newVersion, Optional.empty());
-    } else {
-      newVersion.getDocument().remove(COMMENTS_FIELD);
-    }
-
-    return update(newVersion, Optional.empty());
   }
 
   public ElasticsearchUpdateDao withRefreshPolicy(WriteRequest.RefreshPolicy refreshPolicy) {

--- a/metron-platform/metron-elasticsearch/metron-elasticsearch-common/src/test/java/org/apache/metron/elasticsearch/integration/ElasticsearchUpdateIntegrationTest.java
+++ b/metron-platform/metron-elasticsearch/metron-elasticsearch-common/src/test/java/org/apache/metron/elasticsearch/integration/ElasticsearchUpdateIntegrationTest.java
@@ -160,11 +160,6 @@ public class ElasticsearchUpdateIntegrationTest extends UpdateIntegrationTest {
     return es.getAllIndexedDocs(index, SENSOR_NAME + "_doc");
   }
 
-  @Override
-  protected MockHTable getMockHTable() {
-    return table;
-  }
-
   /**
    * Install the index template to ensure that "guid" is of type "keyword". The
    * {@link org.apache.metron.elasticsearch.dao.ElasticsearchRetrieveLatestDao} cannot find

--- a/metron-platform/metron-indexing/metron-indexing-common/src/main/java/org/apache/metron/indexing/dao/search/AlertComment.java
+++ b/metron-platform/metron-indexing/metron-indexing-common/src/main/java/org/apache/metron/indexing/dao/search/AlertComment.java
@@ -41,8 +41,13 @@ public class AlertComment {
     this.timestamp = timestamp;
   }
 
-  public AlertComment(String json) throws ParseException {
-    JSONObject parsed = (JSONObject) parser.parse(json);
+  public AlertComment(String json) {
+    JSONObject parsed;
+    try {
+      parsed = (JSONObject) parser.parse(json);
+    } catch(ParseException e) {
+      throw new IllegalArgumentException(String.format("Failed to parse; json=%s", json), e);
+    }
     this.comment = (String) parsed.get(COMMENT_FIELD);
     this.username = (String) parsed.get(COMMENT_USERNAME_FIELD);
     this.timestamp = (long) parsed.get(COMMENT_TIMESTAMP_FIELD);

--- a/metron-platform/metron-indexing/metron-indexing-common/src/main/java/org/apache/metron/indexing/dao/update/Document.java
+++ b/metron-platform/metron-indexing/metron-indexing-common/src/main/java/org/apache/metron/indexing/dao/update/Document.java
@@ -189,29 +189,25 @@ public class Document {
             .stream()
             .map(AlertComment::asJson)
             .collect(Collectors.toList());
-
     if(commentsAsJson.size() > 0) {
       // overwrite the comments field
       document.put(COMMENTS_FIELD, commentsAsJson);
 
     } else {
-      // there are no longer and comments
+      // there are no longer any comments
       document.remove(COMMENTS_FIELD);
     }
   }
 
   public List<AlertComment> getComments() {
     List<AlertComment> alertComments = new ArrayList<>();
-
     List<Object> comments = (List<Object>) document.getOrDefault(COMMENTS_FIELD, new ArrayList<>());
     for (Object commentObj: new ArrayList<>(comments)) {
       AlertComment comment;
       if(commentObj instanceof Map) {
         comment = new AlertComment((Map<String, Object>) commentObj);
-
       } else if(commentObj instanceof  String) {
         comment = new AlertComment((String) commentObj);
-
       } else {
         throw new IllegalStateException("Unexpected comment; got " + commentObj);
       }

--- a/metron-platform/metron-indexing/metron-indexing-common/src/test/java/org/apache/metron/indexing/dao/update/DocumentTest.java
+++ b/metron-platform/metron-indexing/metron-indexing-common/src/test/java/org/apache/metron/indexing/dao/update/DocumentTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.indexing.dao.update;
+
+import org.apache.metron.indexing.dao.search.AlertComment;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.apache.metron.indexing.dao.IndexDao.COMMENTS_FIELD;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests the {@link Document} class.
+ */
+public class DocumentTest {
+
+  @Test
+  public void shouldGetNoComments() {
+    Document document = document();
+    assertEquals(Collections.emptyList(), document.getComments());
+  }
+
+  @Test
+  public void shouldAddComment() {
+    // some comments from jane
+    List<AlertComment> expected = new ArrayList<AlertComment>() {{
+      new AlertComment("comment1", "jane", 1234L);
+      new AlertComment("comment2", "jane", 2345L);
+      new AlertComment("comment3", "jane", 3456L);
+      new AlertComment("comment4", "jane", 4567L);
+      new AlertComment("comment5", "jane", 5678L);
+    }};
+
+    // add the comments to the document
+    Document document = document();
+    for(AlertComment comment: expected) {
+      document.addComment(comment);
+    }
+
+    assertEquals(expected, document.getComments());
+  }
+
+  @Test
+  public void shouldRemoveComment() {
+    Document document = document();
+
+    // add some comments
+    AlertComment comment1 = new AlertComment("comment1", "jane", 1234L);
+    document.addComment(comment1);
+
+    AlertComment comment2 = new AlertComment("comment2", "jane", 5678L);
+    document.addComment(comment2);
+
+    // remove a comment
+    document.removeComment(comment2);
+    assertEquals(1, document.getComments().size());
+    assertEquals(comment1, document.getComments().get(0));
+
+    // remove another comment
+    document.removeComment(comment1);
+    assertEquals(0, document.getComments().size());
+  }
+
+  @Test
+  public void shouldRemoveLastComment() {
+    Document document = document();
+
+    // add some comments
+    AlertComment comment1 = new AlertComment("comment1", "jane", 1234L);
+    document.addComment(comment1);
+
+    // remove the last comment
+    document.removeComment(comment1);
+    assertEquals(0, document.getComments().size());
+
+    // if there are no comments, there should be no comment field in the document
+    assertFalse(document.getDocument().containsKey(COMMENTS_FIELD));
+  }
+
+  @Test
+  public void shouldHandleCommentsAsMap() {
+    AlertComment comment1 = new AlertComment("comment1", "jane", 1234L);
+    AlertComment comment2 = new AlertComment("comment2", "jane", 1234L);
+
+    // forcibly write the comments as a list of maps
+    Document document = document();
+    document.getDocument().put(COMMENTS_FIELD, Arrays.asList(comment1.asMap(), comment2.asMap()));
+
+    assertTrue(document.getComments().contains(comment1));
+    assertTrue(document.getComments().contains(comment2));
+  }
+
+  @Test
+  public void shouldHandleCommentsAsJson() {
+    AlertComment comment1 = new AlertComment("comment1", "jane", 1234L);
+    AlertComment comment2 = new AlertComment("comment2", "jane", 1234L);
+
+    // forcibly write the comments as a list of json strings
+    Document document = document();
+    document.getDocument().put(COMMENTS_FIELD, Arrays.asList(comment1.asJson(), comment2.asJson()));
+
+    assertTrue(document.getComments().contains(comment1));
+    assertTrue(document.getComments().contains(comment2));
+  }
+
+  private Document document() {
+    return new Document(fields(), UUID.randomUUID().toString(), "bro", System.currentTimeMillis());
+  }
+
+  private Map<String, Object> fields() {
+    return new HashMap<String, Object>() {{
+      put("ip_src_addr", "192.168.1.1");
+      put("ip_dst_addr", "10.0.0.1");
+      put("timestamp", System.currentTimeMillis());
+    }};
+  }
+}

--- a/metron-platform/metron-indexing/metron-indexing-common/src/test/java/org/apache/metron/indexing/integration/HBaseDaoIntegrationTest.java
+++ b/metron-platform/metron-indexing/metron-indexing-common/src/test/java/org/apache/metron/indexing/integration/HBaseDaoIntegrationTest.java
@@ -183,41 +183,44 @@ public class HBaseDaoIntegrationTest extends UpdateIntegrationTest  {
   @Test
   @SuppressWarnings("unchecked")
   public void testRemoveComments() throws Exception {
+    final String guid = "remove-comment-guid";
     Map<String, Object> fields = new HashMap<>();
-    fields.put("guid", "add_comment");
+    fields.put("guid", guid);
     fields.put("source.type", SENSOR_NAME);
 
-    Document document = new Document(fields, "add_comment", SENSOR_NAME, 1526401584951L);
+    Document document = new Document(fields, guid, SENSOR_NAME, 1526401584951L);
     hbaseDao.update(document, Optional.of(SENSOR_NAME));
-    findUpdatedDoc(document.getDocument(), "add_comment", SENSOR_NAME);
+    findUpdatedDoc(document.getDocument(), guid, SENSOR_NAME);
 
-    addAlertComment("add_comment", "New Comment", "test_user", 1526401584951L);
-    // Ensure we have the first comment
-    ArrayList<AlertComment> comments = new ArrayList<>();
-    comments.add(new AlertComment("New Comment", "test_user", 1526401584951L));
-    document.getDocument().put(COMMENTS_FIELD, comments.stream().map(AlertComment::asMap).collect(
-        Collectors.toList()));
-    findUpdatedDoc(document.getDocument(), "add_comment", SENSOR_NAME);
+    // add a comment
+    AlertComment comment1 = new AlertComment("New Comment", "test_user", 1526401584951L);
+    addAlertComment(guid, comment1.getComment(), comment1.getUsername(), comment1.getTimestamp());
 
-    addAlertComment("add_comment", "New Comment 2", "test_user_2", 1526401584952L);
-    // Ensure we have the second comment
-    comments.add(new AlertComment("New Comment 2", "test_user_2", 1526401584952L));
-    document.getDocument().put(COMMENTS_FIELD, comments.stream().map(AlertComment::asMap).collect(
-        Collectors.toList()));
-    findUpdatedDoc(document.getDocument(), "add_comment", SENSOR_NAME);
+    // ensure the comment was added
+    document.addComment(comment1);
+    findUpdatedDoc(document.getDocument(), guid, SENSOR_NAME);
 
-    removeAlertComment("add_comment", "New Comment 2", "test_user_2", 1526401584952L);
-    // Ensure we only have the first comments
-    comments = new ArrayList<>();
-    comments.add(new AlertComment(commentOne));
-    document.getDocument().put(COMMENTS_FIELD, comments.stream().map(AlertComment::asMap).collect(
-        Collectors.toList()));
-    findUpdatedDoc(document.getDocument(), "add_comment", SENSOR_NAME);
+    // add another comment
+    AlertComment comment2 = new AlertComment("New Comment 2", "test_user_2", 1526401584952L);
+    addAlertComment(guid, comment2.getComment(), comment2.getUsername(), comment2.getTimestamp());
 
-    removeAlertComment("add_comment", "New Comment", "test_user", 1526401584951L);
-    // Ensure we have no comments
-    document.getDocument().remove(COMMENTS_FIELD);
-    findUpdatedDoc(document.getDocument(), "add_comment", SENSOR_NAME);
+    // ensure the comment was added
+    document.addComment(comment2);
+    findUpdatedDoc(document.getDocument(), guid, SENSOR_NAME);
+
+    // remove the first comment
+    removeAlertComment(guid, comment1.getComment(), comment1.getUsername(), comment1.getTimestamp());
+
+    // ensure the comment was removed
+    document.removeComment(comment1);
+    findUpdatedDoc(document.getDocument(), guid, SENSOR_NAME);
+
+    // remove the second comment
+    removeAlertComment(guid, comment2.getComment(), comment2.getUsername(), comment2.getTimestamp());
+
+    // ensure the comment was removed
+    document.removeComment(comment2);
+    findUpdatedDoc(document.getDocument(), guid, SENSOR_NAME);
   }
 
   @Override

--- a/metron-platform/metron-indexing/metron-indexing-common/src/test/java/org/apache/metron/indexing/integration/HBaseDaoIntegrationTest.java
+++ b/metron-platform/metron-indexing/metron-indexing-common/src/test/java/org/apache/metron/indexing/integration/HBaseDaoIntegrationTest.java
@@ -231,11 +231,6 @@ public class HBaseDaoIntegrationTest extends UpdateIntegrationTest  {
   }
 
   @Override
-  protected MockHTable getMockHTable() {
-    return null;
-  }
-
-  @Override
   protected void addTestData(String indexName, String sensorType, List<Map<String, Object>> docs) {
   }
 

--- a/metron-platform/metron-solr/metron-solr-common/src/main/java/org/apache/metron/solr/dao/DocumentBuilder.java
+++ b/metron-platform/metron-solr/metron-solr-common/src/main/java/org/apache/metron/solr/dao/DocumentBuilder.java
@@ -15,34 +15,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.metron.solr.dao;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.HashMap;
-import org.apache.metron.common.Constants;
 import org.apache.metron.indexing.dao.update.Document;
-import org.apache.solr.common.SolrDocument;
-import org.junit.Test;
 
-public class SolrUtilitiesTest {
+/**
+ * Responsible for building and deconstructing a {@link Document}
+ * from an intermediate form.
+ */
+public interface DocumentBuilder<T> {
 
-  @Test
-  public void toDocumentShouldProperlyReturnDocument() throws Exception {
-    SolrDocument solrDocument = new SolrDocument();
-    solrDocument.addField(SolrDao.VERSION_FIELD, 1.0);
-    solrDocument.addField(Constants.GUID, "guid");
-    solrDocument.addField(Constants.SENSOR_TYPE, "bro");
-    solrDocument.addField("field", "value");
+  /**
+   * Builds a {@link Document} from the source document.
+   *
+   * @param sourceDocument The source document.
+   * @return A {@link Document}.
+   */
+  Document toDocument(T sourceDocument);
 
-    Document expectedDocument = new Document(new HashMap<String, Object>() {{
-      put("field", "value");
-      put(Constants.GUID, "guid");
-      put(Constants.SENSOR_TYPE, "bro");
-    }}, "guid", "bro", 0L);
-
-    Document actualDocument = SolrUtilities.toDocument(solrDocument);
-    assertEquals(expectedDocument, actualDocument);
-  }
+  /**
+   * Deconstructs a {@link Document} into the alternate intermediate form.
+   *
+   * @param document The document to deconstruct.
+   * @return The alternate, intermediate document form.
+   */
+  T fromDocument(Document document);
 }

--- a/metron-platform/metron-solr/metron-solr-common/src/main/java/org/apache/metron/solr/dao/SolrDocumentBuilder.java
+++ b/metron-platform/metron-solr/metron-solr-common/src/main/java/org/apache/metron/solr/dao/SolrDocumentBuilder.java
@@ -68,8 +68,21 @@ public class SolrDocumentBuilder implements DocumentBuilder<SolrDocument>, Seria
 
     String guid = (String) solrDocument.getFieldValue(Constants.GUID);
     String sensorType = (String) solrDocument.getFieldValue(Constants.SENSOR_TYPE);
-    Long timestamp = (Long) solrDocument.getFieldValue(Constants.Fields.TIMESTAMP.getName());
-    return new Document(fields, guid, sensorType, timestamp);
+    return new Document(fields, guid, sensorType, getTimestamp(solrDocument));
+  }
+
+  private Long getTimestamp(SolrDocument solrDocument) {
+    Long timestamp;
+    Object fieldValue = solrDocument.getFieldValue(Constants.Fields.TIMESTAMP.getName());
+    if(fieldValue instanceof Long) {
+      timestamp = (Long) fieldValue;
+    } else if(fieldValue instanceof String) {
+      timestamp = Long.valueOf((String) fieldValue);
+    } else {
+      throw new IllegalStateException(String.format("Unexpected value; expected String or Long; field=%s, type=%s",
+              Constants.Fields.TIMESTAMP.getName(), fieldValue.getClass().getName()));
+    }
+    return timestamp;
   }
 
   public static SolrInputDocument toSolrInputDocument(SolrDocument in) {

--- a/metron-platform/metron-solr/metron-solr-common/src/main/java/org/apache/metron/solr/dao/SolrDocumentBuilder.java
+++ b/metron-platform/metron-solr/metron-solr-common/src/main/java/org/apache/metron/solr/dao/SolrDocumentBuilder.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.solr.dao;
+
+import org.apache.metron.common.Constants;
+import org.apache.metron.indexing.dao.metaalert.MetaAlertConstants;
+import org.apache.metron.indexing.dao.update.Document;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrInputDocument;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Responsible for building a {@link Document} from a {@link SolrDocument}.
+ */
+public class SolrDocumentBuilder implements DocumentBuilder<SolrDocument>, Serializable {
+
+  @Override
+  public SolrDocument fromDocument(Document document) {
+    SolrDocument solrDocument = new SolrDocument();
+    for (Map.Entry<String, Object> field : document.getDocument().entrySet()) {
+      if (field.getKey().equals(MetaAlertConstants.ALERT_FIELD)) {
+        // We have a children, that needs to be translated as a child doc, not a field.
+        List<Map<String, Object>> alerts = (List<Map<String, Object>>) field.getValue();
+        for (Map<String, Object> alert : alerts) {
+          SolrDocument childDocument = new SolrDocument();
+          for (Map.Entry<String, Object> alertField : alert.entrySet()) {
+            childDocument.addField(alertField.getKey(), alertField.getValue());
+          }
+          solrDocument.addChildDocument(childDocument);
+        }
+      } else {
+        solrDocument.addField(field.getKey(), field.getValue());
+      }
+    }
+    return solrDocument;
+  }
+
+  @Override
+  public Document toDocument(SolrDocument solrDocument) {
+    Map<String, Object> fields = new HashMap<>();
+    solrDocument.getFieldNames()
+            .stream()
+            .filter(name -> !name.equals(SolrDao.VERSION_FIELD))
+            .forEach(name -> fields.put(name, solrDocument.getFieldValue(name)));
+
+    insertChildAlerts(solrDocument, fields);
+
+    String guid = (String) solrDocument.getFieldValue(Constants.GUID);
+    String sensorType = (String) solrDocument.getFieldValue(Constants.SENSOR_TYPE);
+    Long timestamp = (Long) solrDocument.getFieldValue(Constants.Fields.TIMESTAMP.getName());
+    return new Document(fields, guid, sensorType, timestamp);
+  }
+
+  public static SolrInputDocument toSolrInputDocument(SolrDocument in) {
+    SolrInputDocument out = new SolrInputDocument();
+
+    // copy fields
+    for(String name: in.getFieldNames()) {
+      out.addField( name, in.getFieldValue(name), 1.0f);
+    }
+
+    // copy children documents
+    if(in.getChildDocuments() != null) {
+      for(SolrDocument childDocument: in.getChildDocuments()) {
+        // check to avoid potential infinite loops; not sure if this is necessary
+        if(!childDocument.equals(in)) {
+          out.addChildDocument(toSolrInputDocument(childDocument));
+        }
+      }
+    }
+    return out;
+  }
+
+  protected static void insertChildAlerts(SolrDocument solrDocument, Map<String, Object> document) {
+    // Make sure to put child alerts in
+    if (solrDocument.hasChildDocuments() && isMetaAlert(solrDocument)) {
+      List<Map<String, Object>> childDocuments = new ArrayList<>();
+      for (SolrDocument childDoc : solrDocument.getChildDocuments()) {
+        Map<String, Object> childDocMap = new HashMap<>();
+        childDoc.getFieldNames()
+                .stream()
+                .filter(name -> !name.equals(SolrDao.VERSION_FIELD))
+                .forEach(name -> childDocMap.put(name, childDoc.getFieldValue(name)));
+        childDocuments.add(childDocMap);
+      }
+
+      document.put(MetaAlertConstants.ALERT_FIELD, childDocuments);
+    }
+  }
+
+  private static boolean isMetaAlert(SolrDocument document) {
+    Object sensorType = document.getFieldValue(Constants.SENSOR_TYPE);
+    return Objects.equals(sensorType, MetaAlertConstants.METAALERT_TYPE);
+  }
+}

--- a/metron-platform/metron-solr/metron-solr-common/src/main/java/org/apache/metron/solr/dao/SolrDocumentBuilder.java
+++ b/metron-platform/metron-solr/metron-solr-common/src/main/java/org/apache/metron/solr/dao/SolrDocumentBuilder.java
@@ -17,13 +17,17 @@
  */
 package org.apache.metron.solr.dao;
 
+import org.apache.commons.lang3.ClassUtils;
 import org.apache.metron.common.Constants;
 import org.apache.metron.indexing.dao.metaalert.MetaAlertConstants;
 import org.apache.metron.indexing.dao.update.Document;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrInputDocument;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -34,6 +38,7 @@ import java.util.Objects;
  * Responsible for building a {@link Document} from a {@link SolrDocument}.
  */
 public class SolrDocumentBuilder implements DocumentBuilder<SolrDocument>, Serializable {
+  private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @Override
   public SolrDocument fromDocument(Document document) {
@@ -72,15 +77,14 @@ public class SolrDocumentBuilder implements DocumentBuilder<SolrDocument>, Seria
   }
 
   private Long getTimestamp(SolrDocument solrDocument) {
-    Long timestamp;
+    Long timestamp = null;
     Object fieldValue = solrDocument.getFieldValue(Constants.Fields.TIMESTAMP.getName());
     if(fieldValue instanceof Long) {
       timestamp = (Long) fieldValue;
     } else if(fieldValue instanceof String) {
       timestamp = Long.valueOf((String) fieldValue);
     } else {
-      throw new IllegalStateException(String.format("Unexpected value; expected String or Long; field=%s, type=%s",
-              Constants.Fields.TIMESTAMP.getName(), fieldValue.getClass().getName()));
+      LOG.error("Expected timestamp as String or Long, but got %s", ClassUtils.getSimpleName(fieldValue, "null"));
     }
     return timestamp;
   }

--- a/metron-platform/metron-solr/metron-solr-common/src/main/java/org/apache/metron/solr/dao/SolrMetaAlertRetrieveLatestDao.java
+++ b/metron-platform/metron-solr/metron-solr-common/src/main/java/org/apache/metron/solr/dao/SolrMetaAlertRetrieveLatestDao.java
@@ -18,10 +18,6 @@
 
 package org.apache.metron.solr.dao;
 
-import static org.apache.metron.solr.dao.SolrMetaAlertDao.METAALERTS_COLLECTION;
-
-import java.io.IOException;
-import java.util.List;
 import org.apache.metron.common.Constants;
 import org.apache.metron.indexing.dao.metaalert.MetaAlertConstants;
 import org.apache.metron.indexing.dao.metaalert.MetaAlertRetrieveLatestDao;
@@ -33,15 +29,21 @@ import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocument;
 
-public class SolrMetaAlertRetrieveLatestDao implements
-    MetaAlertRetrieveLatestDao {
+import java.io.IOException;
+import java.util.List;
+
+import static org.apache.metron.solr.dao.SolrMetaAlertDao.METAALERTS_COLLECTION;
+
+public class SolrMetaAlertRetrieveLatestDao implements MetaAlertRetrieveLatestDao {
 
   private SolrDao solrDao;
   private SolrClient solrClient;
+  private SolrDocumentBuilder documentBuilder;
 
   public SolrMetaAlertRetrieveLatestDao(SolrClient client, SolrDao solrDao) {
     this.solrClient = client;
     this.solrDao = solrDao;
+    this.documentBuilder = new SolrDocumentBuilder();
   }
 
   @Override
@@ -59,8 +61,8 @@ public class SolrMetaAlertRetrieveLatestDao implements
         // GUID is unique, so it's definitely the first result
         if (response.getResults().size() == 1) {
           SolrDocument result = response.getResults().get(0);
+          return documentBuilder.toDocument(result);
 
-          return SolrUtilities.toDocument(result);
         } else {
           return null;
         }

--- a/metron-platform/metron-solr/metron-solr-common/src/main/java/org/apache/metron/solr/dao/SolrMetaAlertSearchDao.java
+++ b/metron-platform/metron-solr/metron-solr-common/src/main/java/org/apache/metron/solr/dao/SolrMetaAlertSearchDao.java
@@ -59,11 +59,13 @@ public class SolrMetaAlertSearchDao implements MetaAlertSearchDao {
   transient SolrSearchDao solrSearchDao;
   transient SolrClient solrClient;
   private MetaAlertConfig config;
+  private SolrDocumentBuilder documentBuilder;
 
   public SolrMetaAlertSearchDao(SolrClient solrClient, SolrSearchDao solrSearchDao, MetaAlertConfig config) {
     this.solrClient = solrClient;
     this.solrSearchDao = solrSearchDao;
     this.config = config;
+    this.documentBuilder = new SolrDocumentBuilder();
   }
 
   @Override
@@ -181,7 +183,7 @@ public class SolrMetaAlertSearchDao implements MetaAlertSearchDao {
               .getById(METAALERTS_COLLECTION, metaalertGuids, solrParams);
           Map<String, Document> guidToDocuments = new HashMap<>();
           for (SolrDocument doc : solrDocumentList) {
-            Document document = SolrUtilities.toDocument(doc);
+            Document document = documentBuilder.toDocument(doc);
             guidToDocuments.put(document.getGuid(), document);
           }
 

--- a/metron-platform/metron-solr/metron-solr-common/src/main/java/org/apache/metron/solr/dao/SolrUpdateDao.java
+++ b/metron-platform/metron-solr/metron-solr-common/src/main/java/org/apache/metron/solr/dao/SolrUpdateDao.java
@@ -17,20 +17,6 @@
  */
 package org.apache.metron.solr.dao;
 
-import static org.apache.metron.indexing.dao.IndexDao.COMMENTS_FIELD;
-
-import java.io.IOException;
-import java.lang.invoke.MethodHandles;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.metron.indexing.dao.AccessConfig;
 import org.apache.metron.indexing.dao.search.AlertComment;
 import org.apache.metron.indexing.dao.update.CommentAddRemoveRequest;
@@ -38,86 +24,91 @@ import org.apache.metron.indexing.dao.update.Document;
 import org.apache.metron.indexing.dao.update.UpdateDao;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.beans.DocumentObjectBinder;
+import org.apache.solr.client.solrj.util.ClientUtils;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrInputDocument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.lang.String.format;
+
+/**
+ * An {@link UpdateDao} for Solr.
+ */
 public class SolrUpdateDao implements UpdateDao {
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
   private transient SolrClient client;
-  private AccessConfig config;
   private transient SolrRetrieveLatestDao retrieveLatestDao;
+  private AccessConfig config;
+  private SolrDocumentBuilder documentBuilder;
 
   public SolrUpdateDao(SolrClient client, SolrRetrieveLatestDao retrieveLatestDao, AccessConfig config) {
     this.client = client;
     this.retrieveLatestDao = retrieveLatestDao;
     this.config = config;
+    this.documentBuilder = new SolrDocumentBuilder();
   }
 
   @Override
   public Document update(Document update, Optional<String> rawIndex) throws IOException {
-    Document newVersion = update;
-    // Handle any case where we're given comments in Map form, instead of raw String
-    Object commentsObj = update.getDocument().get(COMMENTS_FIELD);
-    if ( commentsObj instanceof List &&
-        ((List<Object>) commentsObj).size() > 0 &&
-      ((List<Object>) commentsObj).get(0) instanceof Map) {
-      newVersion = new Document(update);
-      convertCommentsToRaw(newVersion.getDocument());
+    Document newVersion = new Document(update);
+
+    Optional<String> index = SolrUtilities.getIndex(config.getIndexSupplier(), newVersion.getSensorType(), rawIndex);
+    if(index.isPresent()) {
+      SolrDocument solrDocument = documentBuilder.fromDocument(newVersion);
+      writeDocuments(index.get(), solrDocument);
+
+    } else {
+      throw new IllegalStateException("Index must be specified or inferred.");
     }
-    try {
-      SolrInputDocument solrInputDocument = SolrUtilities.toSolrInputDocument(newVersion);
-      Optional<String> index = SolrUtilities
-          .getIndex(config.getIndexSupplier(), newVersion.getSensorType(), rawIndex);
-      if (index.isPresent()) {
-        this.client.add(index.get(), solrInputDocument);
-        this.client.commit(index.get());
-      } else {
-        throw new IllegalStateException("Index must be specified or inferred.");
-      }
-    } catch (SolrServerException e) {
-      throw new IOException(e);
-    }
+
     return newVersion;
   }
 
   @Override
   public Map<Document, Optional<String>> batchUpdate(Map<Document, Optional<String>> updates) throws IOException {
     // updates with a collection specified
-    Map<String, Collection<SolrInputDocument>> solrCollectionUpdates = new HashMap<>();
+    Map<String, Collection<SolrDocument>> solrCollectionUpdates = new HashMap<>();
     Set<String> collectionsUpdated = new HashSet<>();
 
     for (Entry<Document, Optional<String>> entry : updates.entrySet()) {
-      SolrInputDocument solrInputDocument = SolrUtilities.toSolrInputDocument(entry.getKey());
+      SolrDocument solrInputDocument = documentBuilder.fromDocument(entry.getKey());
       Optional<String> index = SolrUtilities
-          .getIndex(config.getIndexSupplier(), entry.getKey().getSensorType(), entry.getValue());
+              .getIndex(config.getIndexSupplier(), entry.getKey().getSensorType(), entry.getValue());
       if (index.isPresent()) {
-        Collection<SolrInputDocument> solrInputDocuments = solrCollectionUpdates
-            .getOrDefault(index.get(), new ArrayList<>());
+        Collection<SolrDocument> solrInputDocuments = solrCollectionUpdates.getOrDefault(index.get(), new ArrayList<>());
         solrInputDocuments.add(solrInputDocument);
+
         solrCollectionUpdates.put(index.get(), solrInputDocuments);
         collectionsUpdated.add(index.get());
       } else {
         String lookupIndex = config.getIndexSupplier().apply(entry.getKey().getSensorType());
-        Collection<SolrInputDocument> solrInputDocuments = solrCollectionUpdates
-            .getOrDefault(lookupIndex, new ArrayList<>());
+        Collection<SolrDocument> solrInputDocuments = solrCollectionUpdates.getOrDefault(lookupIndex, new ArrayList<>());
         solrInputDocuments.add(solrInputDocument);
         solrCollectionUpdates.put(lookupIndex, solrInputDocuments);
         collectionsUpdated.add(lookupIndex);
       }
     }
-    try {
-      for (Entry<String, Collection<SolrInputDocument>> entry : solrCollectionUpdates
-          .entrySet()) {
-        this.client.add(entry.getKey(), entry.getValue());
-      }
-      for (String collection : collectionsUpdated) {
-        this.client.commit(collection);
-      }
-    } catch (SolrServerException e) {
-      throw new IOException(e);
+
+    for (Entry<String, Collection<SolrDocument>> entry : solrCollectionUpdates.entrySet()) {
+      String index = entry.getKey();
+      Collection<SolrDocument> documents = entry.getValue();
+      writeDocuments(index, documents);
     }
+
     return updates;
   }
 
@@ -130,34 +121,19 @@ public class SolrUpdateDao implements UpdateDao {
   @Override
   public Document addCommentToAlert(CommentAddRemoveRequest request, Document latest) throws IOException {
     if (latest == null || latest.getDocument() == null) {
-      throw new IOException(String.format("Unable to add comment. Document with guid %s cannot be found.",
-              request.getGuid()));
+      throw new IOException(format("Unable to add comment. Document with guid %s cannot be found.", request.getGuid()));
     }
 
-    @SuppressWarnings("unchecked")
-    List<Map<String, Object>> comments = (List<Map<String, Object>>) latest.getDocument()
-        .getOrDefault(COMMENTS_FIELD, new ArrayList<>());
-    List<Map<String, Object>> originalComments = new ArrayList<>(comments);
+    AlertComment toAdd = new AlertComment(request.getComment(), request.getUsername(), request.getTimestamp());
+    Document updatedDocument = new Document(latest);
+    updatedDocument.addComment(toAdd);
 
-    // Convert all comments back to raw JSON before updating.
-    List<String> commentStrs = new ArrayList<>();
-    for (Map<String, Object> comment : originalComments) {
-      commentStrs.add(new AlertComment(comment).asJson());
-    }
-    commentStrs.add(new AlertComment(
-        request.getComment(),
-        request.getUsername(),
-        request.getTimestamp()
-    ).asJson());
-
-    Document newVersion = new Document(latest);
-    newVersion.getDocument().put(COMMENTS_FIELD, commentStrs);
-    return update(newVersion, Optional.empty());
+    // persist the changes
+    return update(updatedDocument, Optional.empty());
   }
 
   @Override
-  public Document removeCommentFromAlert(CommentAddRemoveRequest request)
-      throws IOException {
+  public Document removeCommentFromAlert(CommentAddRemoveRequest request) throws IOException {
     Document latest = retrieveLatestDao.getLatest(request.getGuid(), request.getSensorType());
     return removeCommentFromAlert(request, latest);
   }
@@ -166,43 +142,45 @@ public class SolrUpdateDao implements UpdateDao {
   public Document removeCommentFromAlert(CommentAddRemoveRequest request, Document latest)
       throws IOException {
     if (latest == null || latest.getDocument() == null) {
-      throw new IOException(String.format("Unable to remove comment. Document with guid %s cannot be found.",
-              request.getGuid()));
+      throw new IOException(format("Unable to remove comment. Document with guid %s cannot be found.", request.getGuid()));
     }
 
-    @SuppressWarnings("unchecked")
-    List<Map<String, Object>> commentMap = (List<Map<String, Object>>) latest.getDocument()
-        .get(COMMENTS_FIELD);
-    // Can't remove anything if there's nothing there
-    if (commentMap == null) {
-      throw new IOException(String.format("Unable to remove comment. Document with guid %s has no comments.",
-              request.getGuid()));
-    }
-    List<Map<String, Object>> originalComments = new ArrayList<>(commentMap);
-    List<AlertComment> comments = new ArrayList<>();
-    for (Map<String, Object> commentStr : originalComments) {
-      comments.add(new AlertComment(commentStr));
+    // remove the comment from the existing comments
+    AlertComment toRemove = new AlertComment(request.getComment(), request.getUsername(), request.getTimestamp());
+    Document updatedDocument = new Document(latest);
+    boolean wasRemoved = updatedDocument.removeComment(toRemove);
+    if(!wasRemoved) {
+      throw new IOException(String.format("Unable to remove comment. Document with guid %s has no comments.", request.getGuid()));
     }
 
-    comments.remove(
-        new AlertComment(request.getComment(), request.getUsername(), request.getTimestamp()));
-    List<String> commentsAsJson = comments.stream().map(AlertComment::asJson)
-        .collect(Collectors.toList());
-    Document newVersion = new Document(latest);
-    newVersion.getDocument().put(COMMENTS_FIELD, commentsAsJson);
-    return update(newVersion, Optional.empty());
+    // persist the changes
+    return update(updatedDocument, Optional.empty());
   }
 
-  public void convertCommentsToRaw(Map<String,Object> source) {
-    @SuppressWarnings("unchecked")
-    List<Map<String, Object>> comments = (List<Map<String, Object>>) source.get(COMMENTS_FIELD);
-    if (comments == null || comments.isEmpty()) {
-      return;
+  /**
+   * Writes a {@link SolrDocument} to a Solr index (aka Collection).
+   *
+   * @param documents The document to write.
+   * @param index THe index/collection to write to.
+   */
+  private void writeDocuments(String index, SolrDocument ... documents) throws IOException {
+    try {
+      // add each document to the batch
+      for(SolrDocument document: documents) {
+        SolrInputDocument input = documentBuilder.toSolrInputDocument(document);
+        client.add(index, input);
+      }
+
+      // commit all pending documents
+      client.commit(index);
+
+    } catch (SolrException | SolrServerException | IOException e) {
+      LOG.error("Unable to add document; index={}", index, e);
+      throw new IOException(e);
     }
-    List<String> asJson = new ArrayList<>();
-    for (Map<String, Object> comment : comments) {
-      asJson.add((new AlertComment(comment)).asJson());
-    }
-    source.put(COMMENTS_FIELD, asJson);
+  }
+
+  private void writeDocuments(String index, Collection<SolrDocument> documents) throws IOException {
+    writeDocuments(index, documents.toArray(new SolrDocument[documents.size()]));
   }
 }

--- a/metron-platform/metron-solr/metron-solr-common/src/main/java/org/apache/metron/solr/dao/SolrUtilities.java
+++ b/metron-platform/metron-solr/metron-solr-common/src/main/java/org/apache/metron/solr/dao/SolrUtilities.java
@@ -18,32 +18,29 @@
 
 package org.apache.metron.solr.dao;
 
-import static org.apache.metron.indexing.dao.IndexDao.COMMENTS_FIELD;
+import org.apache.metron.indexing.dao.search.SearchResult;
+import org.apache.metron.indexing.dao.update.Document;
+import org.apache.solr.common.SolrDocument;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
-import java.util.stream.Collectors;
-import org.apache.metron.common.Constants;
-import org.apache.metron.indexing.dao.metaalert.MetaAlertConstants;
-import org.apache.metron.indexing.dao.search.AlertComment;
-import org.apache.metron.indexing.dao.search.SearchResult;
-import org.apache.metron.indexing.dao.update.Document;
-import org.apache.solr.common.SolrDocument;
-import org.apache.solr.common.SolrInputDocument;
-import org.json.simple.parser.ParseException;
-
 public class SolrUtilities {
 
   public static SearchResult getSearchResult(SolrDocument solrDocument, List<String> fields, Function<String, String> indexSupplier) {
+    SolrDocumentBuilder documentBuilder = new SolrDocumentBuilder();
+    Document document = documentBuilder.toDocument(solrDocument);
+
+    String index = indexSupplier.apply(document.getSensorType());
+
     SearchResult searchResult = new SearchResult();
-    searchResult.setId((String) solrDocument.getFieldValue(Constants.GUID));
-    searchResult.setIndex(indexSupplier.apply((String) solrDocument.getFieldValue(Constants.SENSOR_TYPE)));
-    Map<String, Object> docSource = toDocument(solrDocument).getDocument();
+    searchResult.setId(document.getGuid());
+    searchResult.setIndex(index);
+
+    Map<String, Object> docSource = document.getDocument();
     final Map<String, Object> source = new HashMap<>();
     if (fields != null) {
       fields.forEach(field -> source.put(field, docSource.get(field)));
@@ -51,77 +48,8 @@ public class SolrUtilities {
       source.putAll(docSource);
     }
     searchResult.setSource(source);
+
     return searchResult;
-  }
-
-  public static Document toDocument(SolrDocument solrDocument) {
-    Map<String, Object> document = new HashMap<>();
-    solrDocument.getFieldNames().stream()
-        .filter(name -> !name.equals(SolrDao.VERSION_FIELD))
-        .forEach(name -> document.put(name, solrDocument.getFieldValue(name)));
-
-    reformatComments(solrDocument, document);
-    insertChildAlerts(solrDocument, document);
-
-    return new Document(document,
-        (String) solrDocument.getFieldValue(Constants.GUID),
-        (String) solrDocument.getFieldValue(Constants.SENSOR_TYPE), 0L);
-  }
-
-  protected static void reformatComments(SolrDocument solrDocument, Map<String, Object> document) {
-    // Make sure comments are in the proper format
-    @SuppressWarnings("unchecked")
-    List<String> commentStrs = (List<String>) solrDocument.get(COMMENTS_FIELD);
-    if (commentStrs != null) {
-      try {
-        List<AlertComment> comments = new ArrayList<>();
-        for (String commentStr : commentStrs) {
-          comments.add(new AlertComment(commentStr));
-        }
-        document.put(COMMENTS_FIELD,
-            comments.stream().map(AlertComment::asMap).collect(Collectors.toList()));
-      } catch (ParseException e) {
-        throw new IllegalStateException("Unable to parse comment", e);
-      }
-    }
-  }
-
-  protected static void insertChildAlerts(SolrDocument solrDocument, Map<String, Object> document) {
-    // Make sure to put child alerts in
-    if (solrDocument.hasChildDocuments() && solrDocument
-        .getFieldValue(Constants.SENSOR_TYPE)
-        .equals(MetaAlertConstants.METAALERT_TYPE)) {
-      List<Map<String, Object>> childDocuments = new ArrayList<>();
-      for (SolrDocument childDoc : solrDocument.getChildDocuments()) {
-        Map<String, Object> childDocMap = new HashMap<>();
-        childDoc.getFieldNames().stream()
-            .filter(name -> !name.equals(SolrDao.VERSION_FIELD))
-            .forEach(name -> childDocMap.put(name, childDoc.getFieldValue(name)));
-        childDocuments.add(childDocMap);
-      }
-
-      document.put(MetaAlertConstants.ALERT_FIELD, childDocuments);
-    }
-  }
-
-  public static SolrInputDocument toSolrInputDocument(Document document) {
-    SolrInputDocument solrInputDocument = new SolrInputDocument();
-    for (Map.Entry<String, Object> field : document.getDocument().entrySet()) {
-      if (field.getKey().equals(MetaAlertConstants.ALERT_FIELD)) {
-        // We have a children, that needs to be translated as a child doc, not a field.
-        List<Map<String, Object>> alerts = (List<Map<String, Object>>) field.getValue();
-        for (Map<String, Object> alert : alerts) {
-          SolrInputDocument childDocument = new SolrInputDocument();
-          for (Map.Entry<String, Object> alertField : alert.entrySet()) {
-            childDocument.addField(alertField.getKey(), alertField.getValue());
-          }
-          solrInputDocument.addChildDocument(childDocument);
-        }
-      } else {
-        solrInputDocument.addField(field.getKey(), field.getValue());
-      }
-    }
-    return solrInputDocument;
   }
 
   /**
@@ -131,8 +59,7 @@ public class SolrUtilities {
    * @param index An index to use, if present.
    * @return An Optional containing the actual collection
    */
-  public static Optional<String> getIndex(Function<String, String> indexSupplier, String sensorName,
-      Optional<String> index) {
+  public static Optional<String> getIndex(Function<String, String> indexSupplier, String sensorName, Optional<String> index) {
     if (index.isPresent()) {
       return index;
     } else {

--- a/metron-platform/metron-solr/metron-solr-common/src/test/java/org/apache/metron/solr/dao/SolrUpdateDaoTest.java
+++ b/metron-platform/metron-solr/metron-solr-common/src/test/java/org/apache/metron/solr/dao/SolrUpdateDaoTest.java
@@ -17,24 +17,6 @@
  */
 package org.apache.metron.solr.dao;
 
-import static org.apache.metron.indexing.dao.IndexDao.COMMENTS_FIELD;
-import static org.apache.metron.solr.SolrConstants.SOLR_ZOOKEEPER;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.argThat;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.doReturn;
-import static org.powermock.api.mockito.PowerMockito.spy;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import org.apache.metron.common.Constants;
 import org.apache.metron.common.configuration.IndexingConfigurations;
 import org.apache.metron.common.zookeeper.ConfigurationsCache;
@@ -57,6 +39,25 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.metron.indexing.dao.IndexDao.COMMENTS_FIELD;
+import static org.apache.metron.solr.SolrConstants.SOLR_ZOOKEEPER;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.doReturn;
+import static org.powermock.api.mockito.PowerMockito.spy;
 
 /**
  * This class contains tests specific to the SolrUpdateDao implementation.  It also returns the SolrUpdateDao
@@ -113,7 +114,6 @@ public class SolrUpdateDaoTest extends UpdateDaoTest {
     solrUpdateDao.update(document, Optional.empty());
 
     verify(client).add(eq("bro"), argThat(new SolrInputDocumentMatcher(solrInputDocument)));
-
   }
 
   @Test
@@ -149,13 +149,14 @@ public class SolrUpdateDaoTest extends UpdateDaoTest {
     SolrInputDocument broSolrInputDocument1 = new SolrInputDocument();
     broSolrInputDocument1.addField("broField1", "value");
     broSolrInputDocument1.addField("guid", "broGuid1");
+
     SolrInputDocument broSolrInputDocument2 = new SolrInputDocument();
     broSolrInputDocument2.addField("broField2", "value");
     broSolrInputDocument2.addField("guid", "broGuid2");
 
     solrUpdateDao.batchUpdate(updates);
-
-    verify(client).add(eq("bro"), argThat(new SolrInputDocumentListMatcher(Arrays.asList(broSolrInputDocument1, broSolrInputDocument2))));
+    verify(client).add(eq("bro"), argThat(new SolrInputDocumentMatcher(broSolrInputDocument1)));
+    verify(client).add(eq("bro"), argThat(new SolrInputDocumentMatcher(broSolrInputDocument2)));
   }
 
   @Test
@@ -182,30 +183,8 @@ public class SolrUpdateDaoTest extends UpdateDaoTest {
     snortSolrInputDocument2.addField("guid", "snortGuid2");
 
     solrUpdateDao.batchUpdate(updates);
-
-    verify(client).add(eq("snort"), argThat(new SolrInputDocumentListMatcher(Arrays.asList(snortSolrInputDocument1, snortSolrInputDocument2))));
-  }
-
-  @Test
-  public void testConvertCommentsToRaw() {
-    List<Map<String, Object>> commentList = new ArrayList<>();
-    Map<String, Object> comments = new HashMap<>();
-    comments.put("comment", "test comment");
-    comments.put("username", "test username");
-    comments.put("timestamp", 1526424323279L);
-    commentList.add(comments);
-
-    Map<String, Object> document = new HashMap<>();
-    document.put("testField", "testValue");
-    document.put(COMMENTS_FIELD, commentList);
-    solrUpdateDao.convertCommentsToRaw(document);
-
-    @SuppressWarnings("unchecked")
-    List<String> actualComments = (List<String>) document.get(COMMENTS_FIELD);
-    String expectedComment = "{\"comment\":\"test comment\",\"username\":\"test username\",\"timestamp\":1526424323279}";
-    assertEquals(expectedComment, actualComments.get(0));
-    assertEquals(1, actualComments.size());
-    assertEquals("testValue", document.get("testField"));
+    verify(client).add(eq("snort"), argThat(new SolrInputDocumentMatcher(snortSolrInputDocument1)));
+    verify(client).add(eq("snort"), argThat(new SolrInputDocumentMatcher(snortSolrInputDocument2)));
   }
 
   @Test

--- a/metron-platform/metron-solr/metron-solr-common/src/test/java/org/apache/metron/solr/integration/SolrUpdateIntegrationTest.java
+++ b/metron-platform/metron-solr/metron-solr-common/src/test/java/org/apache/metron/solr/integration/SolrUpdateIntegrationTest.java
@@ -17,26 +17,12 @@
  */
 package org.apache.metron.solr.integration;
 
-import static org.apache.metron.solr.SolrConstants.SOLR_ZOOKEEPER;
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.curator.framework.CuratorFramework;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.metron.common.configuration.ConfigurationsUtils;
 import org.apache.metron.common.zookeeper.ZKConfigurationsCache;
-import org.apache.metron.hbase.mock.MockHBaseTableProvider;
-import org.apache.metron.hbase.mock.MockHTable;
 import org.apache.metron.indexing.dao.AccessConfig;
 import org.apache.metron.indexing.dao.HBaseDao;
-import org.apache.metron.indexing.dao.IndexDao;
-import org.apache.metron.indexing.dao.MultiIndexDao;
 import org.apache.metron.indexing.dao.UpdateIntegrationTest;
 import org.apache.metron.indexing.dao.update.Document;
 import org.apache.metron.indexing.util.IndexingCacheUtil;
@@ -51,6 +37,15 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.metron.solr.SolrConstants.SOLR_ZOOKEEPER;
+import static org.junit.Assert.assertEquals;
+
 public class SolrUpdateIntegrationTest extends UpdateIntegrationTest {
   @Rule
   public final ExpectedException exception = ExpectedException.none();
@@ -59,8 +54,6 @@ public class SolrUpdateIntegrationTest extends UpdateIntegrationTest {
 
   private static final String TABLE_NAME = "modifications";
   private static final String CF = "p";
-  private static MockHTable table;
-  private static IndexDao hbaseDao;
 
   @BeforeClass
   public static void setupBeforeClass() throws Exception {
@@ -73,28 +66,21 @@ public class SolrUpdateIntegrationTest extends UpdateIntegrationTest {
     solrComponent.addCollection(SENSOR_NAME, "./src/test/resources/config/test/conf");
     solrComponent.addCollection("error", "./src/main/config/schema/error");
 
-    Configuration config = HBaseConfiguration.create();
-    MockHBaseTableProvider tableProvider = new MockHBaseTableProvider();
-    MockHBaseTableProvider.addToCache(TABLE_NAME, CF);
-    table = (MockHTable) tableProvider.getTable(config, TABLE_NAME);
-
-    hbaseDao = new HBaseDao();
-    AccessConfig accessConfig = new AccessConfig();
-    accessConfig.setTableProvider(tableProvider);
     Map<String, Object> globalConfig = createGlobalConfig();
     globalConfig.put(HBaseDao.HBASE_TABLE, TABLE_NAME);
     globalConfig.put(HBaseDao.HBASE_CF, CF);
-    accessConfig.setGlobalConfigSupplier(() -> globalConfig);
-    accessConfig.setIndexSupplier(s -> s);
 
-    CuratorFramework client = ConfigurationsUtils
-        .getClient(solrComponent.getZookeeperUrl());
+    CuratorFramework client = ConfigurationsUtils.getClient(solrComponent.getZookeeperUrl());
     client.start();
     ZKConfigurationsCache cache = new ZKConfigurationsCache(client);
     cache.start();
+
+    AccessConfig accessConfig = new AccessConfig();
+    accessConfig.setGlobalConfigSupplier(() -> globalConfig);
+    accessConfig.setIndexSupplier(s -> s);
     accessConfig.setIndexSupplier(IndexingCacheUtil.getIndexLookupFunction(cache, "solr"));
 
-    MultiIndexDao dao = new MultiIndexDao(hbaseDao, new SolrDao());
+    SolrDao dao = new SolrDao();
     dao.init(accessConfig);
     setDao(dao);
   }
@@ -102,7 +88,6 @@ public class SolrUpdateIntegrationTest extends UpdateIntegrationTest {
   @After
   public void reset() {
     solrComponent.reset();
-    table.clear();
   }
 
   @AfterClass
@@ -114,11 +99,6 @@ public class SolrUpdateIntegrationTest extends UpdateIntegrationTest {
   @Override
   protected String getIndexName() {
     return SENSOR_NAME;
-  }
-
-  @Override
-  protected MockHTable getMockHTable() {
-    return table;
   }
 
   private static Map<String, Object> createGlobalConfig() {
@@ -186,6 +166,7 @@ public class SolrUpdateIntegrationTest extends UpdateIntegrationTest {
 
     exception.expect(IOException.class);
     exception.expectMessage("Document contains at least one immense term in field=\"error_hash\"");
+
     getDao().update(errorDoc, Optional.of("error"));
   }
 }

--- a/metron-platform/metron-solr/metron-solr-common/src/test/java/org/apache/metron/solr/integration/components/SolrComponent.java
+++ b/metron-platform/metron-solr/metron-solr-common/src/test/java/org/apache/metron/solr/integration/components/SolrComponent.java
@@ -25,6 +25,7 @@ import org.apache.metron.common.Constants;
 import org.apache.metron.indexing.dao.metaalert.MetaAlertConstants;
 import org.apache.metron.integration.InMemoryComponent;
 import org.apache.metron.integration.UnableToStartException;
+import org.apache.metron.solr.dao.SolrDocumentBuilder;
 import org.apache.metron.solr.dao.SolrUtilities;
 import org.apache.metron.solr.writer.MetronSolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
@@ -86,6 +87,7 @@ public class SolrComponent implements InMemoryComponent {
   private Map<String, String> collections;
   private MiniSolrCloudCluster miniSolrCloudCluster;
   private Function<SolrComponent, Void> postStartCallback;
+  private SolrDocumentBuilder documentBuilder;
 
   private SolrComponent(int port, String solrXmlPath, Map<String, String> collections,
       Function<SolrComponent, Void> postStartCallback) {
@@ -93,6 +95,7 @@ public class SolrComponent implements InMemoryComponent {
     this.solrXmlPath = solrXmlPath;
     this.collections = collections;
     this.postStartCallback = postStartCallback;
+    this.documentBuilder = new SolrDocumentBuilder();
   }
 
   @Override
@@ -183,7 +186,7 @@ public class SolrComponent implements InMemoryComponent {
       QueryResponse response = solr.query(parameters);
       for (SolrDocument solrDocument : response.getResults()) {
         // Use the utils to make sure we get child docs.
-        docs.add(SolrUtilities.toDocument(solrDocument).getDocument());
+        docs.add(documentBuilder.toDocument(solrDocument).getDocument());
       }
     } catch (SolrServerException | IOException e) {
       e.printStackTrace();

--- a/metron-platform/metron-solr/metron-solr-common/src/test/java/org/apache/metron/solr/matcher/SolrInputDocumentMatcher.java
+++ b/metron-platform/metron-solr/metron-solr-common/src/test/java/org/apache/metron/solr/matcher/SolrInputDocumentMatcher.java
@@ -21,6 +21,8 @@ import org.apache.solr.common.SolrInputDocument;
 import org.hamcrest.Description;
 import org.mockito.ArgumentMatcher;
 
+import java.util.Objects;
+
 public class SolrInputDocumentMatcher extends ArgumentMatcher<SolrInputDocument> {
 
   private SolrInputDocument expectedSolrInputDocument;
@@ -31,16 +33,24 @@ public class SolrInputDocumentMatcher extends ArgumentMatcher<SolrInputDocument>
 
   @Override
   public boolean matches(Object o) {
-    SolrInputDocument solrInputDocument = (SolrInputDocument) o;
-    for(String field: solrInputDocument.getFieldNames()) {
-      Object expectedValue = expectedSolrInputDocument.getField(field).getValue();
-      Object value = solrInputDocument.getField(field).getValue();
-      boolean matches = expectedValue != null ? expectedValue.equals(value) : value == null;
-      if (!matches) {
-        return false;
+    boolean matches = false;
+
+    SolrInputDocument actual = (SolrInputDocument) o;
+    for(String expectedField: expectedSolrInputDocument.getFieldNames()) {
+      Object expectedValue = expectedSolrInputDocument.getField(expectedField).getValue();
+
+      // does it even have the expected field?
+      boolean hasField = actual.getField(expectedField) != null;
+      if(hasField) {
+
+        // is the field value the same?
+        Object actualValue = actual.getField(expectedField).getValue();
+        if(Objects.equals(expectedValue, actualValue)) {
+          matches = true;
+        }
       }
     }
-    return true;
+    return matches;
   }
 
   @Override

--- a/metron-platform/metron-solr/metron-solr-storm/pom.xml
+++ b/metron-platform/metron-solr/metron-solr-storm/pom.xml
@@ -34,6 +34,12 @@
             <groupId>org.apache.metron</groupId>
             <artifactId>metron-solr-common</artifactId>
             <version>${project.parent.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.metron</groupId>

--- a/metron-platform/metron-solr/metron-solr-storm/src/test/java/org/apache/metron/indexing/integration/SolrIndexingIntegrationTest.java
+++ b/metron-platform/metron-solr/metron-solr-storm/src/test/java/org/apache/metron/indexing/integration/SolrIndexingIntegrationTest.java
@@ -18,18 +18,11 @@
 package org.apache.metron.indexing.integration;
 
 import com.google.common.base.Function;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import javax.annotation.Nullable;
-
-import org.apache.metron.TestConstants;
 import org.apache.metron.common.configuration.Configurations;
 import org.apache.metron.common.configuration.ConfigurationsUtils;
 import org.apache.metron.common.field.FieldNameConverter;
 import org.apache.metron.common.utils.JSONUtils;
 import org.apache.metron.enrichment.integration.utils.SampleUtil;
-import org.apache.metron.indexing.integration.IndexingIntegrationTest;
 import org.apache.metron.integration.ComponentRunner;
 import org.apache.metron.integration.InMemoryComponent;
 import org.apache.metron.integration.Processor;
@@ -39,6 +32,11 @@ import org.apache.metron.integration.components.KafkaComponent;
 import org.apache.metron.integration.components.ZKServerComponent;
 import org.apache.metron.solr.SolrConstants;
 import org.apache.metron.solr.integration.components.SolrComponent;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 
 public class SolrIndexingIntegrationTest extends IndexingIntegrationTest {

--- a/metron-platform/metron-solr/metron-solr-storm/src/test/java/org/apache/metron/solr/dao/SolrDocumentBuilderTest.java
+++ b/metron-platform/metron-solr/metron-solr-storm/src/test/java/org/apache/metron/solr/dao/SolrDocumentBuilderTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.solr.dao;
+
+import org.apache.metron.common.Constants;
+import org.apache.metron.indexing.dao.update.Document;
+import org.apache.solr.common.SolrDocument;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests the {@link SolrDocumentBuilder}.
+ */
+public class SolrDocumentBuilderTest {
+
+  private SolrDocumentBuilder builder;
+
+  @Before
+  public void setup() {
+    builder = new SolrDocumentBuilder();
+  }
+
+  @Test
+  public void shouldCreateSolrDocument() {
+    Document document = document();
+    SolrDocument solrDocument = builder.fromDocument(document);
+
+    assertFalse(solrDocument.hasChildDocuments());
+    assertFalse(solrDocument.isEmpty());
+    assertEquals("192.168.1.12", solrDocument.get("ip_src_addr"));
+    assertEquals("192.168.1.24", solrDocument.get("ip_dst_addr"));
+    assertEquals("123456789", solrDocument.get("timestamp"));
+  }
+
+  @Test
+  public void shouldCreateDocumentFromSolr() {
+    final String expectedGUID = UUID.randomUUID().toString();
+    final String expectedIP = "192.168.1.12";
+    SolrDocument solrDocument = createSolrDocument(expectedGUID, expectedIP);
+
+    Document actual = builder.toDocument(solrDocument);
+    assertEquals(expectedGUID, actual.getGuid());
+    assertEquals(expectedGUID, actual.getDocument().get(Constants.GUID));
+    assertEquals("bro", actual.getSensorType());
+    assertEquals("bro", actual.getDocument().get(Constants.SENSOR_TYPE));
+    assertEquals(123456789L, (long) actual.getTimestamp());
+    assertEquals(123456789L, actual.getDocument().get(Constants.Fields.TIMESTAMP.getName()));
+    assertEquals(expectedIP, actual.getDocument().get("ip_src_addr"));
+  }
+
+  @Test
+  public void shouldHandleMissingSensorType() {
+    final String expectedGUID = UUID.randomUUID().toString();
+    final String expectedIP = "192.168.1.12";
+    SolrDocument solrDocument = createSolrDocument(expectedGUID, expectedIP);
+
+    // create a child alert so that the document represents a meta-alert
+    SolrDocument childAlert = new SolrDocument();
+    solrDocument.addChildDocument(childAlert);
+
+    // remove the sensor type field to create a malformed document
+    solrDocument.removeFields(Constants.SENSOR_TYPE);
+
+    Document actual = builder.toDocument(solrDocument);
+    assertEquals(expectedGUID, actual.getGuid());
+    assertEquals(expectedGUID, actual.getDocument().get(Constants.GUID));
+    assertEquals(123456789L, (long) actual.getTimestamp());
+    assertEquals(123456789L, actual.getDocument().get(Constants.Fields.TIMESTAMP.getName()));
+    assertEquals(expectedIP, actual.getDocument().get("ip_src_addr"));
+
+    // the sensor type is unknown
+    assertNull(actual.getSensorType());
+    assertNull(actual.getDocument().get(Constants.SENSOR_TYPE));
+  }
+
+  private SolrDocument createSolrDocument(String guid, String ipAddress) {
+    SolrDocument solrDocument = new SolrDocument();
+    solrDocument.addField(SolrDao.VERSION_FIELD, 1.0);
+    solrDocument.addField(Constants.GUID, guid);
+    solrDocument.addField(Constants.SENSOR_TYPE, "bro");
+    solrDocument.addField(Constants.Fields.TIMESTAMP.getName(), 123456789L);
+    solrDocument.addField("ip_src_addr", ipAddress);
+    return solrDocument;
+  }
+
+  private Document document() {
+    return new Document(fields(), UUID.randomUUID().toString(), "bro", System.currentTimeMillis());
+  }
+
+  private Map<String, Object> fields() {
+    return new HashMap<String, Object>() {{
+      put("ip_src_addr", "192.168.1.12");
+      put("ip_dst_addr", "192.168.1.24");
+      put("timestamp", "123456789");
+    }};
+  }
+}


### PR DESCRIPTION
The `SolrUpdateIntegrationTest` is not testing that the `SolrDao` can update and retrieve values.

- [x] This PR builds on #1451 .  The diffs here will include the changes in #1451 until that PR is merged.

### What?
This gap in the integration test is hiding a few existing bugs in the `SolrUpdateIntegrationTest`.  This fix is similar to what was done for Elasticsearch in #1451.

### Why? 
These problems arise because of the way the test is setup.  Instead of directly testing a `SolrDao` this test runs against a `MultiIndexDao` initialized with both a `SolrDao` and an `HBaseDao`. On retrievals the `MultIndexDao` will return the document from whichever index responds first.

With the current test setup, the underlying `SolrDao` will never retrieve the document that the test case is expecting.  In all cases where the test passes, the document is actually being returned from the `HBaseDao` which is actually just interacting with a mock backend.  The test needs to actually test that we can update and retrieve documents from Elasticsearch.

### Bugs?
After correcting the test setup in `SolrUpdateIntegrationTest` the following bugs were found.
1. A timestamp is not being populated in the documents returned from Solr.
1. The comment field is not removed from the document when the last comment is removed.
1. A NullPointerException occurs if a document does not contain a sensor type.

### Changes

1. The `SolrUpdateIntegrationTest` was changed so that it specifically tests a `SolrDao`.

1. The logic to serialize and deserialize a document to/from Solr was moved into a new abstraction called a `DocumentBuilder`.  The Solr DAOs now all use a `SolrDocumentBuilder` to do this.  Most of the existing logic from `SolrUtilities` was moved to `SolrDocumentBuilder`, except for portions that needed corrected.  

    This allowed me to add unit tests for this logic in `SolrDocumentBuilderTests`. Specifically, I was able to add a test to ensure that the document's timestamp is being set correctly and that a missing sensor type does not cause a NullPointerException.

1. Duplicate logic to add, remove, and (de)serialize comments existed in `UpdateIntegrationTest`, `SolrUpdateDao`, `SolrUtilities`, `HBaseUpdateDao`, and `ElasticsearchUpdateDao`. This logic was also not covered by unit tests.

    The comment logic was moved to `Document` so that it could be reused.  This made it so that no additional "reformatting" logic was needed for the comments. This also made it easy to add unit tests to test this functionality in `DocumentTest`.

1. After the previous change the logic for adding and removing comments is exactly the same for Solr, HBase, and Elasticsearch.  So there is no need for custom `addCommentToAlert` and `removeCommentFromAlert` in `HBaseUpdateDao`, `SolrUpdateDao`, and `ElasticsearchUpdateDao`.  The shared implementation for these was moved up to the `UpdateDao` interface as default methods.

### Acceptance Testing

- [ ] Validate against Elasticsearch.
    1. Spin-up Full Dev with Elasticsearch running.
    1. Ensure alerts are visible in the Alerts UI.
    1. Add a comment to an alert.

- [ ] Validate against Solr.
    1. Spin-up Full Dev with Solr running.
    1. Ensure alerts are visible in the Alerts UI.
    1. Add a comment to an alert.


## Pull Request Checklist
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
