### PR TITLE
METRON-2308 Fix 'Degrees' Example Profile

### DIFF
--- a/metron-analytics/metron-profiler-common/README.md
+++ b/metron-analytics/metron-profiler-common/README.md
@@ -363,15 +363,17 @@ This profile captures the vertex degree of a host. If you view network communica
       "profile": "in-degrees",
       "onlyif": "source.type == 'yaf'",
       "foreach": "ip_dst_addr",
-      "update": { "in": "HLLP_ADD(in, ip_src_addr)" },
-      "result": "HLLP_CARDINALITY(in)"
+      "init": { "estimator": "HLLP_INIT()" },
+      "update": { "estimator": "HLLP_ADD(estimator, ip_src_addr)" },
+      "result": "HLLP_CARDINALITY(estimator)"
     },
     {
       "profile": "out-degrees",
       "onlyif": "source.type == 'yaf'",
       "foreach": "ip_src_addr",
-      "update": { "out": "HLLP_ADD(out, ip_dst_addr)" },
-      "result": "HLLP_CARDINALITY(out)"
+      "init": { "estimator": "HLLP_INIT()" },
+      "update": { "estimator": "HLLP_ADD(estimator, ip_dst_addr)" },
+      "result": "HLLP_CARDINALITY(estimator)"
     }
   ]
 }


### PR DESCRIPTION
One of the example profiles uses "in" as a variable name.  This is now a reserved keyword and cannot be used as a variable name.  The example should be updated to work.

## Acceptance Testing

Try out the profile in your favorite Profiler flavor; REPL, Streaming, or Batch.


## Pull Request Checklist
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:
- [x] Have you ensured that any documentation diagrams have been updated, along with their source files, using [draw.io](https://www.draw.io/)? See [Metron Development Guidelines](https://cwiki.apache.org/confluence/display/METRON/Development+Guidelines) for instructions.
