### PR TITLE
METRON-2220 Upgrade Streaming Enrichments for HBase 2.0.2

### DIFF
--- a/metron-platform/metron-enrichment/metron-enrichment-common/src/main/java/org/apache/metron/enrichment/converter/EnrichmentValue.java
+++ b/metron-platform/metron-enrichment/metron-enrichment-common/src/main/java/org/apache/metron/enrichment/converter/EnrichmentValue.java
@@ -23,6 +23,7 @@ import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 public class EnrichmentValue implements LookupValue {
@@ -35,11 +36,10 @@ public class EnrichmentValue implements LookupValue {
     public static final String VALUE_COLUMN_NAME = "v";
     public static final byte[] VALUE_COLUMN_NAME_B = Bytes.toBytes(VALUE_COLUMN_NAME);
 
-    private Map<String, Object> metadata = null;
+    private Map<String, Object> metadata;
 
-    public EnrichmentValue()
-    {
-
+    public EnrichmentValue() {
+      metadata = new HashMap<>();
     }
 
     public EnrichmentValue(Map<String, Object> metadata) {
@@ -66,6 +66,14 @@ public class EnrichmentValue implements LookupValue {
             }
         }
     }
+
+    public void fromColumn(byte[] columnQualifier, byte[] value) {
+      String columnValue = Bytes.toString(value);
+      if(Bytes.equals(columnQualifier, VALUE_COLUMN_NAME_B)) {
+        metadata = stringToValue(columnValue);
+      }
+    }
+
     public Map<String, Object> stringToValue(String s){
         try {
             return _mapper.get().readValue(s, new TypeReference<Map<String, Object>>(){});

--- a/metron-platform/metron-parsing/metron-parsers/pom.xml
+++ b/metron-platform/metron-parsing/metron-parsers/pom.xml
@@ -30,6 +30,15 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
   <dependencies>
+
+    <!-- Test dependencies needed preferentially -->
+    <dependency>
+      <groupId>com.github.fge</groupId>
+      <artifactId>jackson-coreutils</artifactId>
+      <version>1.8</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Metron Dependencies -->
     <dependency>
       <groupId>org.apache.metron</groupId>


### PR DESCRIPTION
This change upgrades the Streaming Enrichment Writer to work with HBase 2.0.2.
* This PR is for the `feature/METRON-2088-support-HDP-3.1` feature branch.

## Changes

1. Updated Streaming Enrichments to use an `HBaseClient`.

1. Updated Streaming Enrichments tests to use a `FakeHBaseClient`.

## Acceptance Testing

### Basics

  Verify data is flowing through the system, from parsing to indexing

  1. Open Ambari and navigate to the Metron service http://node1:8080/#/main/services/METRON/summary

  1. Open the Alerts UI

  1. Verify alerts show up in the main UI - click the search icon (you may need to wait a moment for them to appear)

  1. Head back to Ambari and select the Kibana service http://node1:8080/#/main/services/KIBANA/summary

  1. Open the Kibana dashboard via the "Metron UI" option in the quick links

  1. Verify the dashboard is populating

###  Streaming Enrichments and Enrichment Stellar Functions in the REPL

  1. Create a Streaming Enrichment [by following these instructions](https://cwiki.apache.org/confluence/display/METRON/2016/06/16/Metron+Tutorial+-+Fundamentals+Part+6%3A+Streaming+Enrichment).

  1. Define the streaming enrichment and save it as a new source of telemetry.

      ```
      [Stellar]>>> conf := SHELL_EDIT(conf)
      {
        "parserClassName": "org.apache.metron.parsers.csv.CSVParser",
        "writerClassName": "org.apache.metron.writer.hbase.SimpleHbaseEnrichmentWriter",
        "sensorTopic": "user",
        "parserConfig": {
          "shew.table": "enrichment",
          "shew.cf": "t",
          "shew.keyColumns": "ip",
          "shew.enrichmentType": "user",
          "columns": {
            "user": 0,
            "ip": 1
          }
        }
      }
      [Stellar]>>>
      [Stellar]>>> CONFIG_PUT("PARSER", conf, "user")
      ```

  1. Go to the Management UI and start the new parser called 'user'.

  1. Create some test telemetry.
      ```
      [Stellar]>>> msgs := ["user1,192.168.1.1", "user2,192.168.1.2", "user3,192.168.1.3"]
      [user1,192.168.1.1, user2,192.168.1.2, user3,192.168.1.3]
      [Stellar]>>> KAFKA_PUT("user", msgs)
      3
      [Stellar]>>> KAFKA_PUT("user", msgs)
      3
      [Stellar]>>> KAFKA_PUT("user", msgs)
      3
      ```

  1. Ensure that the enrichments are persisted in HBase.
      ```
      [Stellar]>>> ENRICHMENT_GET('user', '192.168.1.1', 'enrichment', 't')
      {original_string=user1,192.168.1.1, guid=a6caf3c1-2506-4eb7-b33e-7c05b77cd72c, user=user1, timestamp=1551813589399, source.type=user}

      [Stellar]>>> ENRICHMENT_GET('user', '192.168.1.2', 'enrichment', 't')
      {original_string=user2,192.168.1.2, guid=49e4b8fa-c797-44f0-b041-cfb47983d54a, user=user2, timestamp=1551813589399, source.type=user}

      [Stellar]>>> ENRICHMENT_GET('user', '192.168.1.3', 'enrichment', 't')
      {original_string=user3,192.168.1.3, guid=324149fd-6c4c-42a3-b579-e218c032ea7f, user=user3, timestamp=1551813589402, source.type=user}
      ```

## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
