### PR TITLE
METRON-2247 - rpm-docker: Provide an option to bypass running rpmlint

### DIFF
--- a/metron-deployment/ansible/roles/metron-builder/tasks/build-rpms.yml
+++ b/metron-deployment/ansible/roles/metron-builder/tasks/build-rpms.yml
@@ -15,8 +15,10 @@
 #  limitations under the License.
 #
 ---
-- name: Build Metron RPM Packages
+- name: Build Metron RPM Packages {{ '(skipping rpmlint)' if SKIP_RPMLINT is defined else '' }}
   shell: "{{ item }}"
+  environment:
+    SKIP_RPMLINT: "{{ SKIP_RPMLINT if SKIP_RPMLINT is defined else '' }}"
   args:
     chdir: "{{ metron_build_dir }}/metron-deployment"
   with_items:

--- a/metron-deployment/development/centos6/README.md
+++ b/metron-deployment/development/centos6/README.md
@@ -91,6 +91,15 @@ Any platform that supports these tools is suitable, but the following instructio
     env ANSIBLE_ARGS='--extra-vars "SKIP_RPMLINT=1"' vagrant up
     ```
 
+### Deployment debugging
+
+1.  To enable more verbose logging of ansible actions during the deployment, use
+    ```
+    env ANSIBLE_ARGS=' -vvvv' vagrant up
+    ```
+    As this can produce large amounts of logging, it is best to redirect output to a file for later analysis.
+    
+
 ### Explore Metron
 
 Navigate to the following resources to explore your newly minted Apache Metron environment.

--- a/metron-deployment/development/centos6/README.md
+++ b/metron-deployment/development/centos6/README.md
@@ -81,15 +81,15 @@ Any platform that supports these tools is suitable, but the following instructio
 ### Deployment optimizations
 
 1. Set environment variable 
-```
-export ANSIBLE_ARGS='--extra-vars "SKIP_RPMLINT=1"'
-```
-To disable running rpmlint as part of the dev deployment task - this can save a couple of minutes of time on the deployment.
-Either add this variable to your profile, or use it on the command line like
+    ```
+    export ANSIBLE_ARGS='--extra-vars "SKIP_RPMLINT=1"'
+    ```
+    To disable running rpmlint as part of the dev deployment task - this can save a couple of minutes of time on the deployment.
+    Either add this variable to your profile, or use it on the command line like
 
-```
-env ANSIBLE_ARGS='--extra-vars "SKIP_RPMLINT=1"' vagrant up
-```
+    ```
+    env ANSIBLE_ARGS='--extra-vars "SKIP_RPMLINT=1"' vagrant up
+    ```
 
 ### Explore Metron
 

--- a/metron-deployment/development/centos6/README.md
+++ b/metron-deployment/development/centos6/README.md
@@ -78,6 +78,19 @@ Any platform that supports these tools is suitable, but the following instructio
     vagrant provision
     ```
 
+### Deployment optimizations
+
+1. Set environment variable 
+```
+export ANSIBLE_ARGS='--extra-vars "SKIP_RPMLINT=1"'
+```
+To disable running rpmlint as part of the dev deployment task - this can save a couple of minutes of time on the deployment.
+Either add this variable to your profile, or use it on the command line like
+
+```
+env ANSIBLE_ARGS='--extra-vars "SKIP_RPMLINT=1"' vagrant up
+```
+
 ### Explore Metron
 
 Navigate to the following resources to explore your newly minted Apache Metron environment.

--- a/metron-deployment/development/centos6/Vagrantfile
+++ b/metron-deployment/development/centos6/Vagrantfile
@@ -102,5 +102,7 @@ Vagrant.configure(2) do |config|
     ansible.skip_tags = ansibleSkipTags.split(",") if ansibleSkipTags != ''
     ansible.inventory_path = "ansible/inventory"
     ansible.compatibility_mode = "auto"
+    #ansible.verbose = "vvv"
+    ansible.raw_arguments = Shellwords.shellsplit(ENV['ANSIBLE_ARGS']) if ENV['ANSIBLE_ARGS']
   end
 end

--- a/metron-deployment/development/centos6/Vagrantfile
+++ b/metron-deployment/development/centos6/Vagrantfile
@@ -102,7 +102,6 @@ Vagrant.configure(2) do |config|
     ansible.skip_tags = ansibleSkipTags.split(",") if ansibleSkipTags != ''
     ansible.inventory_path = "ansible/inventory"
     ansible.compatibility_mode = "auto"
-    #ansible.verbose = "vvv"
     ansible.raw_arguments = Shellwords.shellsplit(ENV['ANSIBLE_ARGS']) if ENV['ANSIBLE_ARGS']
   end
 end

--- a/metron-deployment/development/centos6/ansible.cfg
+++ b/metron-deployment/development/centos6/ansible.cfg
@@ -21,6 +21,7 @@ roles_path = ../../ansible/roles
 pipelining = True
 log_path = ./ansible.log
 callback_plugins = ../../ansible/callback_plugins
+callback_whitelist = profile_tasks
 
 # fix for "ssh throws 'unix domain socket too long' " problem
 [ssh_connection]

--- a/metron-deployment/development/centos7/Vagrantfile
+++ b/metron-deployment/development/centos7/Vagrantfile
@@ -101,7 +101,6 @@ Vagrant.configure(2) do |config|
     ansible.skip_tags = ansibleSkipTags.split(",") if ansibleSkipTags != ''
     ansible.inventory_path = "ansible/inventory"
     ansible.compatibility_mode = "auto"
-    #ansible.verbose = "vvv"
     ansible.raw_arguments = Shellwords.shellsplit(ENV['ANSIBLE_ARGS']) if ENV['ANSIBLE_ARGS']
   end
 end

--- a/metron-deployment/development/centos7/Vagrantfile
+++ b/metron-deployment/development/centos7/Vagrantfile
@@ -64,7 +64,6 @@ Vagrant.configure(2) do |config|
   if Vagrant.has_plugin?("vagrant-cachier")
     config.cache.enable :yum
     config.cache.scope = :box
-
     config.cache.synced_folder_opts = {
       type: :nfs,
       mount_options: ['rw', 'vers=3', 'tcp', 'nolock']
@@ -102,7 +101,7 @@ Vagrant.configure(2) do |config|
     ansible.skip_tags = ansibleSkipTags.split(",") if ansibleSkipTags != ''
     ansible.inventory_path = "ansible/inventory"
     ansible.compatibility_mode = "auto"
-    ansible.raw_arguments  = [
-    ]
+    #ansible.verbose = "vvv"
+    ansible.raw_arguments = Shellwords.shellsplit(ENV['ANSIBLE_ARGS']) if ENV['ANSIBLE_ARGS']
   end
 end

--- a/metron-deployment/development/centos7/ansible.cfg
+++ b/metron-deployment/development/centos7/ansible.cfg
@@ -21,6 +21,7 @@ roles_path = ../../ansible/roles
 pipelining = True
 log_path = ./ansible.log
 callback_plugins = ../../ansible/callback_plugins
+callback_whitelist = profile_tasks
 
 # fix for "ssh throws 'unix domain socket too long' " problem
 [ssh_connection]

--- a/metron-deployment/development/ubuntu14/Vagrantfile
+++ b/metron-deployment/development/ubuntu14/Vagrantfile
@@ -97,7 +97,6 @@ Vagrant.configure(2) do |config|
     ansible.skip_tags = ansibleSkipTags.split(",") if ansibleSkipTags != ''
     ansible.inventory_path = "ansible/inventory"
     ansible.compatibility_mode = "auto"
-    #ansible.verbose = "vvv"
     ansible.raw_arguments = Shellwords.shellsplit(ENV['ANSIBLE_ARGS']) if ENV['ANSIBLE_ARGS']
   end
 end

--- a/metron-deployment/development/ubuntu14/Vagrantfile
+++ b/metron-deployment/development/ubuntu14/Vagrantfile
@@ -97,5 +97,7 @@ Vagrant.configure(2) do |config|
     ansible.skip_tags = ansibleSkipTags.split(",") if ansibleSkipTags != ''
     ansible.inventory_path = "ansible/inventory"
     ansible.compatibility_mode = "auto"
+    #ansible.verbose = "vvv"
+    ansible.raw_arguments = Shellwords.shellsplit(ENV['ANSIBLE_ARGS']) if ENV['ANSIBLE_ARGS']
   end
 end

--- a/metron-deployment/packaging/docker/rpm-docker/build.sh
+++ b/metron-deployment/packaging/docker/rpm-docker/build.sh
@@ -44,7 +44,11 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-rpmlint -i SPECS/metron.spec RPMS/*/metron* SRPMS/metron
+if [ -z "${SKIP_RPMLINT}" ] || [ $SKIP_RPMLINT -eq 0 ]; then
+  rpmlint -i SPECS/metron.spec RPMS/*/metron* SRPMS/metron]
+else
+  echo -n "SKIP_RPMLINT is non null and not equal to 0 - bypassing rpmlint"
+fi
 
 # Ensure original user permissions are maintained after build
 if [ $OWNER_UID -ne 0 ]; then


### PR DESCRIPTION
## Contributor Comments
This PR allows full dev deploy users to skip rpmlint processing via setting an environment variable.

For justification for excluding rpmlint from the build please see https://issues.apache.org/jira/browse/METRON-2247

The PR contains the needed logic to tunnel an option variable from vagrant->ansible->docker to the shell script that actually runs rpmlint

The shell script has been modified to skip running rpmlint if the SKIP_RPMLINT environment variable has been sent.


To demonstrate this option for a single vagrant operation use:

```
env ANSIBLE_ARGS='--extra-vars "SKIP_RPMLINT=1"' vagrant up
```

To use the option permanently place the ANSIBLE_ARGS environment variable in your profile.

Testing:
an exit 1 was added to the build script where the rpmlint command was being run. This causes the build process to die if rpmlint is being run. Running vagrant up without setting the `SKIP_RPMLINT` environment variable causes the build process to die.  Setting the variable  allows a full dev build to continue.

A full dev build was done both with and without `SKIP_RPMLINT` being set to verify the Metron deploys fine either way.



## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- n/a Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- n/a Have you written or updated unit tests and or integration tests to verify your changes?

- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- n/a Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

- [x] Have you ensured that any documentation diagrams have been updated, along with their source files, using [draw.io](https://www.draw.io/)? See [Metron Development Guidelines](https://cwiki.apache.org/confluence/display/METRON/Development+Guidelines) for instructions.

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.