### PR TITLE
METRON-2192: [UI] "All time" time range is broken on Alerts UI

### DIFF
--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/alerts-list.component.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/alerts-list.component.ts
@@ -296,7 +296,7 @@ export class AlertsListComponent implements OnInit, OnDestroy {
 
   private updateQueryBuilder(timeRangeFilter: Filter) {
     if (timeRangeFilter.value === ALL_TIME) {
-      this.queryBuilder.removeFilter(timeRangeFilter);
+      this.queryBuilder.removeFilterByField(timeRangeFilter.field);
     } else {
       this.queryBuilder.addOrUpdateFilter(timeRangeFilter);
     }

--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/query-builder.spec.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/query-builder.spec.ts
@@ -130,4 +130,36 @@ describe('query-builder', () => {
     expect(queryBuilder.searchRequest.query).toBe('(source\\:type:bro OR metron_alert.source\\:type:bro)');
   });
 
+  it('removeFilter should remove filter by reference', () => {
+    const queryBuilder = new QueryBuilder();
+
+    const filter1 = new Filter(TIMESTAMP_FIELD_NAME, '[1552863600000 TO 1552950000000]');
+    const filter2 = new Filter('fieldName', 'value');
+
+    queryBuilder.addOrUpdateFilter(filter1);
+    queryBuilder.addOrUpdateFilter(filter2);
+
+    queryBuilder.removeFilter(filter1);
+
+    expect(queryBuilder.filters.length).toBe(1);
+    expect(queryBuilder.filters[0]).toBe(filter2);
+  });
+
+  it('removeFilterByField should remove filter having the passed field name', () => {
+    const queryBuilder = new QueryBuilder();
+
+    const filter1 = new Filter('fruit', 'banana');
+    const filter2 = new Filter('fruit', 'orange');
+    const filter3 = new Filter('animal', 'horse');
+
+    queryBuilder.addOrUpdateFilter(filter1);
+    queryBuilder.addOrUpdateFilter(filter2);
+    queryBuilder.addOrUpdateFilter(filter3);
+
+    queryBuilder.removeFilterByField('fruit');
+
+    expect(queryBuilder.filters.length).toBe(1);
+    expect(queryBuilder.filters[0]).toBe(filter3);
+  });
+
 });

--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/query-builder.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/query-builder.ts
@@ -140,11 +140,12 @@ export class QueryBuilder {
   }
 
   removeFilter(filter: Filter) {
-    const filterIndex = this._filters.indexOf(filter);
-    if (filterIndex >= 0) {
-      this._filters.splice(filterIndex, 1);
-      this.onSearchChange();
-    }
+    this._filters = this._filters.filter(fItem => fItem !== filter );
+    this.onSearchChange();
+  }
+
+  removeFilterByField(field: string): void {
+    this._filters = this._filters.filter(fItem => fItem.field !== field );
   }
 
   setFields(fieldNames: string[]) {


### PR DESCRIPTION
## Contributor Comments
As part of this PR I'm fixing the 'All time' range on the Alerts UI. Selecting 'All time' in the time range selector does not clear the previously used time filter. The issue was probably introduced by show/hide functionality added a few days ago.

### Expected behavior 
Selecting 'All time' in the time range selector should clear time filter from the Lucine expression UI sends to narrow down alert entries.

### Actual behavior
When the user selecting 'All time' the previously used time filter stays applied to the query.


## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

- [x] Have you ensured that any documentation diagrams have been updated, along with their source files, using [draw.io](https://www.draw.io/)? See [Metron Development Guidelines](https://cwiki.apache.org/confluence/display/METRON/Development+Guidelines) for instructions.

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
