### PR TITLE
METRON-2314 HDFSIndexingIntegrationTests Fails with SLF4J/Log4j Delegation Loop

### DIFF
--- a/metron-platform/metron-indexing/metron-indexing-storm/pom.xml
+++ b/metron-platform/metron-indexing/metron-indexing-storm/pom.xml
@@ -60,6 +60,12 @@
             <artifactId>metron-integration-test</artifactId>
             <version>${project.parent.version}</version>
             <scope>test</scope>
+            <exclusions>
+              <exclusion>
+                  <groupId>org.slf4j</groupId>
+                  <artifactId>log4j-over-slf4j</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.metron</groupId>

--- a/metron-platform/metron-indexing/metron-indexing-storm/pom.xml
+++ b/metron-platform/metron-indexing/metron-indexing-storm/pom.xml
@@ -62,6 +62,12 @@
             <scope>test</scope>
             <exclusions>
               <exclusion>
+                  <!--
+                      Exclusion needed to prevent `log4j-over-slf4j` from being
+                      pulled in from `storm-core`.  Otherwise, this results in a
+                      delegation loop when the integration tests are run.
+                      See http://www.slf4j.org/codes.html#log4jDelegationLoop.
+                     -->
                   <groupId>org.slf4j</groupId>
                   <artifactId>log4j-over-slf4j</artifactId>
               </exclusion>


### PR DESCRIPTION
After merging #1557 from master into the `feature/METRON-2088-support-hdp-3.1` feature branch, the `HDFSIndexingIntegrationTest` fails.

```
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.185 sec <<< FAILURE! - in org.apache.metron.indexing.integration.HDFSIndexingIntegrationTest
test(org.apache.metron.indexing.integration.HDFSIndexingIntegrationTest)  Time elapsed: 0.177 sec  <<< ERROR!
java.lang.ExceptionInInitializerError
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:264)
	at org.slf4j.impl.Log4jLoggerFactory.<clinit>(Log4jLoggerFactory.java:48)
	...
Caused by: java.lang.IllegalStateException: Detected both log4j-over-slf4j.jar AND slf4j-log4j12.jar on the class path, preempting StackOverflowError. See also http://www.slf4j.org/codes.html#log4jDelegationLoop for more details.
	at org.apache.log4j.Log4jLoggerFactory.<clinit>(Log4jLoggerFactory.java:49)
	... 37 more

Results :

Tests in error:
  HDFSIndexingIntegrationTest>IndexingIntegrationTest.test:72->BaseIntegrationTest.getKafkaComponent:29 Â» ExceptionInInitializer
```

### Root Cause

It doesn't make sense for a project to pull-in both `slf4j-log4j12` and `log4j-over-slf4j`. The purpose of `slf4j-log4j12` is intended to redirect calls made to an SLF4J logger to Log4j. The purpose of `log4j-over-slf4j` is to redirect calls made to a Log4j logger to SLF4J. Pulling in both would cause endless indirection except for the specific check for this error performed by SLF4j.  See  [the SLF4j documentation here](http://www.slf4j.org/codes.html#log4jDelegationLoop) for more information.

The `metron-indexing-storm` project was pulling in `log4j-over-slf4j` incorrectly as a transitive.  This needs to be explicitly excluded.

### Acceptance Testing

The integration tests should pass.


### Pull Request Checklist

- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
