### PR TITLE
METRON-2284 Metron Profiler for Spark doesn't work as expected

### DIFF
--- a/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/BatchProfiler.java
+++ b/metron-analytics/metron-profiler-spark/src/main/java/org/apache/metron/profiler/spark/BatchProfiler.java
@@ -87,13 +87,13 @@ public class BatchProfiler implements Serializable {
 
     // find all routes for each message
     Dataset<MessageRoute> routes = telemetry
-            .flatMap(messageRouterFunction(profilerProps, profiles, globals), Encoders.bean(MessageRoute.class));
+            .flatMap(messageRouterFunction(profilerProps, profiles, globals), Encoders.kryo(MessageRoute.class));
     LOG.debug("Generated {} message route(s)", routes.cache().count());
 
     // build the profiles
     Dataset<ProfileMeasurementAdapter> measurements = routes
             .groupByKey(new GroupByPeriodFunction(profilerProps), Encoders.STRING())
-            .mapGroups(new ProfileBuilderFunction(profilerProps, globals), Encoders.bean(ProfileMeasurementAdapter.class));
+            .mapGroups(new ProfileBuilderFunction(profilerProps, globals), Encoders.kryo(ProfileMeasurementAdapter.class));
     LOG.debug("Produced {} profile measurement(s)", measurements.cache().count());
 
     // write the profile measurements to HBase


### PR DESCRIPTION
### The Problem 

Some profile "update" expressions execute incorrectly in the Batch Profiler. The bug report provides an example where a call to `IS_EMPTY` returns true, when it should be returning false when the profile is executed by the Batch Profiler.  The same profile executed in the REPL or in the Streaming Profiler, returns the expected result.

### Root Cause

The values contained within a telemetry message are exposed to a profile's update expression at runtime.  This allows the profile to refer to message fields by name.  

After message routing occurs, the telemetry message is corrupted during serialization. It appears that all type information is lost when the corruption occurs.  This causes variable resolution for message fields to fail when executing a profile’s ‘update’ expression.  
* This does not impact variables defined within the profile itself. 
* This does not impact the ‘onlyif’, ‘foreach’, ‘init’, and 'result' expressions of a profile; only the 'update' expression.

The corruption occurs when a `MessageRoute` is serialized. This only affects the `JSONObject` representing the telemetry message, rather than any other fields like the profile definition, entity, or timestamp data also contained within a `MessageRoute`. 
 
The `MapVariableResolver` is passed the corrupted `JSONObject` so that variables can be resolved from the fields contained within the message.  Due to the corruption variables referring to the message are not resolved.

The corruption is caused by the use of Spark's bean encoder when serializing `MessageRoute` objects. 

### Changes

* Rather than using the bean encoder, I opted to use the Kryo encoder, which correctly serializes the objects.
* Added test cases for the defect.

### Acceptance Testing

1. Create a profile like the following. We expect the profile to return false in all cases due to the `onlyif` expression.
    ```
    [root@ctr-e141-1563959304486-71855-01-000003 metron]# cat config/zookeeper/profiler.json
    {
     "profiles":[
       {
         "profile":"is-empty",
         "onlyif":"devicehostname == 'windows9.something.com'",
         "foreach":"devicehostname",
         "init":{
         },
         "update":{
           "val":"IS_EMPTY(devicehostname)"
         },
        "result":{
           "profile":"val"
        }
       }
     ],
     "timestampField":"timestamp"
    }
    ```

1. Create some sample data to feed the profile.
    ```
    [root@ctr-e141-1563959304486-71855-01-000003 metron]# cat /tmp/test_data.logs
    {"devicehostname": "windows9.something.com", "timestamp": 1567241981000, "source.type": "testsource"}
    ```

1. Configure the Batch Profiler to read the sample data.
    ```
    [root@ctr-e141-1563959304486-71855-01-000003 metron]# cat config/batch-profiler.properties
    spark.app.name=Batch Profiler
    spark.master=local
    spark.sql.shuffle.partitions=1

    profiler.batch.input.path=file:///tmp/test_data.logs
    profiler.batch.input.format=json

    profiler.period.duration=1
    profiler.period.duration.units=MINUTES
    ```

1. Adjust the Spark logging. I prefer root logger at ERROR and the Batch Profiler set to DEBUG.
    ```
    [root@ctr-e141-1563959304486-71855-01-000003 metron]# cat /usr/hdp/current/spark2-client/conf/log4j.properties

    # Set everything to be logged to the console
    log4j.rootCategory=ERROR, console
    ...

    log4j.logger.org.apache.metron.profiler.spark=DEBUG
    ```

1. Run the Batch Profiler.
    ```
    [root@ctr-e141-1563959304486-71855-01-000003 metron]# source /etc/default/metron
    [root@ctr-e141-1563959304486-71855-01-000003 metron]# ./bin/start_batch_profiler.sh
    Warning: Ignoring non-spark config property: profiler.batch.input.path=hdfs://ctr-e141-1563959304486-71855-01-000005.hwx.site:8020/apps/metron/indexing/indexed/*/*
    Warning: Ignoring non-spark config property: profiler.period.duration=1
    Warning: Ignoring non-spark config property: profiler.period.duration.units=MINUTES
    Warning: Ignoring non-spark config property: profiler.batch.input.format=text
    ...
    19/11/08 20:18:33 DEBUG BatchProfiler: Generated 1 message route(s)
    19/11/08 20:18:34 DEBUG ProfileBuilderFunction: Building a profile for group 'is-empty__windows9.something.com__26120699' from 1 message(s)
    19/11/08 20:18:34 DEBUG ProfileBuilderFunction: Profile measurement created; profile=is-empty, entity=windows9.something.com, period=26120699, value=false
    19/11/08 20:18:34 DEBUG BatchProfiler: Produced 1 profile measurement(s)
    19/11/08 20:18:34 DEBUG HBaseWriterFunction: About to write profile measurement(s) to HBase
    19/11/08 20:18:36 DEBUG HBaseWriterFunction: 1 profile measurement(s) written to HBase
    19/11/08 20:18:36 DEBUG BatchProfiler: 1 profile measurement(s) written to HBase
    19/11/08 20:18:36 INFO BatchProfilerCLI: Profiler produced 1 profile measurement(s)
    ```

    The following log statement shows the expression `IS_EMPTY(devicehostname)` is indeed false as we would expect.

    ```
    19/11/08 20:18:34 DEBUG ProfileBuilderFunction: Profile measurement created; profile=is-empty, entity=windows9.something.com, period=26120699, value=false
    ```

## Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
