### PR TITLE
METRON-2264 Upgrade metron-hbase-client to HBase 2.0.2

### DIFF
--- a/metron-platform/metron-hbase-client/pom.xml
+++ b/metron-platform/metron-hbase-client/pom.xml
@@ -36,15 +36,12 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <!-- Note: This is 1.1.2 and not ${global_hbase_version} to avoid https://issues.apache.org/jira/browse/HBASE-13889 -->
-        <!-- when we migrate to a version > 1.1.2, this can be set to ${global_hbase_version} -->
-        <shaded.client.version>1.1.2</shaded.client.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-shaded-client</artifactId>
-            <version>${shaded.client.version}</version>
+            <version>${global_hbase_version}</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
The `metron-hbase-client` which is used by `metron-rest` has some special handling for pulling in a shaded HBase client library.  This pulls in a different version (1.1.2) than the global HBase version to work around a known HBase bug.  After the upgrade to 2.0.2, this work around is no longer needed and can be removed.

## Acceptance Testing

This PR should be tested using the centos7 development environment.  

1. Start up the centos7 dev environment.
    ```
    cd metron-deployment/development/centos7
    vagrant destroy -f
    vagrant up
    ```

### Basics

Ensure that we can continue to parse, enrich, and index telemetry.  Verify data is flowing through the system, from parsing to indexing

1. Open Ambari and navigate to the Metron service http://node1:8080/#/main/services/METRON/summary

1. Open the Alerts UI.  Verify alerts show up in the main UI - click the search icon (you may need to wait a moment for them to appear)

1. Go to the Alerts UI and ensure that an ever increasing number of telemetry from Bro, Snort, and YAF are visible by watching the total alert count increase over time.

1. Ensure that geoip enrichment is occurring.  The telemetry should contain fields like `enrichments:geo:ip_src_addr:location_point`.

1. Head back to Ambari and select the Kibana service http://node1:8080/#/main/services/KIBANA/summary

1. Open the Kibana dashboard via the "Metron UI" option in the quick links

1. Verify the dashboard is populating

###  Streaming Enrichments

  1. Create a Streaming Enrichment [by following these instructions](https://cwiki.apache.org/confluence/display/METRON/2016/06/16/Metron+Tutorial+-+Fundamentals+Part+6%3A+Streaming+Enrichment).

  1. Launch the Stellar REPL.
      ```
      source /etc/default/metron
      cd $METRON_HOME
      $METRON_HOME/bin/stellar -z $ZOOKEEPER
      ```

  1. Define the streaming enrichment and save it as a new source of telemetry.

      ```
      [Stellar]>>> conf := SHELL_EDIT(conf)
      {
        "parserClassName": "org.apache.metron.parsers.csv.CSVParser",
        "writerClassName": "org.apache.metron.writer.hbase.SimpleHbaseEnrichmentWriter",
        "sensorTopic": "user",
        "parserConfig": {
          "shew.table": "enrichment",
          "shew.cf": "t",
          "shew.keyColumns": "ip",
          "shew.enrichmentType": "user",
          "columns": {
            "user": 0,
            "ip": 1
          }
        }
      }
      [Stellar]>>>
      [Stellar]>>> CONFIG_PUT("PARSER", conf, "user")
      ```

  1. Go to the Management UI and start the new parser called 'user'.

  1. Create some test telemetry.
      ```
      [Stellar]>>> msgs := ["user1,192.168.1.1", "user2,192.168.1.2", "user3,192.168.1.3"]
      [user1,192.168.1.1, user2,192.168.1.2, user3,192.168.1.3]
      [Stellar]>>> KAFKA_PUT("user", msgs)
      3
      [Stellar]>>> KAFKA_PUT("user", msgs)
      3
      [Stellar]>>> KAFKA_PUT("user", msgs)
      3
      ```

  1. Ensure that the enrichments are persisted in HBase.
      ```
      [Stellar]>>> ENRICHMENT_GET('user', '192.168.1.1', 'enrichment', 't')
      {original_string=user1,192.168.1.1, guid=a6caf3c1-2506-4eb7-b33e-7c05b77cd72c, user=user1, timestamp=1551813589399, source.type=user}

      [Stellar]>>> ENRICHMENT_GET('user', '192.168.1.2', 'enrichment', 't')
      {original_string=user2,192.168.1.2, guid=49e4b8fa-c797-44f0-b041-cfb47983d54a, user=user2, timestamp=1551813589399, source.type=user}

      [Stellar]>>> ENRICHMENT_GET('user', '192.168.1.3', 'enrichment', 't')
      {original_string=user3,192.168.1.3, guid=324149fd-6c4c-42a3-b579-e218c032ea7f, user=user3, timestamp=1551813589402, source.type=user}
      ```

### Enrichment Coprocessor

  1. Confirm that the 'user' enrichment added in the previous section was 'found' by the coprocessor.
        * Go to Swagger. 
        * Click the `sensor-enrichment-config-controller` option.
        * Click the `GET /api/v1/sensor/enrichment/config/list/available/enrichments` option.

  1. Click the "Try it out!" button. You should see a array returned with the value of each enrichment type that you have loaded.
    ```
    [
      "user"
    ]
    ```


## Pull Request Checklist

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

- [x] Have you ensured that any documentation diagrams have been updated, along with their source files, using [draw.io](https://www.draw.io/)? See [Metron Development Guidelines](https://cwiki.apache.org/confluence/display/METRON/Development+Guidelines) for instructions.

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
