### PR TITLE
METRON-2290: [UI] Delaying first auto polling request on app start

### DIFF
--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/alerts-list.component.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/alerts-list.component.ts
@@ -190,6 +190,7 @@ export class AlertsListComponent implements OnInit, OnDestroy {
         this.clusterMetaDataService.getDefaultColumns()
     ).subscribe((response: any) => {
       this.prepareData(response[0], response[1]);
+      this.setSearchRequestSize();
       this.refreshAlertData(resetPaginationForSearch);
     });
   }

--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/auto-polling/auto-polling.service.spec.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/auto-polling/auto-polling.service.spec.ts
@@ -442,7 +442,7 @@ describe('AutoPollingService', () => {
 
   });
 
-  describe('polling state persisting and restoring', () => {
+  fdescribe('polling state persisting and restoring', () => {
 
     it('should persist polling state on start', () => {
       spyOn(localStorage, 'setItem');
@@ -462,7 +462,7 @@ describe('AutoPollingService', () => {
       expect(localStorage.setItem).toHaveBeenCalledWith('autoPolling', '{"isActive":false,"refreshInterval":4}');
     });
 
-    it('should restore polling state on construction', () => {
+    it('should restore polling state on construction with a delay', fakeAsync(() => {
       const queryBuilderFake = TestBed.get(QueryBuilder);
       const dialogServiceFake = TestBed.get(QueryBuilder);
 
@@ -470,10 +470,14 @@ describe('AutoPollingService', () => {
 
       const localAutoPollingSvc = new AutoPollingService(searchServiceFake, queryBuilderFake, dialogServiceFake);
 
+      tick(localAutoPollingSvc.AUTO_START_DELAY);
+
       expect(localStorage.getItem).toHaveBeenCalledWith('autoPolling');
       expect(localAutoPollingSvc.getIsPollingActive()).toBe(true);
       expect(localAutoPollingSvc.getInterval()).toBe(443);
-    });
+
+      localAutoPollingSvc.stop();
+    }));
 
     it('should start polling on construction when persisted isActive==true', fakeAsync(() => {
       const queryBuilderFake = TestBed.get(QueryBuilder);
@@ -483,6 +487,8 @@ describe('AutoPollingService', () => {
       spyOn(localStorage, 'getItem').and.returnValue('{"isActive":true,"refreshInterval":10}');
 
       const localAutoPollingSvc = new AutoPollingService(searchServiceFake, queryBuilderFake, dialogServiceFake);
+
+      tick(localAutoPollingSvc.AUTO_START_DELAY);
 
       expect(searchServiceFake.search).toHaveBeenCalledTimes(1);
 
@@ -503,6 +509,8 @@ describe('AutoPollingService', () => {
       spyOn(localStorage, 'getItem').and.returnValue('{"isActive":true,"refreshInterval":4}');
 
       const localAutoPollingSvc = new AutoPollingService(searchServiceFake, queryBuilderFake, dialogServiceFake);
+
+      tick(localAutoPollingSvc.AUTO_START_DELAY);
 
       expect(searchServiceFake.search).toHaveBeenCalledTimes(1);
 

--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/auto-polling/auto-polling.service.spec.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/auto-polling/auto-polling.service.spec.ts
@@ -442,7 +442,7 @@ describe('AutoPollingService', () => {
 
   });
 
-  fdescribe('polling state persisting and restoring', () => {
+  describe('polling state persisting and restoring', () => {
 
     it('should persist polling state on start', () => {
       spyOn(localStorage, 'setItem');

--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/auto-polling/auto-polling.service.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/auto-polling/auto-polling.service.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 import { Injectable } from '@angular/core';
-import { Subscription, Subject, Observable, interval, onErrorResumeNext } from 'rxjs';
+import { Subscription, Subject, Observable, interval, onErrorResumeNext, timer } from 'rxjs';
 import { SearchService } from 'app/service/search.service';
 import { QueryBuilder } from '../query-builder';
 import { SearchResponse } from 'app/model/search-response';
@@ -33,14 +33,15 @@ interface AutoPollingStateModel {
 
 @Injectable()
 export class AutoPollingService {
-  data = new Subject<SearchResponse>();
-
+  private readonly AUTO_START_DELAY = 500;
   private isCongestion = false;
   private refreshInterval = 10;
   private isPollingActive = POLLING_DEFAULT_STATE;
   private isPending = false;
   private isPollingSuppressed = false;
   private pollingIntervalSubs: Subscription;
+
+  data = new Subject<SearchResponse>();
 
   public readonly AUTO_POLLING_STORAGE_KEY = 'autoPolling';
 
@@ -116,7 +117,7 @@ export class AutoPollingService {
       this.refreshInterval = persistedState.refreshInterval;
 
       if (persistedState.isActive) {
-        this.start();
+        timer(this.AUTO_START_DELAY).subscribe(this.start.bind(this));
       }
     }
   }

--- a/metron-interface/metron-alerts/src/app/alerts/alerts-list/auto-polling/auto-polling.service.ts
+++ b/metron-interface/metron-alerts/src/app/alerts/alerts-list/auto-polling/auto-polling.service.ts
@@ -33,7 +33,6 @@ interface AutoPollingStateModel {
 
 @Injectable()
 export class AutoPollingService {
-  private readonly AUTO_START_DELAY = 500;
   private isCongestion = false;
   private refreshInterval = 10;
   private isPollingActive = POLLING_DEFAULT_STATE;
@@ -41,6 +40,7 @@ export class AutoPollingService {
   private isPollingSuppressed = false;
   private pollingIntervalSubs: Subscription;
 
+  readonly AUTO_START_DELAY = 500;
   data = new Subject<SearchResponse>();
 
   public readonly AUTO_POLLING_STORAGE_KEY = 'autoPolling';


### PR DESCRIPTION
## Contributor Comments
The state of auto polling on Alerts UI is persisted in the browser's localStorage. Next time the User visiting the UI the auto polling state (on/off, refresh interval) will be automatically restored.

Unfortunately, there is a race condition between the restoration of
- persisted auto polling state,
- persisted page size and
- default time range filter.

To fix this in the simplest possible way I delayed the start of the auto polling when it's automatically starting on app initialization.
With this the application able to restore the persisted page size and set the default time range properly before the auto polling start using these values.

While I was investigating this issue I realized that the restoration of page size itself was also broken, so I fixed that as well (single line of code change).

## Testing
If you turn on auto polling and refreshing the browser auto polling should stay turned on.
The queries fired by auto polling should contain page size, from fields in the request and timer range filter in the query string. 

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

- [x] Have you ensured that any documentation diagrams have been updated, along with their source files, using [draw.io](https://www.draw.io/)? See [Metron Development Guidelines](https://cwiki.apache.org/confluence/display/METRON/Development+Guidelines) for instructions.

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
