### PR TITLE
METRON-2254 Intermittent Test Failure in RestFunctionsIntegrationTest

### DIFF
--- a/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/dsl/functions/RestFunctionsIntegrationTest.java
+++ b/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/dsl/functions/RestFunctionsIntegrationTest.java
@@ -241,7 +241,6 @@ public class RestFunctionsIntegrationTest {
   @SuppressWarnings("unchecked")
   public void restGetShouldTimeout() {
     String uri = String.format("http://localhost:%d/get", mockServerRule.getPort());
-
     mockServerClient.when(
             request()
                     .withMethod("GET")
@@ -252,7 +251,7 @@ public class RestFunctionsIntegrationTest {
 
     Map<String, Object> globalConfig = new HashMap<String, Object>() {{
       put(STELLAR_REST_SETTINGS, new HashMap<String, Object>() {{
-        put(TIMEOUT, 100);
+        put(TIMEOUT, 10);
       }});
     }};
 
@@ -264,7 +263,7 @@ public class RestFunctionsIntegrationTest {
 
   /**
    * {
-   * "timeout": 100
+   * "timeout": 10
    * }
    */
   @Multiline

--- a/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/dsl/functions/RestFunctionsIntegrationTest.java
+++ b/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/dsl/functions/RestFunctionsIntegrationTest.java
@@ -38,6 +38,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.metron.stellar.common.utils.StellarProcessorUtils.run;
 import static org.apache.metron.stellar.dsl.functions.RestConfig.*;
@@ -246,11 +247,13 @@ public class RestFunctionsIntegrationTest {
                     .withMethod("GET")
                     .withPath("/get"))
             .respond(response()
+                    .withDelay(TimeUnit.MILLISECONDS, 1000)
+                    .applyDelay()
                     .withBody("{\"get\":\"success\"}"));
 
     Map<String, Object> globalConfig = new HashMap<String, Object>() {{
       put(STELLAR_REST_SETTINGS, new HashMap<String, Object>() {{
-        put(TIMEOUT, 1);
+        put(TIMEOUT, 100);
       }});
     }};
 
@@ -262,7 +265,7 @@ public class RestFunctionsIntegrationTest {
 
   /**
    * {
-   * "timeout": 1
+   * "timeout": 100
    * }
    */
   @Multiline
@@ -274,7 +277,17 @@ public class RestFunctionsIntegrationTest {
   @Test
   @SuppressWarnings("unchecked")
   public void restGetShouldTimeoutWithSuppliedTimeout() {
-    String expression = String.format("REST_GET('%s', %s)", getUri, timeoutConfig);
+    String uri = String.format("http://localhost:%d/get", mockServerRule.getPort());
+    mockServerClient.when(
+            request()
+                    .withMethod("GET")
+                    .withPath("/get"))
+            .respond(response()
+                    .withDelay(TimeUnit.MILLISECONDS, 1000)
+                    .applyDelay()
+                    .withBody("{\"get\":\"success\"}"));
+
+    String expression = String.format("REST_GET('%s', %s)", uri, timeoutConfig);
     Map<String, Object> actual = (Map<String, Object>) run(expression, context);
     assertNull(actual);
   }

--- a/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/dsl/functions/RestFunctionsIntegrationTest.java
+++ b/metron-stellar/stellar-common/src/test/java/org/apache/metron/stellar/dsl/functions/RestFunctionsIntegrationTest.java
@@ -248,7 +248,6 @@ public class RestFunctionsIntegrationTest {
                     .withPath("/get"))
             .respond(response()
                     .withDelay(TimeUnit.MILLISECONDS, 1000)
-                    .applyDelay()
                     .withBody("{\"get\":\"success\"}"));
 
     Map<String, Object> globalConfig = new HashMap<String, Object>() {{
@@ -284,7 +283,6 @@ public class RestFunctionsIntegrationTest {
                     .withPath("/get"))
             .respond(response()
                     .withDelay(TimeUnit.MILLISECONDS, 1000)
-                    .applyDelay()
                     .withBody("{\"get\":\"success\"}"));
 
     String expression = String.format("REST_GET('%s', %s)", uri, timeoutConfig);


### PR DESCRIPTION
The `RestFunctionsIntegrationTest.restGetShouldTimeoutWithSuppliedTimeout` test will intermittently fail.

We use an in-memory, mock server to respond to HTTP requests made during these tests. The way that we currently test a timeout is to set the timeout extremely low (1 millisecond) and assume that the in-memory, mock server will not be able to respond fast enough.  In most cases this works, but in some cases this does not and causes CI failures.

This most likely doesn't work at times because the functionality that we use to timeout just isn't granular enough to enforce a 1 millisecond timeout.  So its much more likely enforcing a timeout on the order of tens or hundreds of milliseconds.  And if the enforcement mechanism is slower than mock server, the test case will fail.

Rather than doing that, there is a method that allows us to introduce a fixed delay before the mock server responds.  This should provide us with reliable pass/fail signal from these tests.


## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

- [x] Have you ensured that any documentation diagrams have been updated, along with their source files, using [draw.io](https://www.draw.io/)? See [Metron Development Guidelines](https://cwiki.apache.org/confluence/display/METRON/Development+Guidelines) for instructions.

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
