### PR TITLE
METRON-2271 Reorganize Travis Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,27 +36,27 @@ matrix:
   include:
     - name: Unit Tests
       script:
-        - time mvn install -T 2C -q -DskipTests=true -Dmaven.javadoc.skip=true -B -V -pl '!org.apache.metron:metron-config,!org.apache.metron:metron-alerts'
+        - time mvn install -T 2C -q -DskipTests=true -Dmaven.javadoc.skip=true -B -V -pl '!:metron-config,!:metron-alerts'
         - time mvn surefire:test@unit-tests -T 2C
 
     - name: Integration Tests
       script:
-        - time mvn install -T 2C -q -DskipTests=true -Dmaven.javadoc.skip=true -B -V -pl '!org.apache.metron:metron-config,!org.apache.metron:metron-alerts'
+        - time mvn install -T 2C -q -DskipTests=true -Dmaven.javadoc.skip=true -B -V -pl '!:metron-config,!:metron-alerts'
         - time mvn surefire:test@integration-tests
 
     - name: Alerts UI Tests
       script:
-        - time mvn install -T 2C -q -DskipTests=true -Dmaven.javadoc.skip=true -B -V -pl 'org.apache.metron:metron-alerts'
-        - time mvn test -pl 'org.apache.metron:metron-alerts'
+        - time mvn install -T 2C -q -DskipTests=true -Dmaven.javadoc.skip=true -B -V -pl ':metron-alerts'
+        - time mvn test -pl ':metron-alerts'
 
     - name: Management UI Tests
       script:
-        - time mvn install -T 2C -q -DskipTests=true -Dmaven.javadoc.skip=true -B -V -pl 'org.apache.metron:metron-config'
-        - time mvn test -pl 'org.apache.metron:metron-config'
+        - time mvn install -T 2C -q -DskipTests=true -Dmaven.javadoc.skip=true -B -V -pl ':metron-config'
+        - time mvn test -pl ':metron-config'
 
     - name: Site Book
       script:
-        - time mvn clean site --projects site-book
+        - time mvn clean site -pl site-book
 
     - name: Verify Licenses
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,7 @@
 dist: trusty
 sudo: required
 addons:
-  chrome: stable
-
-env:
-  - SCRIPT="mvn surefire:test@unit-tests -T 2C"
-  - SCRIPT="mvn surefire:test@integration-tests"
-  - SCRIPT="mvn clean site --projects site-book"
-  - SCRIPT="mvn test --projects metron-interface/metron-config,metron-interface/metron-alerts"
-  - SCRIPT="./dev-utilities/build-utils/verify_licenses.sh"
+ chrome: stable
 
 install: true
 language: java
@@ -38,14 +31,36 @@ before_install:
   - npm config set cache $HOME/.npm-cache --global
   - npm config set prefix $HOME/.npm-prefix --global
 
-install:
-  - time mvn install -T 2C -q -DskipTests=true -Dmaven.javadoc.skip=true -B -V
-
-script:
-  - time $SCRIPT
-
 matrix:
   fast_finish: true
+  include:
+    - name: Unit Tests
+      script:
+        - time mvn install -T 2C -q -DskipTests=true -Dmaven.javadoc.skip=true -B -V -pl '!org.apache.metron:metron-config,!org.apache.metron:metron-alerts'
+        - time mvn surefire:test@unit-tests -T 2C
+
+    - name: Integration Tests
+      script:
+        - time mvn install -T 2C -q -DskipTests=true -Dmaven.javadoc.skip=true -B -V -pl '!org.apache.metron:metron-config,!org.apache.metron:metron-alerts'
+        - time mvn surefire:test@integration-tests
+
+    - name: Alerts UI Tests
+      script:
+        - time mvn install -T 2C -q -DskipTests=true -Dmaven.javadoc.skip=true -B -V -pl 'org.apache.metron:metron-alerts'
+        - time mvn test -pl 'org.apache.metron:metron-alerts'
+
+    - name: Management UI Tests
+      script:
+        - time mvn install -T 2C -q -DskipTests=true -Dmaven.javadoc.skip=true -B -V -pl 'org.apache.metron:metron-config'
+        - time mvn test -pl 'org.apache.metron:metron-config'
+
+    - name: Site Book
+      script:
+        - time mvn clean site --projects site-book
+
+    - name: Verify Licenses
+      script:
+        - time ./dev-utilities/build-utils/verify_licenses.sh
 
 before_cache:
   - rm -rf $HOME/.m2/repository/org/apache/metron

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@
 dist: trusty
 sudo: required
 addons:
- chrome: stable
+  chrome: stable
 
 install: true
 language: java


### PR DESCRIPTION
We are increasingly hitting the 50 minute time limit on our integration test job in Travis.  This 
 causes the entire Travis build to fail.  My goal here is to make minor modifications to avoid these failures until we can come back for a more comprehensive review of our integration tests to address the issue of total run time.

### Background

The way in which we organize the Travis build currently causes each job to build *all* of Metron, *every* time.  Although we attempt to cache the local Maven repository to avoid repetitively building Metron, in practice all of the jobs in a build start roughly in parallel and so this cache is never used.  The result is that every job builds all of Metron. 

As evidence review how long it takes for the license verification job to complete.  While this should take a few seconds/minutes, this always takes 15+ minutes because the job does a full build of Metron.  It is never able to re-use what was built and cached by any other job.

### Solution

By reorganizing the build, so that each job only builds the modules that it needs (and avoid a one-size-fits-all "install" step) we save enough time to avoid breaching the 50 minute time limit on any individual job.  In addition, I added names to each job to improve clarity in the Travis UI and split out the the UI tests so that the Alerts and Management tests run separately.

These are the advantages that I see with this change.

1. This will prevent us from unnecessarily breaching the 50 minute time limit for the integration test job with minimal effort or risk as compared to re-architecting the integration tests. 

1. We get more immediate feedback. If you messed up the licenses, you're going to know in a minute, rather than after 20 minutes.

1. We have a much more accurate picture of how long each step is taking.  Previously the site-book appeared to take 16-18 minutes, but it is now very clear that it takes 1-2 minutes.

1. The total aggregate run time was previously 2.25-2.5 hours, but is now about 1.25-1.5 hours.  This is less load on Travis and we like Travis, so let's help him out.

<img width="1292" alt="Screen Shot 2019-10-01 at 5 45 14 PM" src="https://user-images.githubusercontent.com/2475409/66003180-6053fe00-e473-11e9-898e-39db49fcf5f6.png">

See the following examples.
* https://travis-ci.org/nickwallen/metron/builds/592235729 
* https://travis-ci.org/apache/metron/builds/592263213

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
