### PR TITLE
METRON-2235 - Increase server startup timeout

### DIFF
--- a/metron-deployment/ansible/roles/ambari_master/tasks/ambari.yml
+++ b/metron-deployment/ansible/roles/ambari_master/tasks/ambari.yml
@@ -30,6 +30,12 @@
     replace: " -Xmx{{ ambari_server_mem }}m "
     backup: no
 
+- name: Allow 150 seconds of startup time for ambari server
+  lineinfile:
+    path: /etc/ambari-server/conf/ambari.properties
+    regexp: 'server\.startup\.web\.timeout='
+    line: 'server.startup.web.timeout=150'
+
 - name: Setup Ambari Server
   shell: ambari-server setup -s && touch /etc/ambari-server/configured creates=/etc/ambari-server/configured
   register: ambari_server_setup


### PR DESCRIPTION
## Contributor Comments
With full dev on slower systems ambari startup can take longer then the default 50 seconds.  This update tweaks the ansible setup scripts to change the timeout to 150 seconds.

When run from the command line this appears as 
```
Waiting for server start............................................................

DB configs consistency check: no errors and warnings were found.

ERROR: Exiting with exit code 1.

REASON: Server not yet listening on http port 8080 after 50 seconds. Exiting.
```

This shows itself during a full dev build as occasional errors during the Ansible setup script about an error occurred during the final phases of the full dev deployment, however logging onto Ambari server to identify what went wrong shows a server running fine.


Testing:
1. Run full dev deploy
2. Login to node1:8080 to verify Ambari has started successfully
2. ssh onto dev box and check file `/etc/amabri-server/conf/ambari.properties`
for line `server.startup.web.timeout=150`

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- n/a Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- n/a Have you written or updated unit tests and or integration tests to verify your changes?
- n/a If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- n/a Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

- n/a Have you ensured that any documentation diagrams have been updated, along with their source files, using [draw.io](https://www.draw.io/)? See [Metron Development Guidelines](https://cwiki.apache.org/confluence/display/METRON/Development+Guidelines) for instructions.

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.