### PR TITLE
METRON-2298 'User Base DN' Missing from Security Configuration

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/themes/metron_theme.json
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/themes/metron_theme.json
@@ -897,6 +897,10 @@
           "subsection-name": "subsection-security-ldap"
         },
         {
+          "config": "metron-security-env/metron.ldap.user.basedn",
+          "subsection-name": "subsection-security-ldap"
+        },
+        {
           "config": "metron-security-env/metron.ldap.user.dnpattern",
           "subsection-name": "subsection-security-ldap"
         },
@@ -1685,6 +1689,12 @@
         "config": "metron-security-env/metron.ldap.ssl.truststore.password",
         "widget": {
           "type": "password"
+        }
+      },
+      {
+        "config": "metron-security-env/metron.ldap.user.basedn",
+        "widget": {
+          "type": "text-field"
         }
       },
       {


### PR DESCRIPTION
The "User Base DN" is not visible on Metron's Security configuration tab in Ambari.  This property should be visible along with the other LDAP properties. This property is currently only visible under "Advanced metron-security-env".

## Validation

Spin-up the development environment and ensure that the "User Base DN" property is visible on the Metron > Configs >  Security page.

## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
