### PR TITLE
METRON-2297 Enrichment Topology Unable to Load Geo IP Data from HDFS

### DIFF
--- a/metron-analytics/metron-profiler-storm/pom.xml
+++ b/metron-analytics/metron-profiler-storm/pom.xml
@@ -148,6 +148,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.metron</groupId>
+            <artifactId>metron-common-storm</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.metron</groupId>
             <artifactId>metron-writer-storm</artifactId>
             <version>${project.parent.version}</version>
             <exclusions>

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/configuration/metron-security-env.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/configuration/metron-security-env.xml
@@ -159,7 +159,6 @@
     </value-attributes>
     <on-ambari-upgrade add="true"/>
   </property>
-
   <property>
     <name>metron.ldap.ssl.truststore</name>
     <display-name>LDAP Truststore</display-name>
@@ -239,5 +238,14 @@
     <value>ADMIN</value>
     <description>Name of the role at the authentication provider that provides administrative access to Metron.</description>
     <on-ambari-upgrade add="true"/>
+  </property>
+  <property>
+    <name>topology_auto_credentials</name>
+    <display-name>Topology Auto Credentials</display-name>
+    <description>The value of Storm's `topology.auto-credentials`. A list of plugins used to unpack credentials on the Storm worker. This value is only used when Kerberos has been enabled.</description>
+    <value>['org.apache.metron.storm.security.auth.kerberos.AutoTGT']</value>
+    <value-attributes>
+      <empty-value-valid>true</empty-value-valid>
+    </value-attributes>
   </property>
 </configuration>

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/params_linux.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/params_linux.py
@@ -258,7 +258,12 @@ profiler_topology_worker_childopts = client_jaas_arg if security_enabled else ''
 indexing_topology_worker_childopts = client_jaas_arg if security_enabled else ''
 pcap_topology_worker_childopts = client_jaas_arg if security_enabled else ''
 metron_jvm_flags += (' ' + client_jaas_arg) if security_enabled else ''
-topology_auto_credentials = config['configurations']['storm-site'].get('nimbus.credential.renewers.classes', [])
+
+# the user-defined `topology.auto-credentials` are only used if security is enabled
+topology_auto_credentials = []
+if security_enabled:
+    topology_auto_credentials = config['configurations']['metron-security-env'].get('topology_auto_credentials', [])
+
 # Needed for storm.config, because it needs Java String
 topology_auto_credentials_double_quotes = str(topology_auto_credentials).replace("'", '"')
 

--- a/metron-platform/metron-common-streaming/metron-common-storm/src/main/java/org/apache/metron/storm/security/auth/kerberos/AutoTGT.java
+++ b/metron-platform/metron-common-streaming/metron-common-storm/src/main/java/org/apache/metron/storm/security/auth/kerberos/AutoTGT.java
@@ -1,0 +1,254 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.metron.storm.security.auth.kerberos;
+
+import org.apache.storm.security.auth.AuthUtils;
+import org.apache.storm.security.auth.IAutoCredentials;
+import org.apache.storm.security.auth.ICredentialsRenewer;
+import org.apache.storm.security.auth.kerberos.ClientCallbackHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.security.auth.DestroyFailedException;
+import javax.security.auth.RefreshFailedException;
+import javax.security.auth.Subject;
+import javax.security.auth.kerberos.KerberosPrincipal;
+import javax.security.auth.kerberos.KerberosTicket;
+import javax.security.auth.login.Configuration;
+import javax.security.auth.login.LoginContext;
+import javax.xml.bind.DatatypeConverter;
+import java.lang.reflect.Method;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Automatically take a user's TGT, and push it, and renew it in Nimbus.
+ *
+ * <p>To allow a topology running in a Storm Supervisor to authenticate with Hadoop using
+ * the TGT pushed by Nimbus, this class should be configured as part of a topology's
+ * `topology.auto-credentials` parameter.
+ *
+ * <p>When using Storm's {@link org.apache.storm.security.auth.kerberos.AutoTGT}, Hadoop
+ * authentication fails because it is unable to dyanamically load Hadoop's
+ * {@link org.apache.hadoop.security.UserGroupInformation} class at runtime. This issue is
+ * avoided by using this custom AutoTGT implementation that is packaged in a topology's uber jar.
+ *
+ * <p>This work is derived from the {@link org.apache.storm.security.auth.kerberos.AutoTGT} class
+ * in storm-core version 1.2.1.
+ */
+public class AutoTGT implements IAutoCredentials, ICredentialsRenewer {
+    private static final Logger LOG = LoggerFactory.getLogger(AutoTGT.class);
+    private static final float TICKET_RENEW_WINDOW = 0.80f;
+    protected static final AtomicReference<KerberosTicket> kerbTicket = new AtomicReference<>();
+    private Map conf;
+
+    public void prepare(Map conf) {
+        this.conf = conf;
+    }
+
+    private static KerberosTicket getTGT(Subject subject) {
+        Set<KerberosTicket> tickets = subject.getPrivateCredentials(KerberosTicket.class);
+        for(KerberosTicket ticket: tickets) {
+            KerberosPrincipal server = ticket.getServer();
+            if (server.getName().equals("krbtgt/" + server.getRealm() + "@" + server.getRealm())) {
+                return ticket;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void populateCredentials(Map<String, String> credentials) {
+        //Log the user in and get the TGT
+        try {
+            Configuration login_conf = AuthUtils.GetConfiguration(conf);
+            ClientCallbackHandler client_callback_handler = new ClientCallbackHandler(login_conf);
+
+            //login our user
+            Configuration.setConfiguration(login_conf);
+            LoginContext lc = new LoginContext(AuthUtils.LOGIN_CONTEXT_CLIENT, client_callback_handler);
+            try {
+                lc.login();
+                final Subject subject = lc.getSubject();
+                KerberosTicket tgt = getTGT(subject);
+
+                if (tgt == null) { //error
+                    throw new RuntimeException("Fail to verify user principal with section \""
+                            +AuthUtils.LOGIN_CONTEXT_CLIENT+"\" in login configuration file "+ login_conf);
+                }
+
+                if (!tgt.isForwardable()) {
+                    throw new RuntimeException("The TGT found is not forwardable");
+                }
+
+                if (!tgt.isRenewable()) {
+                    throw new RuntimeException("The TGT found is not renewable");
+                }
+
+                LOG.info("Pushing TGT for "+tgt.getClient()+" to topology.");
+                saveTGT(tgt, credentials);
+            } finally {
+                lc.logout();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void saveTGT(KerberosTicket tgt, Map<String, String> credentials) {
+        try {
+
+            byte[] bytes = AuthUtils.serializeKerberosTicket(tgt);
+            credentials.put("TGT", DatatypeConverter.printBase64Binary(bytes));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static KerberosTicket getTGT(Map<String, String> credentials) {
+        KerberosTicket ret = null;
+        if (credentials != null && credentials.containsKey("TGT") && credentials.get("TGT") != null) {
+            ret = AuthUtils.deserializeKerberosTicket(DatatypeConverter.parseBase64Binary(credentials.get("TGT")));
+        }
+        return ret;
+    }
+
+    @Override
+    public void updateSubject(Subject subject, Map<String, String> credentials) {
+        populateSubjectWithTGT(subject, credentials);
+    }
+
+    @Override
+    public void populateSubject(Subject subject, Map<String, String> credentials) {
+        populateSubjectWithTGT(subject, credentials);
+        loginHadoopUser(subject);
+    }
+
+    private void populateSubjectWithTGT(Subject subject, Map<String, String> credentials) {
+        KerberosTicket tgt = getTGT(credentials);
+        if (tgt != null) {
+            clearCredentials(subject, tgt);
+            subject.getPrincipals().add(tgt.getClient());
+            kerbTicket.set(tgt);
+        } else {
+            LOG.info("No TGT found in credentials");
+        }
+    }
+
+    public static void clearCredentials(Subject subject, KerberosTicket tgt) {
+        Set<Object> creds = subject.getPrivateCredentials();
+        synchronized(creds) {
+            Iterator<Object> iterator = creds.iterator();
+            while (iterator.hasNext()) {
+                Object o = iterator.next();
+                if (o instanceof KerberosTicket) {
+                    KerberosTicket t = (KerberosTicket)o;
+                    iterator.remove();
+                    try {
+                        t.destroy();
+                    } catch (DestroyFailedException e) {
+                        LOG.warn("Failed to destory ticket ", e);
+                    }
+                }
+            }
+            if(tgt != null) {
+                creds.add(tgt);
+            }
+        }
+    }
+
+    /**
+     * Hadoop does not just go off of a TGT, it needs a bit more.  This
+     * should fill in the rest.
+     * @param subject the subject that should have a TGT in it.
+     */
+    private void loginHadoopUser(Subject subject) {
+        final String clazz = "org.apache.hadoop.security.UserGroupInformation";
+        Class<?> ugi;
+        try {
+            ugi = Class.forName(clazz);
+        } catch (ClassNotFoundException e) {
+            /*
+             * When using Storm's `org.apache.storm.security.auth.kerberos.AutoTGT` class, Hadoop
+             * authentication fails because it is unable to load Hadoop's UserGroupInformation class
+             * at runtime. This issue is avoided when using a custom AutoTGT implementation like
+             * this, packaged into a topology's uber jar.
+             */
+            LOG.error("Hadoop authentication failed. Hadoop was not found on the class path. " +
+                    "Unable to load '{}' because '{}'", clazz, e.getMessage(), e);
+            return;
+        }
+        try {
+            Method isSecEnabled = ugi.getMethod("isSecurityEnabled");
+            if (!((Boolean)isSecEnabled.invoke(null))) {
+                LOG.warn("Hadoop is on the classpath but not configured for " +
+                        "security, if you want security you need to be sure that " +
+                        "hadoop.security.authentication=kerberos in core-site.xml " +
+                        "in your jar");
+                return;
+            }
+            Method login = ugi.getMethod("loginUserFromSubject", Subject.class);
+            login.invoke(null, subject);
+        } catch (Exception e) {
+            LOG.warn("Something went wrong while trying to initialize Hadoop through reflection. This version of hadoop may not be compatible.", e);
+        }
+    }
+
+    private long getRefreshTime(KerberosTicket tgt) {
+        long start = tgt.getStartTime().getTime();
+        long end = tgt.getEndTime().getTime();
+        return start + (long) ((end - start) * TICKET_RENEW_WINDOW);
+    }
+
+    @Override
+    public void renew(Map<String,String> credentials, Map<String, Object> topologyConf, String topologyOwnerPrincipal) {
+        KerberosTicket tgt = getTGT(credentials);
+        if (tgt != null) {
+            long refreshTime = getRefreshTime(tgt);
+            long now = System.currentTimeMillis();
+            if (now >= refreshTime) {
+                try {
+                    LOG.info("Renewing TGT for "+tgt.getClient());
+                    tgt.refresh();
+                    saveTGT(tgt, credentials);
+                } catch (RefreshFailedException e) {
+                    LOG.warn("Failed to refresh TGT", e);
+                }
+            }
+        }
+    }
+
+    public void renew(Map<String, String> credentials, Map topologyConf) {
+        throw new IllegalStateException("SHOULD NOT BE CALLED");
+    }
+
+    public static void main(String[] args) throws Exception {
+        AutoTGT at = new AutoTGT();
+        Map conf = new java.util.HashMap();
+        conf.put("java.security.auth.login.config", args[0]);
+        at.prepare(conf);
+        Map<String,String> creds = new java.util.HashMap<String,String>();
+        at.populateCredentials(creds);
+        Subject s = new Subject();
+        at.populateSubject(s, creds);
+        LOG.info("Got a Subject "+s);
+    }
+}

--- a/metron-platform/metron-elasticsearch/metron-elasticsearch-storm/pom.xml
+++ b/metron-platform/metron-elasticsearch/metron-elasticsearch-storm/pom.xml
@@ -100,6 +100,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.metron</groupId>
+            <artifactId>metron-common-storm</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.metron</groupId>
             <artifactId>metron-indexing-storm</artifactId>
             <version>${project.parent.version}</version>
             <exclusions>

--- a/metron-platform/metron-enrichment/metron-enrichment-storm/pom.xml
+++ b/metron-platform/metron-enrichment/metron-enrichment-storm/pom.xml
@@ -74,6 +74,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.metron</groupId>
+            <artifactId>metron-common-storm</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.metron</groupId>
             <artifactId>metron-writer-storm</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/metron-platform/metron-indexing/metron-indexing-storm/pom.xml
+++ b/metron-platform/metron-indexing/metron-indexing-storm/pom.xml
@@ -42,6 +42,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.metron</groupId>
+            <artifactId>metron-common-storm</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.metron</groupId>
             <artifactId>metron-writer-storm</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/metron-platform/metron-pcap-backend/pom.xml
+++ b/metron-platform/metron-pcap-backend/pom.xml
@@ -70,6 +70,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.metron</groupId>
+            <artifactId>metron-common-storm</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${global_junit_version}</version>

--- a/metron-platform/metron-solr/metron-solr-storm/pom.xml
+++ b/metron-platform/metron-solr/metron-solr-storm/pom.xml
@@ -90,6 +90,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.metron</groupId>
+            <artifactId>metron-common-storm</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.metron</groupId>
             <artifactId>metron-indexing-storm</artifactId>
             <version>${project.parent.version}</version>
         </dependency>


### PR DESCRIPTION
On the `feature/METRON-2088-support-hdp-3.1` feature branch, the Enrichment topology is sometimes unable to load the GeoIP data from HDFS when using Kerberos authentication.  

### The Problem

The Enrichment topology shows this exception.
```
2019-10-03 18:23:18.545 o.a.h.i.Client Curator-TreeCache-0 [WARN] Exception encountered while connecting to the server : org.apache.hadoop.security.AccessControlException: Client cannot authenticate via:[TOKEN, KERBEROS]
2019-10-03 18:23:18.552 o.a.m.e.a.m.MaxMindDbUtilities Curator-TreeCache-0 [ERROR] Unable to open new database file /apps/metron/geo/default/GeoLite2-City.tar.gz
java.io.IOException: DestHost:destPort metrong-1.openstacklocal:8020 , LocalHost:localPort metrong-7/172.22.74.121:0. Failed on local exception: java.io.IOException: org.apache.hadoop.security.AccessControlException: Client cannot authenticate via:[TOKEN, KERBEROS]
```

* When using Kerberos authentication with no previously cached ticket, a topology is unable to access HDFS, which primarily impacts Enrichment and Batch Indexing.
* If the local credential cache on a Storm worker contains a ticket for the 'metron' user, the topology is able to access HDFS.
* When using Kerberos authentication, all topologies are able to access Kafka. This only impacts HDFS.

### Why?

We use [Storm's AutoTGT](https://github.com/apache/storm/blob/v1.2.1/storm-core/src/jvm/org/apache/storm/security/auth/kerberos/AutoTGT.java) class to unpack the user credentials obtained by the Nimbus and authenticate with HDFS.  

When attempting to authenticate with HDFS, this class uses reflection to load Hadoop's `org.apache.hadoop.security.UserGroupInformation` class at runtime.  I believe Storm uses reflection so `hadoop-common` is not a required dependency for all Storm users. 
 
When [this class is loaded at runtime](https://github.com/apache/storm/blob/d156d25d991311eaa1f5131d3dc34787f87ce684/storm-core/src/jvm/org/apache/storm/security/auth/kerberos/AutoTGT.java#L177), it fails indicating that the class is not found on the classpath.  When this occurs, the error is effectively ignored, an `INFO` message is logged (rather than error or warn), and no details from the exception are logged.  This has made it difficult to understand the cause of the problem.

The JVM is unable to load this class at runtime, despite it being on the classpath in three different places.
1. The class is packaged into into the Enrichment topology Uber jar.
1. The class is packaged into the Stellar common jar which is added to the classpath using `--jars`.
1. The class is added to the classpath at runtime by Storm as part of storm-autocreds.

### The Solution

If we use bundle a custom `AutoTGT` class in the topology uber jars, the custom `AutoTGT` implementation is able to correctly load the `hadoop-common` dependency at runtime.  This avoids the problem.


### Changes

1. Created a custom `AutoTGT` implementation that lives within `metron-common-storm`.  This is a clone of Storm's AutoTGT except that it includes additional commentary and logging should this error occur again.

1. Added `metron-common-storm` as a direct dependency of all project's that create a Storm uber jar.  In all cases except `metron-pcap-backend` this was already a transitive dependency.  We need this to be a direct dependency because without the new AutoTGT implementation, none of the topologies will start when using Kerberos authentication.

1. Created an additional configuration in the Mpack for the topology's `topology.auto-credentials` property.  This can no longer default to the value of Nimbus's `nimbus.credential.renewers.classes`.  This property is only exposed to the user as an "advanced" setting and should rarely need changed by a user.

### Validation

This is difficult (impossible?) to test in the development environment.  This should be tested on a multi-node cluster.  The bug cannot be replicated on a single node because the ticket that is cached when the topology is submitted will be reused by the Storm worker when attempting to access HDFS.  The bug only occurs when there is not already a cached ticket to use.

1. Spin-up Metron on a multi-node cluster.
1. Kerberize the environment.
1. Start the Enrichment topology.
1. Ensure that the Enrichment topology is able to load the GeoIP data from HDFS.
1. Ensure that telemetry is being indexed in HDFS.


## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:
- [x] Have you ensured that any documentation diagrams have been updated, along with their source files, using [draw.io](https://www.draw.io/)? See [Metron Development Guidelines](https://cwiki.apache.org/confluence/display/METRON/Development+Guidelines) for instructions.
