### PR TITLE
METRON-2262: Upgrade to Curator 4.2.0

### DIFF
--- a/metron-analytics/metron-maas-common/pom.xml
+++ b/metron-analytics/metron-maas-common/pom.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
-  Licensed to the Apache Software 
-  Foundation (ASF) under one or more contributor license agreements. See the 
-  NOTICE file distributed with this work for additional information regarding 
-  copyright ownership. The ASF licenses this file to You under the Apache License, 
-  Version 2.0 (the "License"); you may not use this file except in compliance 
-  with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
-  Unless required by applicable law or agreed to in writing, software distributed 
-  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
-  OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
-  the specific language governing permissions and limitations under the License. 
+<!--
+  Licensed to the Apache Software
+  Foundation (ASF) under one or more contributor license agreements. See the
+  NOTICE file distributed with this work for additional information regarding
+  copyright ownership. The ASF licenses this file to You under the Apache License,
+  Version 2.0 (the "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed
+  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+  OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+  the specific language governing permissions and limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -54,11 +54,25 @@
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-recipes</artifactId>
       <version>${global_curator_version}</version>
+      <exclusions>
+        <exclusion>
+          <!-- need to exclude zookeeper 3.5.x http://curator.apache.org/zk-compatibility.html -->
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-x-discovery</artifactId>
       <version>${global_curator_version}</version>
+      <exclusions>
+        <exclusion>
+          <!-- need to exclude zookeeper 3.5.x http://curator.apache.org/zk-compatibility.html -->
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -83,8 +97,15 @@
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-test</artifactId>
-      <version>${curator.version}</version>
+      <version>${global_curator_test_version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <!-- need to exclude zookeeper 3.5.x http://curator.apache.org/zk-compatibility.html -->
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
   </dependencies>

--- a/metron-analytics/metron-maas-common/src/main/java/org/apache/metron/maas/discovery/ServiceDiscoverer.java
+++ b/metron-analytics/metron-maas-common/src/main/java/org/apache/metron/maas/discovery/ServiceDiscoverer.java
@@ -197,6 +197,7 @@ public class ServiceDiscoverer implements Closeable{
       //}
       ServiceInstance<ModelEndpoint> ep = containerToEndpoint.get(containerId);
       if(ep != null) {
+        serviceDiscovery.registerService(ep);
         serviceDiscovery.unregisterService(ep);
       }
       else {

--- a/metron-analytics/metron-maas-service/pom.xml
+++ b/metron-analytics/metron-maas-service/pom.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
-  Licensed to the Apache Software 
-  Foundation (ASF) under one or more contributor license agreements. See the 
-  NOTICE file distributed with this work for additional information regarding 
-  copyright ownership. The ASF licenses this file to You under the Apache License, 
-  Version 2.0 (the "License"); you may not use this file except in compliance 
-  with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
-  Unless required by applicable law or agreed to in writing, software distributed 
-  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
-  OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
-  the specific language governing permissions and limitations under the License. 
+<!--
+  Licensed to the Apache Software
+  Foundation (ASF) under one or more contributor license agreements. See the
+  NOTICE file distributed with this work for additional information regarding
+  copyright ownership. The ASF licenses this file to You under the Apache License,
+  Version 2.0 (the "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed
+  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+  OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+  the specific language governing permissions and limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -59,6 +59,23 @@
       <artifactId>hadoop-yarn-server-common</artifactId>
       <version>${hadoop.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+            <!-- to avoid pulling in curator 2.12.0 -->
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+        </exclusion>
+        <exclusion>
+            <!-- to avoid pulling in curator 2.12.0 -->
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-client</artifactId>
+        </exclusion>
+        <exclusion>
+            <!-- to avoid pulling in curator 2.12.0 -->
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -119,16 +136,19 @@
       <scope>provided</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.apache.curator</groupId>
-          <artifactId>curator-recipes</artifactId>
+            <!-- to avoid pulling in curator 2.12.0 -->
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.curator</groupId>
-          <artifactId>curator-client</artifactId>
+            <!-- to avoid pulling in curator 2.12.0 -->
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-client</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.curator</groupId>
-          <artifactId>curator-framework</artifactId>
+            <!-- to avoid pulling in curator 2.12.0 -->
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/metron-analytics/metron-maas-service/src/main/java/org/apache/metron/maas/service/callback/ContainerRequestListener.java
+++ b/metron-analytics/metron-maas-service/src/main/java/org/apache/metron/maas/service/callback/ContainerRequestListener.java
@@ -118,7 +118,6 @@ public class ContainerRequestListener implements AMRMClientAsync.CallbackHandler
               + containerStatus.getDiagnostics());
       removeContainer(containerStatus.getContainerId());
       LOG.info("REMOVING CONTAINER " + containerStatus.getContainerId());
-      serviceDiscoverer.unregisterByContainer(containerStatus.getContainerId() + "");
       // non complete containers should not be here
       assert (containerStatus.getState() == ContainerState.COMPLETE);
       // increment counters for completed/failed containers

--- a/metron-analytics/metron-profiler-spark/pom.xml
+++ b/metron-analytics/metron-profiler-spark/pom.xml
@@ -32,6 +32,13 @@
           <groupId>org.apache.spark</groupId>
           <artifactId>spark-core_2.11</artifactId>
           <version>${global_spark_version}</version>
+          <exclusions>
+              <exclusion>
+                  <!-- to avoid pulling in curator 2.12.0 -->
+                  <groupId>org.apache.curator</groupId>
+                  <artifactId>curator-recipes</artifactId>
+              </exclusion>
+          </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
@@ -154,6 +161,21 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>log4j-over-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/metron-analytics/metron-profiler-storm/pom.xml
+++ b/metron-analytics/metron-profiler-storm/pom.xml
@@ -67,6 +67,26 @@
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>httpclient</artifactId>
                 </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- need to exclude zookeeper 3.4.9 -->
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -93,6 +113,16 @@
                 <exclusion>
                     <artifactId>commons-lang</artifactId>
                     <groupId>commons-lang</groupId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -209,6 +239,21 @@
                 <exclusion>
                     <artifactId>commons-lang</artifactId>
                     <groupId>commons-lang</groupId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/metron-interface/metron-rest/pom.xml
+++ b/metron-interface/metron-rest/pom.xml
@@ -27,7 +27,6 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
         <antlr.version>4.5</antlr.version>
-        <curator.version>2.7.1</curator.version>
         <powermock.version>1.6.4</powermock.version>
         <spring.boot.version>2.0.1.RELEASE</spring.boot.version>
         <spring.kerberos.version>1.0.1.RELEASE</spring.kerberos.version>
@@ -127,7 +126,7 @@
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-recipes</artifactId>
-            <version>${curator.version}</version>
+            <version>${global_curator_version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>
@@ -137,6 +136,11 @@
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
+              <exclusion>
+                <!-- need to exclude zookeeper 3.5.x http://curator.apache.org/zk-compatibility.html -->
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+              </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -245,6 +249,21 @@
             <exclusion>
               <groupId>javax.servlet</groupId>
               <artifactId>servlet-api</artifactId>
+            </exclusion>
+            <exclusion>
+                <!-- to avoid pulling in curator 2.12.0 -->
+                <groupId>org.apache.curator</groupId>
+                <artifactId>curator-framework</artifactId>
+            </exclusion>
+            <exclusion>
+                <!-- to avoid pulling in curator 2.12.0 -->
+                <groupId>org.apache.curator</groupId>
+                <artifactId>curator-client</artifactId>
+            </exclusion>
+            <exclusion>
+                <!-- to avoid pulling in curator 2.12.0 -->
+                <groupId>org.apache.curator</groupId>
+                <artifactId>curator-recipes</artifactId>
             </exclusion>
           </exclusions>
       </dependency>
@@ -444,6 +463,21 @@
                 <exclusion>
                     <groupId>commons-httpclient</groupId>
                     <artifactId>commons-httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/metron-platform/metron-common-streaming/metron-common-storm/pom.xml
+++ b/metron-platform/metron-common-streaming/metron-common-storm/pom.xml
@@ -75,14 +75,33 @@
         <version>${global_flux_version}</version>
       </dependency>
       <dependency>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+          <version>${global_zookeeper_version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.curator</groupId>
         <artifactId>curator-client</artifactId>
         <version>${global_curator_version}</version>
+        <exclusions>
+            <exclusion>
+                <!-- need to exclude zookeeper 3.5.x http://curator.apache.org/zk-compatibility.html -->
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+            </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.curator</groupId>
         <artifactId>curator-test</artifactId>
-        <version>${global_curator_version}</version>
+        <version>${global_curator_test_version}</version>
+        <exclusions>
+            <exclusion>
+                <!-- need to exclude zookeeper 3.5.x http://curator.apache.org/zk-compatibility.html -->
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+            </exclusion>
+        </exclusions>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/metron-platform/metron-common/pom.xml
+++ b/metron-platform/metron-common/pom.xml
@@ -40,6 +40,47 @@
     </repositories>
     <dependencies>
         <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>${global_zookeeper_version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.curator</groupId>
+          <artifactId>curator-client</artifactId>
+          <version>${global_curator_version}</version>
+          <exclusions>
+              <exclusion>
+                  <!-- need to exclude zookeeper 3.5.x -->
+                  <groupId>org.apache.zookeeper</groupId>
+                  <artifactId>zookeeper</artifactId>
+              </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.curator</groupId>
+          <artifactId>curator-recipes</artifactId>
+          <version>${global_curator_version}</version>
+          <exclusions>
+              <exclusion>
+                  <!-- need to exclude zookeeper 3.5.x -->
+                  <groupId>org.apache.zookeeper</groupId>
+                  <artifactId>zookeeper</artifactId>
+              </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.curator</groupId>
+          <artifactId>curator-framework</artifactId>
+          <version>${global_curator_version}</version>
+          <exclusions>
+              <exclusion>
+                  <!-- need to exclude zookeeper 3.5.x -->
+                  <groupId>org.apache.zookeeper</groupId>
+                  <artifactId>zookeeper</artifactId>
+              </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.apache.metron</groupId>
             <artifactId>metron-maas-common</artifactId>
             <version>${project.parent.version}</version>
@@ -69,6 +110,21 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>log4j-over-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -147,11 +203,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-client</artifactId>
-            <version>${global_curator_version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.atteo.classindex</groupId>
             <artifactId>classindex</artifactId>
             <version>${global_classindex_version}</version>
@@ -206,6 +257,26 @@
                     <artifactId>slf4j-log4j12</artifactId>
                     <groupId>org.slf4j</groupId>
                 </exclusion>
+                <exclusion>
+                    <!-- need to exclude zookeeper 3.4.9 -->
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -228,6 +299,21 @@
                 <exclusion>
                     <groupId>asm</groupId>
                     <artifactId>asm</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- need to exclude zookeeper 3.4.9 -->
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -254,8 +340,15 @@
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
-            <version>${global_curator_version}</version>
+            <version>${global_curator_test_version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <!-- need to exclude zookeeper 3.5.x http://curator.apache.org/zk-compatibility.html -->
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>

--- a/metron-platform/metron-data-management/pom.xml
+++ b/metron-platform/metron-data-management/pom.xml
@@ -168,6 +168,21 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -186,6 +201,16 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
                 </exclusion>
             </exclusions>
             <scope>provided</scope>
@@ -245,6 +270,21 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -294,6 +334,21 @@
                 <exclusion>
                     <artifactId>log4j-over-slf4j</artifactId>
                     <groupId>org.slf4j</groupId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/metron-platform/metron-elasticsearch/metron-elasticsearch-common/pom.xml
+++ b/metron-platform/metron-elasticsearch/metron-elasticsearch-common/pom.xml
@@ -155,6 +155,16 @@
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>httpcore</artifactId>
                 </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
+                </exclusion>
              </exclusions>
         </dependency>
         <dependency>
@@ -208,6 +218,21 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>log4j-over-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/metron-platform/metron-enrichment/metron-enrichment-storm/pom.xml
+++ b/metron-platform/metron-enrichment/metron-enrichment-storm/pom.xml
@@ -132,6 +132,21 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -223,6 +238,16 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/metron-platform/metron-enrichment/pom.xml
+++ b/metron-platform/metron-enrichment/pom.xml
@@ -66,6 +66,21 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>log4j-over-slf4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/metron-platform/metron-hbase-server/pom.xml
+++ b/metron-platform/metron-hbase-server/pom.xml
@@ -132,6 +132,21 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -191,6 +206,21 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>log4j-over-slf4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -202,6 +232,21 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/metron-platform/metron-hbase/metron-hbase-common/pom.xml
+++ b/metron-platform/metron-hbase/metron-hbase-common/pom.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
-  Licensed to the Apache Software 
-	Foundation (ASF) under one or more contributor license agreements. See the 
-	NOTICE file distributed with this work for additional information regarding 
-	copyright ownership. The ASF licenses this file to You under the Apache License, 
-	Version 2.0 (the "License"); you may not use this file except in compliance 
-	with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
-	Unless required by applicable law or agreed to in writing, software distributed 
-	under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
-	OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
-  the specific language governing permissions and limitations under the License. 
+<!--
+  Licensed to the Apache Software
+	Foundation (ASF) under one or more contributor license agreements. See the
+	NOTICE file distributed with this work for additional information regarding
+	copyright ownership. The ASF licenses this file to You under the Apache License,
+	Version 2.0 (the "License"); you may not use this file except in compliance
+	with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software distributed
+	under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+	OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+  the specific language governing permissions and limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -69,6 +69,21 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -98,6 +113,16 @@
                     <!-- to avoid pulling in guava 11 -->
                     <groupId>com.google.guava</groupId>
                     <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -150,6 +175,21 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/metron-platform/metron-indexing/metron-indexing-common/pom.xml
+++ b/metron-platform/metron-indexing/metron-indexing-common/pom.xml
@@ -59,7 +59,11 @@
             <version>${global_log4j_core_version}</version>
             <scope>runtime</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-math</artifactId>
+            <version>2.2</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-client</artifactId>
@@ -114,6 +118,16 @@
                     <artifactId>log4j</artifactId>
                     <groupId>log4j</groupId>
                 </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -143,6 +157,21 @@
             <version>${project.parent.version}</version>
             <scope>test</scope>
             <exclusions>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>log4j-over-slf4j</artifactId>

--- a/metron-platform/metron-indexing/metron-indexing-storm/pom.xml
+++ b/metron-platform/metron-indexing/metron-indexing-storm/pom.xml
@@ -75,6 +75,21 @@
                     <groupId>io.netty</groupId>
                     <artifactId>netty-all</artifactId>
                 </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/metron-platform/metron-integration-test/pom.xml
+++ b/metron-platform/metron-integration-test/pom.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
-  Licensed to the Apache Software 
-  Foundation (ASF) under one or more contributor license agreements. See the 
-  NOTICE file distributed with this work for additional information regarding 
-  copyright ownership. The ASF licenses this file to You under the Apache License, 
-  Version 2.0 (the "License"); you may not use this file except in compliance 
-  with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
-  Unless required by applicable law or agreed to in writing, software distributed 
-  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
-  OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
-  the specific language governing permissions and limitations under the License. 
+<!--
+  Licensed to the Apache Software
+  Foundation (ASF) under one or more contributor license agreements. See the
+  NOTICE file distributed with this work for additional information regarding
+  copyright ownership. The ASF licenses this file to You under the Apache License,
+  Version 2.0 (the "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed
+  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+  OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+  the specific language governing permissions and limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -28,6 +28,11 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>org.apache.zookeeper</groupId>
+      <artifactId>zookeeper</artifactId>
+      <version>${global_zookeeper_version}</version>
+    </dependency>
+    <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <version>1.2.17</version>
@@ -37,13 +42,47 @@
       <artifactId>junit</artifactId>
       <version>${global_junit_version}</version>
     </dependency>
-
     <dependency>
       <groupId>org.apache.storm</groupId>
       <artifactId>flux-core</artifactId>
       <version>${global_flux_version}</version>
     </dependency>
-
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-client</artifactId>
+      <version>${global_curator_version}</version>
+      <exclusions>
+          <exclusion>
+              <!-- need to exclude zookeeper 3.5.x http://curator.apache.org/zk-compatibility.html -->
+              <groupId>org.apache.zookeeper</groupId>
+              <artifactId>zookeeper</artifactId>
+          </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-recipes</artifactId>
+      <version>${global_curator_version}</version>
+      <exclusions>
+          <exclusion>
+              <!-- need to exclude zookeeper 3.5.x http://curator.apache.org/zk-compatibility.html -->
+              <groupId>org.apache.zookeeper</groupId>
+              <artifactId>zookeeper</artifactId>
+          </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-framework</artifactId>
+      <version>${global_curator_version}</version>
+      <exclusions>
+          <exclusion>
+              <!-- need to exclude zookeeper 3.5.x http://curator.apache.org/zk-compatibility.html -->
+              <groupId>org.apache.zookeeper</groupId>
+              <artifactId>zookeeper</artifactId>
+          </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>org.apache.storm</groupId>
       <artifactId>storm-core</artifactId>
@@ -77,6 +116,25 @@
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
+        <exclusion>
+            <!-- to avoid pulling in curator 2.12.0 -->
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+        </exclusion>
+        <exclusion>
+            <!-- to avoid pulling in curator 2.12.0 -->
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-client</artifactId>
+        </exclusion>
+        <exclusion>
+            <!-- to avoid pulling in curator 2.12.0 -->
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -95,6 +153,21 @@
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+            <!-- to avoid pulling in curator 2.12.0 -->
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+        </exclusion>
+        <exclusion>
+            <!-- to avoid pulling in curator 2.12.0 -->
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-client</artifactId>
+        </exclusion>
+        <exclusion>
+            <!-- to avoid pulling in curator 2.12.0 -->
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -144,20 +217,29 @@
         </exclusion>
       </exclusions>
     </dependency>
-
-
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka_2.12</artifactId>
       <version>${global_kafka_version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka_2.12</artifactId>
       <version>${global_kafka_version}</version>
       <classifier>test</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
-
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs</artifactId>
@@ -194,6 +276,21 @@
         <exclusion>
           <artifactId>slf4j-log4j12</artifactId>
           <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+            <!-- to avoid pulling in curator 2.12.0 -->
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+        </exclusion>
+        <exclusion>
+            <!-- to avoid pulling in curator 2.12.0 -->
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-client</artifactId>
+        </exclusion>
+        <exclusion>
+            <!-- to avoid pulling in curator 2.12.0 -->
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -247,6 +344,23 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-server-common</artifactId>
       <version>${global_hadoop_version}</version>
+      <exclusions>
+        <exclusion>
+            <!-- to avoid pulling in curator 2.12.0 -->
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+        </exclusion>
+        <exclusion>
+            <!-- to avoid pulling in curator 2.12.0 -->
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-client</artifactId>
+        </exclusion>
+        <exclusion>
+            <!-- to avoid pulling in curator 2.12.0 -->
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -262,6 +376,21 @@
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+            <!-- to avoid pulling in curator 2.12.0 -->
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+        </exclusion>
+        <exclusion>
+            <!-- to avoid pulling in curator 2.12.0 -->
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-client</artifactId>
+        </exclusion>
+        <exclusion>
+            <!-- to avoid pulling in curator 2.12.0 -->
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/metron-platform/metron-management/pom.xml
+++ b/metron-platform/metron-management/pom.xml
@@ -123,16 +123,39 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
         <!-- Test -->
 
         <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>${global_zookeeper_version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
-            <version>${global_curator_version}</version>
+            <version>${global_curator_test_version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <!-- need to exclude zookeeper 3.5.x http://curator.apache.org/zk-compatibility.html -->
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.metron</groupId>
@@ -156,6 +179,21 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>log4j-over-slf4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -170,6 +208,21 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
                 </exclusion>
             </exclusions>
             <scope>test</scope>

--- a/metron-platform/metron-parsing/metron-parsers-common/pom.xml
+++ b/metron-platform/metron-parsing/metron-parsers-common/pom.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
-  Licensed to the Apache Software 
-	Foundation (ASF) under one or more contributor license agreements. See the 
-	NOTICE file distributed with this work for additional information regarding 
-	copyright ownership. The ASF licenses this file to You under the Apache License, 
-	Version 2.0 (the "License"); you may not use this file except in compliance 
-	with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
-	Unless required by applicable law or agreed to in writing, software distributed 
-	under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
-	OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
-  the specific language governing permissions and limitations under the License. 
+<!--
+  Licensed to the Apache Software
+	Foundation (ASF) under one or more contributor license agreements. See the
+	NOTICE file distributed with this work for additional information regarding
+	copyright ownership. The ASF licenses this file to You under the Apache License,
+	Version 2.0 (the "License"); you may not use this file except in compliance
+	with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software distributed
+	under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+	OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+  the specific language governing permissions and limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -76,6 +76,16 @@
                 <exclusion>
                     <artifactId>log4j</artifactId>
                     <groupId>log4j</groupId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -175,6 +185,21 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>log4j-over-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/metron-platform/metron-pcap-backend/pom.xml
+++ b/metron-platform/metron-pcap-backend/pom.xml
@@ -37,9 +37,21 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>${global_zookeeper_version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-client</artifactId>
-            <version>2.10.0</version>
+            <version>${global_curator_version}</version>
+            <exclusions>
+                <exclusion>
+                    <!-- need to exclude zookeeper 3.5.x http://curator.apache.org/zk-compatibility.html -->
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.storm</groupId>
@@ -50,12 +62,6 @@
             <groupId>org.apache.metron</groupId>
             <artifactId>metron-common</artifactId>
             <version>${project.parent.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.curator</groupId>
-                    <artifactId>curator-client</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.metron</groupId>
@@ -87,8 +93,14 @@
             <version>${global_hadoop_version}</version>
             <exclusions>
                 <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
                     <groupId>org.apache.curator</groupId>
                     <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -209,6 +221,23 @@
             <artifactId>metron-integration-test</artifactId>
             <version>${project.parent.version}</version>
             <scope>test</scope>
+            <exclusions>
+              <exclusion>
+                  <!-- to avoid pulling in curator 2.12.0 -->
+                  <groupId>org.apache.curator</groupId>
+                  <artifactId>curator-framework</artifactId>
+              </exclusion>
+              <exclusion>
+                  <!-- to avoid pulling in curator 2.12.0 -->
+                  <groupId>org.apache.curator</groupId>
+                  <artifactId>curator-client</artifactId>
+              </exclusion>
+              <exclusion>
+                  <!-- to avoid pulling in curator 2.12.0 -->
+                  <groupId>org.apache.curator</groupId>
+                  <artifactId>curator-recipes</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/metron-platform/metron-pcap/pom.xml
+++ b/metron-platform/metron-pcap/pom.xml
@@ -121,6 +121,21 @@
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>httpcore</artifactId>
                 </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/metron-platform/metron-solr/metron-solr-common/pom.xml
+++ b/metron-platform/metron-solr/metron-solr-common/pom.xml
@@ -132,6 +132,16 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -192,6 +202,21 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>log4j-over-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/metron-platform/metron-test-utilities/pom.xml
+++ b/metron-platform/metron-test-utilities/pom.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
-  Licensed to the Apache Software 
-  Foundation (ASF) under one or more contributor license agreements. See the 
-  NOTICE file distributed with this work for additional information regarding 
-  copyright ownership. The ASF licenses this file to You under the Apache License, 
-  Version 2.0 (the "License"); you may not use this file except in compliance 
-  with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
-  Unless required by applicable law or agreed to in writing, software distributed 
-  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
-  OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
-  the specific language governing permissions and limitations under the License. 
+<!--
+  Licensed to the Apache Software
+  Foundation (ASF) under one or more contributor license agreements. See the
+  NOTICE file distributed with this work for additional information regarding
+  copyright ownership. The ASF licenses this file to You under the Apache License,
+  Version 2.0 (the "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed
+  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+  OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+  the specific language governing permissions and limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -51,6 +51,18 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-auth</artifactId>
       <version>${global_hadoop_version}</version>
+      <exclusions>
+        <exclusion>
+            <!-- to avoid pulling in curator 2.12.0 -->
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+        </exclusion>
+        <exclusion>
+            <!-- need to exclude zookeeper 3.4.9 -->
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -64,6 +76,21 @@
         <exclusion>
           <artifactId>commons-httpclient</artifactId>
           <groupId>commons-httpclient</groupId>
+        </exclusion>
+        <exclusion>
+            <!-- to avoid pulling in curator 2.12.0 -->
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-client</artifactId>
+        </exclusion>
+        <exclusion>
+            <!-- to avoid pulling in curator 2.12.0 -->
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+        </exclusion>
+        <exclusion>
+            <!-- need to exclude zookeeper 3.4.9 -->
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -140,11 +167,22 @@
         </exclusion>
       </exclusions>
     </dependency>
-
+    <dependency>
+        <groupId>org.apache.zookeeper</groupId>
+        <artifactId>zookeeper</artifactId>
+        <version>${global_zookeeper_version}</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-test</artifactId>
-      <version>${global_curator_version}</version>
+      <version>${global_curator_test_version}</version>
+      <exclusions>
+          <exclusion>
+              <!-- need to exclude zookeeper 3.5.x http://curator.apache.org/zk-compatibility.html -->
+              <groupId>org.apache.zookeeper</groupId>
+              <artifactId>zookeeper</artifactId>
+          </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/metron-platform/metron-writer/metron-writer-common/pom.xml
+++ b/metron-platform/metron-writer/metron-writer-common/pom.xml
@@ -47,6 +47,26 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- need to exclude zookeeper 3.4.9 -->
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -69,6 +89,21 @@
                 <exclusion>
                     <groupId>com.google.guava</groupId>
                     <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- need to exclude zookeeper 3.4.9 -->
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
                 </exclusion>
             </exclusions>
             <scope>provided</scope>
@@ -102,6 +137,11 @@
                     <groupId>org.apache.hadoop</groupId>
                     <artifactId>hadoop-mapreduce-client-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <!-- need to exclude zookeeper 3.4.9 -->
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
             </exclusions>
             <scope>provided</scope>
         </dependency>
@@ -130,6 +170,11 @@
                 <exclusion>
                     <groupId>org.apache.hadoop</groupId>
                     <artifactId>hadoop-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- need to exclude zookeeper 3.4.9 -->
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/metron-platform/metron-writer/metron-writer-storm/pom.xml
+++ b/metron-platform/metron-writer/metron-writer-storm/pom.xml
@@ -63,6 +63,16 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
+                </exclusion>
             </exclusions>
             <scope>provided</scope>
         </dependency>

--- a/metron-platform/metron-zookeeper/pom.xml
+++ b/metron-platform/metron-zookeeper/pom.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
-  Licensed to the Apache Software 
-  Foundation (ASF) under one or more contributor license agreements. See the 
-  NOTICE file distributed with this work for additional information regarding 
-  copyright ownership. The ASF licenses this file to You under the Apache License, 
-  Version 2.0 (the "License"); you may not use this file except in compliance 
-  with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
-  Unless required by applicable law or agreed to in writing, software distributed 
-  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
-  OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
-  the specific language governing permissions and limitations under the License. 
+<!--
+  Licensed to the Apache Software
+  Foundation (ASF) under one or more contributor license agreements. See the
+  NOTICE file distributed with this work for additional information regarding
+  copyright ownership. The ASF licenses this file to You under the Apache License,
+  Version 2.0 (the "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed
+  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+  OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+  the specific language governing permissions and limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -29,14 +29,45 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>org.apache.zookeeper</groupId>
+      <artifactId>zookeeper</artifactId>
+      <version>${global_zookeeper_version}</version>
+   </dependency>
+    <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-client</artifactId>
       <version>${global_curator_version}</version>
+      <exclusions>
+          <exclusion>
+              <!-- need to exclude zookeeper 3.5.x http://curator.apache.org/zk-compatibility.html -->
+              <groupId>org.apache.zookeeper</groupId>
+              <artifactId>zookeeper</artifactId>
+          </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-recipes</artifactId>
       <version>${global_curator_version}</version>
+      <exclusions>
+          <exclusion>
+              <!-- need to exclude zookeeper 3.5.x http://curator.apache.org/zk-compatibility.html -->
+              <groupId>org.apache.zookeeper</groupId>
+              <artifactId>zookeeper</artifactId>
+          </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-framework</artifactId>
+      <version>${global_curator_version}</version>
+      <exclusions>
+          <exclusion>
+              <!-- need to exclude zookeeper 3.5.x http://curator.apache.org/zk-compatibility.html -->
+              <groupId>org.apache.zookeeper</groupId>
+              <artifactId>zookeeper</artifactId>
+          </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/metron-stellar/stellar-common/pom.xml
+++ b/metron-stellar/stellar-common/pom.xml
@@ -31,6 +31,11 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>${global_zookeeper_version}</version>
+        </dependency>
+        <dependency>
           <groupId>com.github.ben-manes.caffeine</groupId>
           <artifactId>caffeine</artifactId>
           <version>${global_caffeine_version}</version>
@@ -44,6 +49,26 @@
               <groupId>asm</groupId>
               <artifactId>asm</artifactId>
             </exclusion>
+            <exclusion>
+                <!-- to avoid pulling in curator 2.12.0 -->
+                <groupId>org.apache.curator</groupId>
+                <artifactId>curator-client</artifactId>
+            </exclusion>
+            <exclusion>
+                <!-- to avoid pulling in curator 2.12.0 -->
+                <groupId>org.apache.curator</groupId>
+                <artifactId>curator-recipes</artifactId>
+            </exclusion>
+            <exclusion>
+                <!-- to avoid pulling in curator 2.12.0 -->
+                <groupId>org.apache.curator</groupId>
+                <artifactId>curator-framework</artifactId>
+            </exclusion>
+            <exclusion>
+                <!-- need to exclude zookeeper 3.4.9 -->
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+            </exclusion>
           </exclusions>
         </dependency>
         <dependency>
@@ -51,6 +76,33 @@
             <artifactId>hadoop-auth</artifactId>
             <version>${global_hadoop_version}</version>
             <scope>test</scope>
+            <exclusions>
+              <exclusion>
+                  <!-- to avoid pulling in curator 2.12.0 -->
+                  <groupId>org.apache.curator</groupId>
+                  <artifactId>curator-client</artifactId>
+              </exclusion>
+              <exclusion>
+                  <!-- to avoid pulling in curator 2.12.0 -->
+                  <groupId>org.apache.curator</groupId>
+                  <artifactId>curator-recipes</artifactId>
+              </exclusion>
+              <exclusion>
+                  <!-- to avoid pulling in curator 2.12.0 -->
+                  <groupId>org.apache.curator</groupId>
+                  <artifactId>curator-framework</artifactId>
+              </exclusion>
+              <exclusion>
+                  <!-- need to exclude zookeeper 3.4.9 -->
+                  <groupId>org.apache.zookeeper</groupId>
+                  <artifactId>zookeeper</artifactId>
+              </exclusion>
+              <exclusion>
+                  <!-- need to exclude zookeeper 3.4.9 -->
+                  <groupId>org.apache.zookeeper</groupId>
+                  <artifactId>zookeeper</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.accumulo</groupId>
@@ -129,20 +181,58 @@
             <version>1.6</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-client</artifactId>
-            <version>${global_curator_version}</version>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>${global_zookeeper_version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-recipes</artifactId>
-            <version>${global_curator_version}</version>
+          <groupId>org.apache.curator</groupId>
+          <artifactId>curator-client</artifactId>
+          <version>${global_curator_version}</version>
+          <exclusions>
+              <exclusion>
+                  <!-- need to exclude zookeeper 3.5.x http://curator.apache.org/zk-compatibility.html -->
+                  <groupId>org.apache.zookeeper</groupId>
+                  <artifactId>zookeeper</artifactId>
+              </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.curator</groupId>
+          <artifactId>curator-recipes</artifactId>
+          <version>${global_curator_version}</version>
+          <exclusions>
+              <exclusion>
+                  <!-- need to exclude zookeeper 3.5.x http://curator.apache.org/zk-compatibility.html -->
+                  <groupId>org.apache.zookeeper</groupId>
+                  <artifactId>zookeeper</artifactId>
+              </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.curator</groupId>
+          <artifactId>curator-framework</artifactId>
+          <version>${global_curator_version}</version>
+          <exclusions>
+              <exclusion>
+                  <!-- need to exclude zookeeper 3.5.x http://curator.apache.org/zk-compatibility.html -->
+                  <groupId>org.apache.zookeeper</groupId>
+                  <artifactId>zookeeper</artifactId>
+              </exclusion>
+          </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
-            <version>${global_curator_version}</version>
+            <version>${global_curator_test_version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <!-- need to exclude zookeeper 3.5.x http://curator.apache.org/zk-compatibility.html -->
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jboss.aesh</groupId>

--- a/metron-stellar/stellar-zeppelin/pom.xml
+++ b/metron-stellar/stellar-zeppelin/pom.xml
@@ -45,6 +45,21 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>log4j-over-slf4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- to avoid pulling in curator 2.12.0 -->
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -153,8 +153,8 @@
                 <!-- For Zookeeper/Curator version compatibility see
                       http://curator.apache.org/zk-compatibility.html -->
                 <global_zookeeper_version>3.4.6</global_zookeeper_version>
-                <global_curator_version>2.7.1</global_curator_version>
-                <global_curator_test_version>2.7.1</global_curator_test_version>
+                <global_curator_version>4.2.0</global_curator_version>
+                <global_curator_test_version>2.12.0</global_curator_test_version>
             </properties>
         </profile>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,6 @@
         <global_caffeine_version>2.6.2</global_caffeine_version>
         <global_antlr_version>4.5</global_antlr_version>
         <global_opencsv_version>3.7</global_opencsv_version>
-        <global_curator_version>2.7.1</global_curator_version>
         <global_classindex_version>3.3</global_classindex_version>
         <global_hbase_version>1.1.1</global_hbase_version>
         <global_hbase_guava_version>12.0</global_hbase_guava_version>
@@ -151,6 +150,11 @@
                 <global_solr_version>7.4.0</global_solr_version>
                 <global_hbase_version>2.0.2</global_hbase_version>
                 <global_hbase_guava_version>17.0</global_hbase_guava_version>
+                <!-- For Zookeeper/Curator version compatibility see
+                      http://curator.apache.org/zk-compatibility.html -->
+                <global_zookeeper_version>3.4.6</global_zookeeper_version>
+                <global_curator_version>2.7.1</global_curator_version>
+                <global_curator_test_version>2.7.1</global_curator_test_version>
             </properties>
         </profile>
         <profile>
@@ -167,6 +171,11 @@
                 <global_solr_version>6.6.2</global_solr_version>
                 <global_hbase_version>2.0.2</global_hbase_version>
                 <global_hbase_guava_version>17.0</global_hbase_guava_version>
+                <!-- For Zookeeper/Curator version compatibility see
+                      http://curator.apache.org/zk-compatibility.html -->
+                <global_zookeeper_version>3.4.6</global_zookeeper_version>
+                <global_curator_version>2.7.1</global_curator_version>
+                <global_curator_test_version>2.7.1</global_curator_test_version>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
## Contributor Comments
This PR is based on [METRON-2261](https://github.com/apache/metron/pull/1515) and includes those changes.  It must be merged before this.

This PR upgrades Curator to version 4.2.0 and fixes a couple bugs in `MaasIntegrationTest` that resulted from the upgrade.  There was an extra service unregister in the `ContainerRequestListener` class (should only be unregistered once) and another more complicated bug (described in the next section).

### Bug Fix
After upgrading to Curator version 4.2.0, both tests in `MaasIntegrationTest` fail with this error:
```
testMaaSWithoutDomain(org.apache.metron.maas.service.MaasIntegrationTest)  Time elapsed: 214.791 sec  <<< FAILURE!
java.lang.AssertionError
	at org.junit.Assert.fail(Assert.java:86)
	at org.junit.Assert.assertTrue(Assert.java:41)
	at org.junit.Assert.assertTrue(Assert.java:52)
	at org.apache.metron.maas.service.MaasIntegrationTest.testDSShell(MaasIntegrationTest.java:269)
	at org.apache.metron.maas.service.MaasIntegrationTest.testMaaSWithoutDomain(MaasIntegrationTest.java:113)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:748)
``` 
The service is not properly unregistered, the test [waits for the service to be removed from the list of endpoints](https://github.com/apache/metron/blob/master/metron-analytics/metron-maas-service/src/test/java/org/apache/metron/maas/service/MaasIntegrationTest.java#L261) and then timeouts and fails.

The root cause is a change in how the `org.apache.curator.x.discovery.details. ServiceDiscoveryImpl` class unregisters a service after the upgrade.  The list of services is maintained in 2 places:  Zookeeper and an [internal Map](https://github.com/apache/curator/blob/apache-curator-4.2.0/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/ServiceDiscoveryImpl.java#L64) in `ServiceDiscoveryImpl`.  There are several read functions in `ServiceDiscoveryImpl` but then don't refresh the internal Map.  The internal Map is only updated when `registerService` and `unregisterService` are called. 

Before the upgrade, a service is [removed from Zookeeper](https://github.com/apache/curator/blob/apache-curator-2.7.0/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/ServiceDiscoveryImpl.java#L218) then [removed from the internal Map](https://github.com/apache/curator/blob/apache-curator-2.7.0/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/ServiceDiscoveryImpl.java#L224).

After the upgrade, the order is reversed.  The service is [removed from the internal Map](https://github.com/apache/curator/blob/apache-curator-4.2.0/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/ServiceDiscoveryImpl.java#L255) then [removed from Zookeeper](https://github.com/apache/curator/blob/apache-curator-4.2.0/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/ServiceDiscoveryImpl.java#L524).  However there is a check that [ensures the service existed in the internal Map](https://github.com/apache/curator/blob/apache-curator-4.2.0/curator-x-discovery/src/main/java/org/apache/curator/x/discovery/details/ServiceDiscoveryImpl.java#L511) before removing it for Zookeeper.  Services are registered in `org.apache.metron.maas.service.runner.Runner` and unregistered in `org.apache.metron.maas.service.callback.ContainerRequestListener`.  The latter runs in a different process so registered services are not in the internal Map.  This was not a problem before the upgrade because Zookeeper was updated regardless of the internal Map state.

The fix proposed in this PR is to register a service immediately before unregistering it in `org.apache.metron.maas.discovery.ServiceDiscoverer`.  This populates the internal Map in `ServiceDiscoveryImpl` with the service so that the subsequent unregister call functions correctly.  A side effect of this would be writing duplicate data to Zookeeper.  The only other solution I can think of would be to rearchitect how and where services are registered/unregistered.

### Testing
The `MaasIntegrationTest` (and all tests) should pass.  Upgrading Curator without the fixes in this PR should cause the error above.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

- [ ] Have you ensured that any documentation diagrams have been updated, along with their source files, using [draw.io](https://www.draw.io/)? See [Metron Development Guidelines](https://cwiki.apache.org/confluence/display/METRON/Development+Guidelines) for instructions.

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
