### PR TITLE
METRON-2325: Wrong validation message appears when clicking on input of existing group

### DIFF
--- a/metron-interface/metron-config/src/app/sensors/sensor-parser-aggregate-sidebar/sensor-parser-aggregate-sidebar.component.html
+++ b/metron-interface/metron-config/src/app/sensors/sensor-parser-aggregate-sidebar/sensor-parser-aggregate-sidebar.component.html
@@ -26,7 +26,7 @@
             <label>
               <span class="label-text">NAME *</span>
               <input #groupNameInput type="text" class="form-control" [value]="name" [readOnly]="existingGroup" (keyup)="onNameChange($event)" />
-              <div *ngIf="groupNameInvalid"><label><span class="warning-text"> Group already exists </span></label></div>
+              <div *ngIf="groupNameInvalid && !existingGroup"><label><span class="warning-text"> Group already exists </span></label></div>
             </label>
           </div>
           <div class="form-field">


### PR DESCRIPTION
## Contributor Comments
Link to ASF Jira ticket: https://jira.apache.org/jira/browse/METRON-2325

After a user creates a parser group and tries to edit the details of the group, the name input becomes readonly. However, we have a keyup event that's active and causes the existing group validation message to appear.

<img width="626" alt="Screen Shot 2019-11-20 at 6 23 28 PM" src="https://user-images.githubusercontent.com/7304869/69290015-16121200-0bc4-11ea-9a45-0a686c68e801.png">


Since we do not receive validation messages in other parts of the UI where we have a readonly field, I simply disabled the validation message once the group is created.

### Testing
Open up the Management UI and try grouping together two parsers by drag and dropping one onto another. Create a group. Now, try to edit that group by clicking on the pencil icon in the group's row. Try clicking on the name field. It should be readonly and no validation message should appear.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

- [x] Have you ensured that any documentation diagrams have been updated, along with their source files, using [draw.io](https://www.draw.io/)? See [Metron Development Guidelines](https://cwiki.apache.org/confluence/display/METRON/Development+Guidelines) for instructions.

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
