### PR TITLE
METRON-2275 Solr Indexing Topology Fails to Start on Secure Cluster with HDP 3.1

### DIFF
--- a/metron-platform/metron-solr/metron-solr-storm/pom.xml
+++ b/metron-platform/metron-solr/metron-solr-storm/pom.xml
@@ -28,6 +28,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <commons.config.version>1.10</commons.config.version>
+        <guava_version>${global_hbase_guava_version}</guava_version>
     </properties>
     <dependencies>
         <dependency>
@@ -158,6 +159,10 @@
                                 </filter>
                             </filters>
                             <relocations>
+                                <relocation>
+                                    <pattern>com.google.common</pattern>
+                                    <shadedPattern>org.apache.metron.guava.${guava_version}</shadedPattern>
+                                </relocation>
                                 <relocation>
                                     <pattern>com.fasterxml.jackson</pattern>
                                     <shadedPattern>org.apache.metron.jackson</shadedPattern>

--- a/metron-platform/metron-solr/metron-solr-storm/pom.xml
+++ b/metron-platform/metron-solr/metron-solr-storm/pom.xml
@@ -160,6 +160,12 @@
                             </filters>
                             <relocations>
                                 <relocation>
+                                    <!--
+                                      Need to relocate Guava 17.0 as it is required by Curator 2.7.1. When running with
+                                      kerberos, Storm adds all jars in `$STORM_HOME/contrib/storm-autocreds` to the
+                                      classpath.  This includes Guava 28.0, which is incompatible with Curator 2.7.1.
+                                      This only seems to be a problem when running Storm with kerberos.
+                                    -->
                                     <pattern>com.google.common</pattern>
                                     <shadedPattern>org.apache.metron.guava.${guava_version}</shadedPattern>
                                 </relocation>


### PR DESCRIPTION

The Solr indexing topology will fail to start on a secure, kerberized cluster with HDP 3.1.  The following error will occur when starting the topology.  The topology will not start successfully.

```
+-         Apache Storm        -+
+-  data FLow User eXperience  -+
Version: 1.0.1
Parsing file: /usr/hcp/1.9.2.0-94/metron/flux/indexing/random_access/remote.yaml
797  [main] INFO  o.a.s.f.p.FluxParser - loading YAML from input stream...
804  [main] INFO  o.a.s.f.p.FluxParser - Performing property substitution.
808  [main] INFO  o.a.s.f.p.FluxParser - Not performing environment variable substitution.
1118 [main] INFO  o.a.c.f.i.CuratorFrameworkImpl - Starting
Exception in thread "main" java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.apache.storm.flux.FluxBuilder.buildObject(FluxBuilder.java:294)
	at org.apache.storm.flux.FluxBuilder.buildComponents(FluxBuilder.java:342)
	at org.apache.storm.flux.FluxBuilder.buildTopology(FluxBuilder.java:75)
	at org.apache.storm.flux.Flux.runCli(Flux.java:153)
	at org.apache.storm.flux.Flux.main(Flux.java:98)
Caused by: java.lang.NoSuchMethodError: com.google.common.util.concurrent.MoreExecutors.sameThreadExecutor()Lcom/google/common/util/concurrent/ListeningExecutorService;
	at org.apache.curator.framework.listen.ListenerContainer.addListener(ListenerContainer.java:40)
	at org.apache.curator.framework.imps.CuratorFrameworkImpl.start(CuratorFrameworkImpl.java:246)
	at org.apache.metron.common.utils.KafkaUtils.getBrokersFromZookeeper(KafkaUtils.java:49)
	at org.apache.metron.storm.kafka.flux.SimpleStormKafkaBuilder.getBootstrapServers(SimpleStormKafkaBuilder.java:246)
	at org.apache.metron.storm.kafka.flux.SimpleStormKafkaBuilder.<init>(SimpleStormKafkaBuilder.java:203)
	at org.apache.metron.storm.kafka.flux.SimpleStormKafkaBuilder.<init>(SimpleStormKafkaBuilder.java:187)
	... 9 more
```

### Root Cause

When kerberized, Storm adds a bunch of jars from `$STORM_HOME/contrib/storm-autocreds` to the classpath. These jars are not added to the classpath when the cluster is unsecure (no kerberos).

The exception here occurs because...
* We build against Guava 17.0 and Curator 2.7.1.
* Curator 2.7.1 calls a Guava method MoreExecutors.sameThreadExecutor.
* The method [MoreExecutors.sameThreadExecutor](https://guava.dev/releases/20.0/api/docs/com/google/common/util/concurrent/MoreExecutors.html#sameThreadExecutor--) was removed in Guava 21.0
* At runtime Storm is providing Guava 28.0 (which does not include MoreExecutors.sameThreadExecutor) from `/usr/hdp/current/storm-client/contrib/storm-autocreds/guava-28.0-jre.jar` 

### The Fix

We need to relocate Guava 17.0 in the Solr uber jar.  This will allow Curator 2.7.1 to use Guava 17.0.  This is the same relocation that occurs for the Elasticsearch indexing topology.

### Testing

1. Spin-up the `centos7` development environment.
1. Kerberize the cluster.
1. Attempt to start the Indexing topologies.  The topologies should start successfully.

## Pull Request Checklist

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
