### PR TITLE
METRON-2305: Unable to Add Enrichment Coprocessor with Kerberos

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/enrichment_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/enrichment_commands.py
@@ -268,7 +268,7 @@ class EnrichmentCommands:
                   self.__params.hbase_principal_name,
                   execute_user=self.__params.hbase_user)
 
-        cmd = "echo \"grant '{0}', 'RW', '{1}'\" | hbase shell -n"
+        cmd = "echo \"grant '{0}', 'CRW', '{1}'\" | hbase shell -n"
         add_enrichment_acl_cmd = cmd.format(self.__params.metron_user, self.__params.enrichment_hbase_table)
         Execute(add_enrichment_acl_cmd,
                 tries=3,
@@ -278,6 +278,7 @@ class EnrichmentCommands:
                 user=self.__params.hbase_user
                 )
 
+        cmd = "echo \"grant '{0}', 'RW', '{1}'\" | hbase shell -n"
         add_enrichment_list_acl_cmd = cmd.format(self.__params.metron_user, self.__params.enrichment_list_hbase_table)
         Execute(add_enrichment_list_acl_cmd,
                 tries=3,

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/enrichment_master.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/enrichment_master.py
@@ -69,10 +69,10 @@ class Enrichment(Script):
             commands.init_kafka_acls()
         if not commands.is_hbase_configured():
             commands.create_hbase_tables()
-        if not commands.is_hbase_coprocessor_configured():
-            commands.load_enrichment_coprocessor()
         if params.security_enabled and not commands.is_hbase_acl_configured():
             commands.set_hbase_acls()
+        if not commands.is_hbase_coprocessor_configured():
+            commands.load_enrichment_coprocessor()
         if not commands.is_maxmind_configured():
             commands.init_maxmind()
 


### PR DESCRIPTION
## Contributor Comments
metron enrichment topology fails to star on pre kerberized cluster with insufficent permission to load the hbase coprocessor [METRON-2305]( https://issues.apache.org/jira/browse/METRON-2305). This pr will provide required hbase acl to metron user before altering enrichment table and adding coprocessor.

### Steps to reproduce
1. Deploy multinode metron cluster
2. Kerberize the cluster before starting the services
3. starting enrichment service fails while altering enrichment table and adding coprocessor.

### Verified the fix using a multinode cluster

```
2019-10-30 12:39:36,170 - Loading HBase coprocessor for enrichments
2019-10-30 12:39:36,170 - See https://hbase.apache.org/2.0/book.html#load_coprocessor_in_shell for more detail
2019-10-30 12:39:36,170 - HBase coprocessor setup - first disabling the enrichments HBase table.
2019-10-30 12:39:36,170 - Executing command echo "disable 'enrichment'" | hbase shell -n
2019-10-30 12:39:36,171 - Execute['echo "disable 'enrichment'" | hbase shell -n'] {'logoutput': True, 'tries': 1, 'user': 'metron'}
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/usr/hdp/3.1.4.0-315/phoenix/phoenix-5.0.0.3.1.4.0-315-server.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/usr/hdp/3.1.4.0-315/hadoop/lib/slf4j-log4j12-1.7.25.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
Took 1.1231 seconds

2019-10-30 12:39:44,512 - HBase coprocessor setup - altering table and adding coprocessor.
2019-10-30 12:39:44,512 - Executing command /usr/hcp/2.0.0.0-4/metron/bin/load_enrichment_coprocessor.sh enrichment hdfs://ctr-e141-1563959304486-63852-01-000005.hwx.site:8020 /apps/metron/coprocessor org.apache.metron.hbase.coprocessor.EnrichmentCoprocessor ctr-e141-1563959304486-63852-01-000011.hwx.site:2181
2019-10-30 12:39:44,513 - Execute['/usr/hcp/2.0.0.0-4/metron/bin/load_enrichment_coprocessor.sh enrichment hdfs://ctr-e141-1563959304486-63852-01-000005.hwx.site:8020 /apps/metron/coprocessor org.apache.metron.hbase.coprocessor.EnrichmentCoprocessor ctr-e141-1563959304486-63852-01-000011.hwx.site:2181'] {'logoutput': True, 'tries': 1, 'user': 'metron'}
Altering enrichment to add coprocessor.
Executing: alter 'enrichment', METHOD => 'table_att', 'Coprocessor'=>'hdfs://ctr-e141-1563959304486-63852-01-000005.hwx.site:8020/apps/metron/coprocessor/metron-hbase-server-0.7.2.2.0.0.0-4-uber.jar|org.apache.metron.hbase.coprocessor.EnrichmentCoprocessor||zookeeperUrl=ctr-e141-1563959304486-63852-01-000011.hwx.site:2181'
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/usr/hdp/3.1.4.0-315/phoenix/phoenix-5.0.0.3.1.4.0-315-server.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/usr/hdp/3.1.4.0-315/hadoop/lib/slf4j-log4j12-1.7.25.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
HBase Shell
Use "help" to get list of supported commands.
Use "exit" to quit this interactive shell.
For Reference, please visit: http://hbase.apache.org/2.0/book.html#shell
Version 2.0.2.3.1.4.0-315, r, Fri Aug 23 05:15:48 UTC 2019
Took 0.0015 seconds
stty: standard input: Inappropriate ioctl for device
alter 'enrichment', METHOD => 'table_att', 'Coprocessor'=>'hdfs://ctr-e141-1563959304486-63852-01-000005.hwx.site:8020/apps/metron/coprocessor/metron-hbase-server-0.7.2.2.0.0.0-4-uber.jar|org.apache.metron.hbase.coprocessor.EnrichmentCoprocessor||zookeeperUrl=ctr-e141-1563959304486-63852-01-000011.hwx.site:2181'
Updating all regions with the new schema...
All regions updated.
Done.
Took 2.1859 seconds

Done
2019-10-30 12:39:58,073 - HBase coprocessor setup - re-enabling enrichments table.
2019-10-30 12:39:58,074 - Executing command echo "enable'enrichment'" | hbase shell -n
2019-10-30 12:39:58,074 - Execute['echo "enable'enrichment'" | hbase shell -n'] {'logoutput': True, 'tries': 1, 'user': 'metron'}
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/usr/hdp/3.1.4.0-315/phoenix/phoenix-5.0.0.3.1.4.0-315-server.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/usr/hdp/3.1.4.0-315/hadoop/lib/slf4j-log4j12-1.7.25.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
Took 1.7707 seconds

2019-10-30 12:40:06,790 - HBase coprocessor setup - verifying coprocessor was loaded. The coprocessor should be listed in the TABLE_ATTRIBUTES.
2019-10-30 12:40:06,790 - Executing command echo "describe 'enrichment'" | hbase shell -n
2019-10-30 12:40:06,791 - Execute['echo "describe 'enrichment'" | hbase shell -n'] {'logoutput': True, 'tries': 1, 'user': 'metron'}
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/usr/hdp/3.1.4.0-315/phoenix/phoenix-5.0.0.3.1.4.0-315-server.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/usr/hdp/3.1.4.0-315/hadoop/lib/slf4j-log4j12-1.7.25.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
Table enrichment is ENABLED
enrichment, {TABLE_ATTRIBUTES => {coprocessor$1 => 'hdfs://ctr-e141-1563959304486-63852-01-000005.hwx.site:8020/apps/metron/coprocessor/metron-hbase-server-0.7.2.2.0.0.0-4-uber.jar|org.apache.metron.hbase.coprocessor.EnrichmentCoprocessor||zookeeperUrl=ctr-e141-1563959304486-63852-01-000011.hwx.site:2181'}
COLUMN FAMILIES DESCRIPTION
{NAME => 't', VERSIONS => '1', EVICT_BLOCKS_ON_CLOSE => 'false', NEW_VERSION_BEHAVIOR => 'false', KEEP_DELETED_CELLS => 'FALSE', CACHE_DATA_ON_WRITE => 'false', DATA_BLOCK_ENCODING => 'NONE', TTL => 'FOREVER', MIN_VERSIONS => '0', REPLICATION_SCOPE => '0', BLOOMFILTER => 'ROW', CACHE_INDEX_ON_WRITE => 'false', IN_MEMORY => 'false', CACHE_BLOOMS_ON_WRITE => 'false', PREFETCH_BLOCKS_ON_OPEN => 'false', COMPRESSION => 'NONE', BLOCKCACHE => 'true', BLOCKSIZE => '65536'}
1 row(s)
Took 0.6450 seconds

2019-10-30 12:40:14,437 - Done loading HBase coprocessor for enrichments
```

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [ ] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [ ] Have you included steps or a guide to how the change may be verified and tested manually?
- [ ] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

- [ ] Have you ensured that any documentation diagrams have been updated, along with their source files, using [draw.io](https://www.draw.io/)? See [Metron Development Guidelines](https://cwiki.apache.org/confluence/display/METRON/Development+Guidelines) for instructions.

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
