### PR TITLE
METRON-2279 Unable to Index to Solr with Kerberos

### DIFF
--- a/metron-platform/metron-solr/metron-solr-storm/pom.xml
+++ b/metron-platform/metron-solr/metron-solr-storm/pom.xml
@@ -29,6 +29,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <commons.config.version>1.10</commons.config.version>
         <guava_version>${global_hbase_guava_version}</guava_version>
+        <!-- the version of httpclient required by solr 7.4.0 -->
+        <http_client_version>4.5.3</http_client_version>
     </properties>
     <dependencies>
         <dependency>
@@ -168,6 +170,21 @@
                                     -->
                                     <pattern>com.google.common</pattern>
                                     <shadedPattern>org.apache.metron.guava.${guava_version}</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <!--
+                                      Need to relocate httpclient 4.5.3 and httpcore 4.4.6 as these versions are required
+                                      by Solr 7.4.0. This will relocate all HttpComponents libraries pulled-in including
+                                      `httpclient`, `httpcore`, and `httpmime` because each share a common base package
+                                      namespace (org.apache.http).
+
+                                      When running with kerberos, Storm adds all jars in `$STORM_HOME/contrib/storm-autocreds`
+                                      to the classpath at runtime.  This includes httpcore 4.4.1 and httpclient 4.3.6, which are
+                                      incompatible with Solr 7.4.0. This is only a problem when running Storm with
+                                      kerberos.
+                                    -->
+                                    <pattern>org.apache.http</pattern>
+                                    <shadedPattern>org.apache.metron.http.${http_client_version}</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>com.fasterxml.jackson</pattern>


### PR DESCRIPTION
On the HDP 3.1 feature branch the indexing topology is unable to index telemetry to Solr when running in a secure/kerberized environment. The topology fails with this error.
```
2019-10-09 06:32:33.039 o.a.s.util Thread-7-indexingBolt-executor[3 3] [ERROR] Async loop died!
java.lang.NoSuchMethodError: org.apache.http.impl.conn.PoolingHttpClientConnectionManager.setValidateAfterInactivity(I)V
        at org.apache.solr.client.solrj.impl.HttpClientUtil.createClient(HttpClientUtil.java:277) ~[stormjar.jar:?]
        at org.apache.solr.client.solrj.impl.HttpClientUtil.createClient(HttpClientUtil.java:328) ~[stormjar.jar:?]
        at org.apache.solr.client.solrj.impl.HttpClientUtil.createClient(HttpClientUtil.java:266) ~[stormjar.jar:?]
        at org.apache.solr.client.solrj.impl.HttpClientUtil.createClient(HttpClientUtil.java:253) ~[stormjar.jar:?]
        at org.apache.metron.solr.writer.SolrClientFactory.create(SolrClientFactory.java:49) ~[stormjar.jar:?]
        at org.apache.metron.solr.writer.SolrWriter.init(SolrWriter.java:171) ~[stormjar.jar:?]
        at org.apache.metron.writer.bolt.BulkMessageWriterBolt.prepare(BulkMessageWriterBolt.java:239) ~[stormjar.jar:?]
        at org.apache.storm.daemon.executor$fn__10219$fn__10232.invoke(executor.clj:810) ~[storm-core-1.2.1.3.1.4.0-315.jar:1.2.1.3.1.4.0-315]
        at org.apache.storm.util$async_loop$fn__1221.invoke(util.clj:482) [storm-core-1.2.1.3.1.4.0-315.jar:1.2.1.3.1.4.0-315]
        at clojure.lang.AFn.run(AFn.java:22) [clojure-1.7.0.jar:?]
        at java.lang.Thread.run(Thread.java:745) [?:1.8.0_112]
2019-10-09 06:32:33.166 o.a.s.d.executor Thread-7-indexingBolt-executor[3 3] [ERROR]
java.lang.NoSuchMethodError: org.apache.http.impl.conn.PoolingHttpClientConnectionManager.setValidateAfterInactivity(I)V
        at org.apache.solr.client.solrj.impl.HttpClientUtil.createClient(HttpClientUtil.java:277) ~[stormjar.jar:?]
        at org.apache.solr.client.solrj.impl.HttpClientUtil.createClient(HttpClientUtil.java:328) ~[stormjar.jar:?]
        at org.apache.solr.client.solrj.impl.HttpClientUtil.createClient(HttpClientUtil.java:266) ~[stormjar.jar:?]
        at org.apache.solr.client.solrj.impl.HttpClientUtil.createClient(HttpClientUtil.java:253) ~[stormjar.jar:?]
        at org.apache.metron.solr.writer.SolrClientFactory.create(SolrClientFactory.java:49) ~[stormjar.jar:?]
        at org.apache.metron.solr.writer.SolrWriter.init(SolrWriter.java:171) ~[stormjar.jar:?]
        at org.apache.metron.writer.bolt.BulkMessageWriterBolt.prepare(BulkMessageWriterBolt.java:239) ~[stormjar.jar:?]
        at org.apache.storm.daemon.executor$fn__10219$fn__10232.invoke(executor.clj:810) ~[storm-core-1.2.1.3.1.4.0-315.jar:1.2.1.3.1.4.0-315]
        at org.apache.storm.util$async_loop$fn__1221.invoke(util.clj:482) [storm-core-1.2.1.3.1.4.0-315.jar:1.2.1.3.1.4.0-315]
        at clojure.lang.AFn.run(AFn.java:22) [clojure-1.7.0.jar:?]
        at java.lang.Thread.run(Thread.java:745) [?:1.8.0_112]
OptionsAttachments
```

### Why?

The method [PoolingHttpClientConnectionManager.setValidateAfterInactivity(int)](https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.html#setValidateAfterInactivity(int)) is only available from org.apache.httpcomponents:httpclient in versions > 4.4.  In `metron-solr-storm` we allow org.apache.solr:solr-solrj version 7.4.0 to pull in org.apache.httpcomponents:httpclient version 4.5.3.  When executed in a non-kerberized environment this works just fine.

Unfortunately, when Storm is using Kerberos authentication, it pulls in a slew of additional dependencies at runtime from `/usr/hdp/current/storm-client/contrib/storm-autocreds/`.  This includes `httpclient-4.3.6.jar` which does not contain the method mentioned above.

We need to relocate the `httpclient` dependency in the Solr uber jar to prevent Storm from trouncing on this dependency at runtime.

## Testing

1. Spin up the centos7 development environment.

1. Switch the indexer to Solr instead of Elasticsearch by [following these instructions](https://github.com/apache/metron/tree/master/metron-platform/metron-solr/metron-solr-common#installing).

1. Ensure that telemetry is being indexed into Solr.

1. Ensure that the telemetry from Solr is visible in the Alerts UI.

1. Kerberize the environment.

1. Ensure that telemetry is being indexed into Solr after the environment has been kerberized.

1. Ensure that the telemetry from Solr is visible in the Alerts UI.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

- [x] Have you ensured that any documentation diagrams have been updated, along with their source files, using [draw.io](https://www.draw.io/)? See [Metron Development Guidelines](https://cwiki.apache.org/confluence/display/METRON/Development+Guidelines) for instructions.

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
