### PR TITLE
METRON-2211: [UI] Alerts UI should optionally render timestamp in local time

### DIFF
--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/table-view/table-view.component.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/table-view/table-view.component.ts
@@ -38,6 +38,7 @@ import {HttpErrorResponse} from '@angular/common/http';
 
 import { merge } from '../../../shared/context-menu/context-menu.util'
 import * as moment from 'moment/moment';
+import { TimezoneConfigService } from 'app/alerts/configure-rows/timezone-config/timezone-config.service';
 
 export enum MetronAlertDisplayState {
   COLLAPSE, EXPAND
@@ -87,7 +88,8 @@ export class TableViewComponent implements OnInit, OnChanges, OnDestroy {
               public updateService: UpdateService,
               public metaAlertService: MetaAlertService,
               public globalConfigService: GlobalConfigService,
-              public dialogService: DialogService) {
+              public dialogService: DialogService,
+              public timezoneConfigService: TimezoneConfigService, ) {
   }
 
   ngOnInit() {
@@ -189,12 +191,9 @@ export class TableViewComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   formatValue(column: ColumnMetadata, returnValue: string) {
-    this.localTime = localStorage.getItem('convertUTCtoLocal') === 'true';
+    this.localTime = this.timezoneConfigService.getTimezoneConfig();
     try {
       if ((column.name.endsWith(':ts') || column.name.endsWith('timestamp')) && this.localTime === true) {
-        // returnValue = new Date(parseInt(returnValue, 10)).toISOString().replace('T', ' ').slice(0, 19);
-        // returnValue = moment.utc(returnValue).format('YYYY-MM-DD H:mm:ss');
-        // const timestamp = moment.utc(returnValue);
         returnValue = moment.utc(returnValue).local().format('YYYY-MM-DD H:mm:ss');
       } else if ((column.name.endsWith(':ts') || column.name.endsWith('timestamp')) && this.localTime === false) {
         returnValue = moment.utc(returnValue).format('YYYY-MM-DD H:mm:ss');

--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/table-view/table-view.component.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/table-view/table-view.component.ts
@@ -37,6 +37,7 @@ import { ConfirmationType } from 'app/model/confirmation-type';
 import {HttpErrorResponse} from '@angular/common/http';
 
 import { merge } from '../../../shared/context-menu/context-menu.util'
+import * as moment from 'moment/moment';
 
 export enum MetronAlertDisplayState {
   COLLAPSE, EXPAND
@@ -67,6 +68,7 @@ export class TableViewComponent implements OnInit, OnChanges, OnDestroy {
   configSubscription: Subscription;
 
   merge: Function = merge;
+  localTime: boolean;
 
   @Input() alerts: Alert[] = [];
   @Input() pagination: Pagination;
@@ -187,9 +189,15 @@ export class TableViewComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   formatValue(column: ColumnMetadata, returnValue: string) {
+    this.localTime = localStorage.getItem('convertUTCtoLocal') === 'true';
     try {
-      if (column.name.endsWith(':ts') || column.name.endsWith('timestamp')) {
-        returnValue = new Date(parseInt(returnValue, 10)).toISOString().replace('T', ' ').slice(0, 19);
+      if ((column.name.endsWith(':ts') || column.name.endsWith('timestamp')) && this.localTime === true) {
+        // returnValue = new Date(parseInt(returnValue, 10)).toISOString().replace('T', ' ').slice(0, 19);
+        // returnValue = moment.utc(returnValue).format('YYYY-MM-DD H:mm:ss');
+        // const timestamp = moment.utc(returnValue);
+        returnValue = moment.utc(returnValue).local().format('YYYY-MM-DD H:mm:ss');
+      } else if ((column.name.endsWith(':ts') || column.name.endsWith('timestamp')) && this.localTime === false) {
+        returnValue = moment.utc(returnValue).format('YYYY-MM-DD H:mm:ss');
       }
     } catch (e) {}
 

--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/tree-view/tree-view.component.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/tree-view/tree-view.component.ts
@@ -42,6 +42,7 @@ import { AlertSource } from '../../../model/alert-source';
 import { QueryBuilder } from '../query-builder';
 import { GroupRequest } from 'app/model/group-request';
 import { Group } from 'app/model/group';
+import { TimezoneConfigService } from 'app/alerts/configure-rows/timezone-config/timezone-config.service';
 
 @Component({
   selector: 'app-tree-view',
@@ -71,8 +72,9 @@ export class TreeViewComponent extends TableViewComponent implements OnInit, OnC
               updateService: UpdateService,
               metaAlertService: MetaAlertService,
               globalConfigService: GlobalConfigService,
-              dialogService: DialogService) {
-    super(searchService, updateService, metaAlertService, globalConfigService, dialogService);
+              dialogService: DialogService,
+              timezoneConfigService: TimezoneConfigService, ) {
+    super(searchService, updateService, metaAlertService, globalConfigService, dialogService, timezoneConfigService);
   }
 
   addAlertChangedListner() {

--- a/metron-interface/metron-alerts/src/app/alerts/configure-rows/configure-rows.component.html
+++ b/metron-interface/metron-alerts/src/app/alerts/configure-rows/configure-rows.component.html
@@ -39,6 +39,9 @@
 
       <label> HIDE ALERT ENTRIES </label>
       <app-show-hide-alert-entries (changed)="configRowsChange.emit($event)" ></app-show-hide-alert-entries>
+
+      <label class="pt-2"> TIMEZONE CONFIGURATION </label>
+      <app-timezone-config></app-timezone-config>
       </form>
   </div>
 </div>

--- a/metron-interface/metron-alerts/src/app/alerts/configure-rows/configure-rows.component.spec.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/configure-rows/configure-rows.component.spec.ts
@@ -22,6 +22,7 @@ import { ConfigureRowsComponent } from './configure-rows.component';
 import { ConfigureTableService } from '../../service/configure-table.service';
 import { ShowHideAlertEntriesComponent } from './show-hide/show-hide-alert-entries.component';
 import { SwitchComponent } from 'app/shared/switch/switch.component';
+import { TimezoneConfigComponent } from './timezone-config/timezone-config.component';
 
 @Injectable()
 class ConfigureTableServiceStub {}
@@ -36,6 +37,7 @@ describe('ConfigureRowsComponent', () => {
         ConfigureRowsComponent,
         ShowHideAlertEntriesComponent,
         SwitchComponent,
+        TimezoneConfigComponent,
       ],
       providers: [
         { provide: ConfigureTableService, useValue: ConfigureTableServiceStub }

--- a/metron-interface/metron-alerts/src/app/alerts/configure-rows/configure-rows.module.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/configure-rows/configure-rows.module.ts
@@ -23,15 +23,16 @@ import { SwitchModule } from 'app/shared/switch/switch.module';
 import { QueryBuilder } from '../alerts-list/query-builder';
 import { ShowHideService } from './show-hide/show-hide.service';
 import { TimezoneConfigComponent } from './timezone-config/timezone-config.component';
+import { TimezoneConfigService } from './timezone-config/timezone-config.service';
 
 @NgModule({
     imports: [ SharedModule, SwitchModule ],
     declarations: [ ConfigureRowsComponent, ShowHideAlertEntriesComponent, TimezoneConfigComponent ],
     exports: [ ConfigureRowsComponent ],
-    providers: [ QueryBuilder, ShowHideService ],
+    providers: [ QueryBuilder, ShowHideService, TimezoneConfigService, ],
 })
 export class ConfigureRowsModule {
 
-    constructor(private showHideService: ShowHideService) {}
+    constructor(private showHideService: ShowHideService, private timezoneConfigService: TimezoneConfigService) {}
 
 }

--- a/metron-interface/metron-alerts/src/app/alerts/configure-rows/configure-rows.module.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/configure-rows/configure-rows.module.ts
@@ -22,10 +22,11 @@ import { ShowHideAlertEntriesComponent } from './show-hide/show-hide-alert-entri
 import { SwitchModule } from 'app/shared/switch/switch.module';
 import { QueryBuilder } from '../alerts-list/query-builder';
 import { ShowHideService } from './show-hide/show-hide.service';
+import { TimezoneConfigComponent } from './timezone-config/timezone-config.component';
 
 @NgModule({
     imports: [ SharedModule, SwitchModule ],
-    declarations: [ ConfigureRowsComponent, ShowHideAlertEntriesComponent ],
+    declarations: [ ConfigureRowsComponent, ShowHideAlertEntriesComponent, TimezoneConfigComponent ],
     exports: [ ConfigureRowsComponent ],
     providers: [ QueryBuilder, ShowHideService ],
 })

--- a/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.component.spec.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.component.spec.ts
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TimezoneConfigComponent } from './timezone-config.component';

--- a/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.component.spec.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TimezoneConfigComponent } from './timezone-config.component';
+
+describe('TimezoneConfigComponent', () => {
+  let component: TimezoneConfigComponent;
+  let fixture: ComponentFixture<TimezoneConfigComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TimezoneConfigComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TimezoneConfigComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.component.spec.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.component.spec.ts
@@ -1,16 +1,31 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TimezoneConfigComponent } from './timezone-config.component';
+import { SwitchComponent } from 'app/shared/switch/switch.component';
+import { TimezoneConfigService } from './timezone-config.service';
+import { By } from '@angular/platform-browser';
+
+class TimezoneConfigServiceStub {
+  toggleUTCtoLocal(showLocal) {}
+}
 
 describe('TimezoneConfigComponent', () => {
   let component: TimezoneConfigComponent;
   let fixture: ComponentFixture<TimezoneConfigComponent>;
+  let service: TimezoneConfigService;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ TimezoneConfigComponent ]
+      declarations: [
+        TimezoneConfigComponent,
+        SwitchComponent,
+      ],
+      providers: [
+        { provide: TimezoneConfigService, useClass: TimezoneConfigServiceStub },
+      ]
     })
     .compileComponents();
+    service = TestBed.get(TimezoneConfigService);
   }));
 
   beforeEach(() => {
@@ -21,5 +36,24 @@ describe('TimezoneConfigComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should toggle between UTC and Local time when clicked', () => {
+    spyOn(service, 'toggleUTCtoLocal');
+    spyOn(component, 'toggleTimezoneConfig').and.callThrough();
+    fixture.detectChanges();
+
+    const timeToggle = fixture.debugElement.query(By.css('[data-qe-id="UTCtoLocalToggle"] input')).nativeElement;
+    timeToggle.click();
+    fixture.detectChanges();
+    expect(timeToggle.checked).toBe(true);
+    expect(component.toggleTimezoneConfig).toHaveBeenCalledWith(true);
+    expect(service.toggleUTCtoLocal).toHaveBeenCalledWith(true);
+
+    timeToggle.click();
+    fixture.detectChanges();
+    expect(timeToggle.checked).toBe(false);
+    expect(component.toggleTimezoneConfig).toHaveBeenCalledWith(false);
+    expect(component.timezoneConfigService.toggleUTCtoLocal).toHaveBeenCalledWith(false);
   });
 });

--- a/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.component.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.component.ts
@@ -12,10 +12,8 @@ import { TimezoneConfigService } from './timezone-config.service';
     ></app-switch>
   `,
 })
-export class TimezoneConfigComponent implements OnInit {
+export class TimezoneConfigComponent {
   constructor(public timezoneConfigService: TimezoneConfigService) {}
-
-  ngOnInit() {}
 
   toggleTimezoneConfig(isLocal) {
     this.timezoneConfigService.toggleUTCtoLocal(isLocal);

--- a/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.component.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.component.ts
@@ -5,6 +5,7 @@ import { TimezoneConfigService } from './timezone-config.service';
   selector: 'app-timezone-config',
   template: `
     <app-switch
+      data-qe-id="UTCtoLocalToggle"
       [text]="'Convert timestamps to local time'"
       (onChange)="toggleTimezoneConfig($event)"
       [selected]="timezoneConfigService.showLocal"
@@ -16,7 +17,7 @@ export class TimezoneConfigComponent implements OnInit {
 
   ngOnInit() {}
 
-  toggleTimezoneConfig(e) {
-    this.timezoneConfigService.toggleUTCtoLocal(e);
+  toggleTimezoneConfig(isLocal) {
+    this.timezoneConfigService.toggleUTCtoLocal(isLocal);
   }
 }

--- a/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.component.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.component.ts
@@ -1,0 +1,22 @@
+import { Component, OnInit } from '@angular/core';
+import { TimezoneConfigService } from './timezone-config.service';
+
+@Component({
+  selector: 'app-timezone-config',
+  template: `
+    <app-switch
+      [text]="'Convert timestamps to local time'"
+      (onChange)="toggleTimezoneConfig($event)"
+      [selected]="timezoneConfigService.showLocal"
+    ></app-switch>
+  `,
+})
+export class TimezoneConfigComponent implements OnInit {
+  constructor(public timezoneConfigService: TimezoneConfigService) {}
+
+  ngOnInit() {}
+
+  toggleTimezoneConfig(e) {
+    this.timezoneConfigService.toggleUTCtoLocal(e);
+  }
+}

--- a/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.component.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.component.ts
@@ -1,4 +1,21 @@
-import { Component, OnInit } from '@angular/core';
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component } from '@angular/core';
 import { TimezoneConfigService } from './timezone-config.service';
 
 @Component({

--- a/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.service.spec.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { TimezoneConfigService } from './timezone-config.service';
+
+describe('TimezoneConfigService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: TimezoneConfigService = TestBed.get(TimezoneConfigService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.service.spec.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.service.spec.ts
@@ -29,4 +29,10 @@ describe('TimezoneConfigService', () => {
   it('should set initial switch state', () => {
     expect(service.toggleUTCtoLocal).toHaveBeenCalledWith(true);
   });
+
+  it('should return the current timezone configuration with getTimezoneConfig()', () => {
+    expect(service.getTimezoneConfig()).toBe(true);
+    service.showLocal = false;
+    expect(service.getTimezoneConfig()).toBe(false);
+  });
 });

--- a/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.service.spec.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.service.spec.ts
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { TestBed } from '@angular/core/testing';
 
 import { TimezoneConfigService } from './timezone-config.service';

--- a/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.service.spec.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.service.spec.ts
@@ -1,12 +1,32 @@
 import { TestBed } from '@angular/core/testing';
 
 import { TimezoneConfigService } from './timezone-config.service';
+import { SwitchComponent } from 'app/shared/switch/switch.component';
 
 describe('TimezoneConfigService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+  let service: TimezoneConfigService;
+
+  beforeEach(() => {
+    spyOn(localStorage, 'getItem').and.returnValues('true');
+
+    TestBed.configureTestingModule({
+      declarations: [ SwitchComponent ],
+      providers: [ TimezoneConfigService ]
+    });
+
+    spyOn(TimezoneConfigService.prototype, 'toggleUTCtoLocal').and.callThrough();
+    service = TestBed.get(TimezoneConfigService);
+  });
 
   it('should be created', () => {
-    const service: TimezoneConfigService = TestBed.get(TimezoneConfigService);
     expect(service).toBeTruthy();
+  });
+
+  it('should get persisted state from localStorage', () => {
+    expect(localStorage.getItem).toHaveBeenCalledWith(service.CONVERT_UTC_TO_LOCAL_KEY);
+  });
+
+  it('should set initial switch state', () => {
+    expect(service.toggleUTCtoLocal).toHaveBeenCalledWith(true);
   });
 });

--- a/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.service.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.service.ts
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { Injectable } from '@angular/core';
 
 @Injectable({

--- a/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.service.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { QueryBuilder } from 'app/alerts/alerts-list/query-builder';
 
 @Injectable({
   providedIn: 'root'
@@ -9,12 +10,17 @@ export class TimezoneConfigService {
 
   showLocal = false;
 
-  constructor() {
+  constructor(public queryBuilder: QueryBuilder) {
     this.showLocal = localStorage.getItem(this.CONVERT_UTC_TO_LOCAL_KEY) === 'true';
     this.toggleUTCtoLocal(this.showLocal);
   }
 
   toggleUTCtoLocal(isLocal: boolean) {
+    this.showLocal = isLocal;
     localStorage.setItem(this.CONVERT_UTC_TO_LOCAL_KEY, isLocal.toString());
+  }
+
+  getTimezoneConfig() {
+    return this.showLocal;
   }
 }

--- a/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.service.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { QueryBuilder } from 'app/alerts/alerts-list/query-builder';
 
 @Injectable({
   providedIn: 'root'
@@ -10,7 +9,7 @@ export class TimezoneConfigService {
 
   showLocal = false;
 
-  constructor(public queryBuilder: QueryBuilder) {
+  constructor() {
     this.showLocal = localStorage.getItem(this.CONVERT_UTC_TO_LOCAL_KEY) === 'true';
     this.toggleUTCtoLocal(this.showLocal);
   }

--- a/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.service.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/configure-rows/timezone-config/timezone-config.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TimezoneConfigService {
+
+  public readonly CONVERT_UTC_TO_LOCAL_KEY = 'convertUTCtoLocal';
+
+  showLocal = false;
+
+  constructor() {
+    this.showLocal = localStorage.getItem(this.CONVERT_UTC_TO_LOCAL_KEY) === 'true';
+    this.toggleUTCtoLocal(this.showLocal);
+  }
+
+  toggleUTCtoLocal(isLocal: boolean) {
+    localStorage.setItem(this.CONVERT_UTC_TO_LOCAL_KEY, isLocal.toString());
+  }
+}


### PR DESCRIPTION
## Contributor Comments
Link to ASF Jira ticket: https://issues.apache.org/jira/browse/METRON-2211

Currently, timestamps show in UTC time when the timestamp field is included as a column header. This PR adds a toggle button that, when switched on, will show timestamps relative to local time vs. UTC.

## Testing
Open the Alerts UI and perform a search. Click on the Settings button (see the gif below) and click on the switch with the label `Convert timestamps to local time.` You should see the timestamps update accordingly. For example, I'm UTC +2, so you'll see in the gif below that the timestamps added 2 hours when the local switch was enabled.

![local-time-switch](https://user-images.githubusercontent.com/7304869/63531114-1ab52480-c508-11e9-84d1-3464abdf4f8c.gif)

This feature references your OS' time settings, so feel free to update to another timezone and test that the timestamps update as they should. The timezone setting is kept in local storage, so a page reload should retain your settings.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

- [x] Have you ensured that any documentation diagrams have been updated, along with their source files, using [draw.io](https://www.draw.io/)? See [Metron Development Guidelines](https://cwiki.apache.org/confluence/display/METRON/Development+Guidelines) for instructions.

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
