### PR TITLE
METRON-2191: [UI] Checkbox selector on Alerts UI is broken

### DIFF
--- a/metron-interface/metron-alerts/src/app/shared/context-menu/context-menu.component.ts
+++ b/metron-interface/metron-alerts/src/app/shared/context-menu/context-menu.component.ts
@@ -54,6 +54,10 @@ export class ContextMenuComponent implements OnInit, AfterContentInit, OnDestroy
 
   private popper: Popper;
 
+  private excludedDomElements = [
+    'label', 'input', 'button'
+  ];
+
   constructor(
     private contextMenuSvc: ContextMenuService,
     private host: ElementRef
@@ -100,10 +104,14 @@ export class ContextMenuComponent implements OnInit, AfterContentInit, OnDestroy
   }
 
   private toggle($event: MouseEvent) {
+    if (this.isElementExcluded($event)) {
+      return;
+    }
+
     $event.stopPropagation();
 
     if (!this.isEnabled) {
-      this.host.nativeElement.dispatchEvent(new Event(this.ctxMenuItems[0].event));
+      this.dispatchDefaultEvent($event);
       return;
     }
 
@@ -132,6 +140,14 @@ export class ContextMenuComponent implements OnInit, AfterContentInit, OnDestroy
       characterData: false,
       subtree: true}
     );
+  }
+
+  private dispatchDefaultEvent($event: MouseEvent) {
+    this.host.nativeElement.dispatchEvent(new Event(this.ctxMenuItems[0].event));
+  }
+
+  private isElementExcluded($event: MouseEvent) {
+    return this.excludedDomElements.find(element => element === ($event.target as HTMLElement).nodeName.toLowerCase());
   }
 
   private getContextMenuOrigin($event: MouseEvent): HTMLElement {


### PR DESCRIPTION
## Contributor Comments
Alert selection by the checkbox is broken on the Alerts UI. The issue occurs when the context menu turned off. This is a possible regression of that feature. I fixed and retested the feature now it works fine.

### Expected behavior
Click on checkbox selector should mark the item as selected for further operation in the actions menu. The checkbox should not be impacted by the on or off state of the context menu feature.

### Actual behavior
Click on checkbox selector opening the detail pane when context menu turned off.

You can turn the context menu on and off with the config file in $METRON_ROOT/metron-interface/metron-alerts/src/assets/context-menu.conf.json

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

- [x] Have you ensured that any documentation diagrams have been updated, along with their source files, using [draw.io](https://www.draw.io/)? See [Metron Development Guidelines](https://cwiki.apache.org/confluence/display/METRON/Development+Guidelines) for instructions.

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
